### PR TITLE
Set up GET /persons/{id} API endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
   testImplementation("io.kotest:kotest-assertions-core-jvm:5.5.4")
   testImplementation("io.kotest.extensions:kotest-extensions-wiremock:1.0.3")
   testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
+  testImplementation("org.mockito:mockito-core:4.9.0")
+
   annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,12 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+  testImplementation("io.kotest:kotest-runner-junit5-jvm:5.5.4")
+  testImplementation("io.kotest:kotest-assertions-core-jvm:5.5.4")
+  testImplementation("io.kotest.extensions:kotest-extensions-wiremock:1.0.3")
+  testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
+  annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
 
 java {
@@ -16,6 +22,9 @@ java {
 }
 
 tasks {
+  withType<Test>().configureEach {
+    useJUnitPlatform()
+  }
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
       jvmTarget = "18"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/persons")
-class PersonController {
+class PersonController() {
 
   @GetMapping("{id}")
   fun getPerson() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 
 @RestController
@@ -12,7 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonServic
 class PersonController(@Autowired val getPersonService: GetPersonService) {
 
   @GetMapping("{id}")
-  fun getPerson(@PathVariable id: Int) {
-    getPersonService.execute(id)
+  fun getPerson(@PathVariable id: Int): Person? {
+    return getPersonService.execute(id)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/persons")
+class PersonController {
+
+  @GetMapping("{id}")
+  fun getPerson() {
+
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -1,15 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
 
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 
 @RestController
 @RequestMapping("/persons")
-class PersonController() {
+class PersonController(@Autowired val getPersonService: GetPersonService) {
 
   @GetMapping("{id}")
-  fun getPerson() {
-
+  fun getPerson(@PathVariable id: Int) {
+    getPersonService.execute(id)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -1,3 +1,3 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models;
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
-data class Person(val id: Int, val firstName : String, val lastName : String)
+data class Person(val id: Int, val firstName: String, val lastName: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models;
+
+data class Person(val id: Int, val firstName : String, val lastName : String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -1,8 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 
 @Service
 class GetPersonService {
-  fun execute(id: Int) {}
+  fun execute(id: Int): Person? {
+    return null
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import org.springframework.stereotype.Service
+
+@Service
+class GetPersonService {
+  fun execute(id: Int) {}
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
 
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -8,12 +10,13 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest
-internal class PersonControllerTest(@Autowired val mockMvc: MockMvc) {
-
-    @Test
-    fun `retrieve a person`() {
+internal class PersonControllerTest(@Autowired val mockMvc: MockMvc) : DescribeSpec({
+  describe("GET /persons/{id}") {
+    it("responds with a 200 OK status") {
       val id=1
-      val result = mockMvc.perform(get("/persons/$id"))
-        .andExpect(status().isOk())
+      val result = mockMvc.perform(get("/persons/$id")).andReturn();
+
+      result.response.status.shouldBe(200);
     }
-}
+  }
+})

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -3,20 +3,40 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 
-@WebMvcTest
-internal class PersonControllerTest(@Autowired val mockMvc: MockMvc) : DescribeSpec({
+@WebMvcTest(controllers = [PersonController::class])
+internal class PersonControllerTest(
+  @Autowired val mockMvc: MockMvc,
+  @MockBean val getPersonService: GetPersonService
+) : DescribeSpec({
   describe("GET /persons/{id}") {
+    val id = 1
+
+    beforeTest {
+      Mockito.reset(getPersonService);
+    }
+
     it("responds with a 200 OK status") {
-      val id=1
       val result = mockMvc.perform(get("/persons/$id")).andReturn();
 
       result.response.status.shouldBe(200);
+    }
+
+    it("retrieves a person with the matching ID") {
+      mockMvc.perform(get("/persons/$id")).andReturn();
+
+      verify(getPersonService, times(1)).execute(id);
     }
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -2,17 +2,17 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Test
+import io.kotest.matchers.string.shouldNotBeEmpty
+import org.json.JSONObject
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
-import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 
 @WebMvcTest(controllers = [PersonController::class])
@@ -37,6 +37,18 @@ internal class PersonControllerTest(
       mockMvc.perform(get("/persons/$id")).andReturn();
 
       verify(getPersonService, times(1)).execute(id);
+    }
+
+    it("returns a person with the matching ID") {
+      val person = Person(id, "Billy", "Bob")
+      Mockito.`when`(getPersonService.execute(id)).thenReturn(person)
+
+      val result = mockMvc.perform(get("/persons/$id")).andReturn();
+
+      result.response.contentAsString.shouldNotBeEmpty();
+      JSONObject(result.response.contentAsString)["id"].shouldBe(person.id)
+      JSONObject(result.response.contentAsString)["firstName"].shouldBe(person.firstName)
+      JSONObject(result.response.contentAsString)["lastName"].shouldBe(person.lastName)
     }
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -24,28 +24,28 @@ internal class PersonControllerTest(
     val id = 1
 
     beforeTest {
-      Mockito.reset(getPersonService);
+      Mockito.reset(getPersonService)
     }
 
     it("responds with a 200 OK status") {
-      val result = mockMvc.perform(get("/persons/$id")).andReturn();
+      val result = mockMvc.perform(get("/persons/$id")).andReturn()
 
-      result.response.status.shouldBe(200);
+      result.response.status.shouldBe(200)
     }
 
     it("retrieves a person with the matching ID") {
-      mockMvc.perform(get("/persons/$id")).andReturn();
+      mockMvc.perform(get("/persons/$id")).andReturn()
 
-      verify(getPersonService, times(1)).execute(id);
+      verify(getPersonService, times(1)).execute(id)
     }
 
     it("returns a person with the matching ID") {
       val person = Person(id, "Billy", "Bob")
       Mockito.`when`(getPersonService.execute(id)).thenReturn(person)
 
-      val result = mockMvc.perform(get("/persons/$id")).andReturn();
+      val result = mockMvc.perform(get("/persons/$id")).andReturn()
 
-      result.response.contentAsString.shouldNotBeEmpty();
+      result.response.contentAsString.shouldNotBeEmpty()
       JSONObject(result.response.contentAsString)["id"].shouldBe(person.id)
       JSONObject(result.response.contentAsString)["firstName"].shouldBe(person.firstName)
       JSONObject(result.response.contentAsString)["lastName"].shouldBe(person.lastName)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest
+internal class PersonControllerTest(@Autowired val mockMvc: MockMvc) {
+
+    @Test
+    fun `retrieve a person`() {
+      val id=1
+      val result = mockMvc.perform(get("/persons/$id"))
+        .andExpect(status().isOk())
+    }
+}


### PR DESCRIPTION
- Add a basic `GET /persons/{id}` API endpoint, it lacks any meaningful logic atm.
- Add [kotest](https://kotest.io/) as the testing framework and [mockito](https://site.mockito.org/) for stubbing and verifying mocks.