### PR TITLE
Update pipeline to improve understanding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,9 @@ jobs:
             AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin 754256621582.dkr.ecr.eu-west-2.amazonaws.com
             docker tag hmpps-integration-api "${ECR_ENDPOINT}:${CIRCLE_SHA1}"
             docker push "${ECR_ENDPOINT}:${CIRCLE_SHA1}"
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              docker tag hmpps-integration-api "${ECR_ENDPOINT}:${APP_VERSION}"
-              docker push "${ECR_ENDPOINT}:${APP_VERSION}"
-            fi
+            docker tag hmpps-integration-api "${ECR_ENDPOINT}:${APP_VERSION}"
+            docker push "${ECR_ENDPOINT}:${APP_VERSION}"
+
 workflows:
   version: 2
   build-test-and-deploy:
@@ -81,18 +80,26 @@ workflows:
           env: development
       - create-and-push-image-to-ecr:
           name: create-and-push-image-to-development-ecr
+          context: hmpps-integration-api-development
           requires:
             - lint-code
             - unit-tests
             - lint-helm-charts
-          context: hmpps-integration-api-development
+          filters:
+            branches:
+              only:
+                - main
       - hmpps/deploy_env:
           name: deploy-to-development
-          requires:
-            - create-and-push-image-to-development-ecr
           context:
             - hmpps-integration-api-development
             - hmpps-common-vars
+          requires:
+            - create-and-push-image-to-development-ecr
+          filters:
+            branches:
+              only:
+                - main
           env: "development"
           helm_timeout: 5m
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,6 @@ jobs:
           name: Push application Docker image
           command: |
             AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin 754256621582.dkr.ecr.eu-west-2.amazonaws.com
-            docker tag hmpps-integration-api "${ECR_ENDPOINT}:${CIRCLE_SHA1}"
-            docker push "${ECR_ENDPOINT}:${CIRCLE_SHA1}"
             docker tag hmpps-integration-api "${ECR_ENDPOINT}:${APP_VERSION}"
             docker push "${ECR_ENDPOINT}:${APP_VERSION}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: hmpps-integration-api
 
 jobs:
-  validate:
+  lint:
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -23,15 +23,31 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew check
+          name: Run linting
+          command: ./gradlew ktlintCheck
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle.kts" }}
+  test:
+    executor:
+      name: hmpps/java
+      tag: "19.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle.kts" }}
+            - gradle-
+      - run:
+          name: Run tests
+          command: ./gradlew test
       - save_cache:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_test_results:
           path: build/test-results
-      - store_artifacts:
-          path: build/reports/tests
   build:
     docker:
       - image: ministryofjustice/cloud-platform-tools
@@ -58,10 +74,8 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - validate:
-          filters:
-            tags:
-              ignore: /.*/
+      - lint
+      - test
       - hmpps/helm_lint:
           name: helm_lint
           env: development
@@ -69,7 +83,8 @@ workflows:
           name: build
           context: hmpps-integration-api-development
           requires:
-            - validate
+            - lint
+            - test
             - helm_lint
       - hmpps/deploy_env:
           name: deploy_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: hmpps-integration-api
 
 jobs:
-  lint:
+  lint-code:
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -23,13 +23,13 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          name: Run linting
+          name: Lint code
           command: ./gradlew ktlintCheck
       - save_cache:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
-  test:
+  unit-tests:
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -40,7 +40,7 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          name: Run tests
+          name: Run unit tests
           command: ./gradlew test
       - save_cache:
           paths:
@@ -48,7 +48,7 @@ jobs:
           key: gradle-{{ checksum "build.gradle.kts" }}
       - store_test_results:
           path: build/test-results
-  build:
+  create-and-push-image-to-ecr:
     docker:
       - image: ministryofjustice/cloud-platform-tools
     steps:
@@ -74,20 +74,22 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - lint
-      - test
+      - lint-code
+      - unit-tests
       - hmpps/helm_lint:
-          name: helm_lint
+          name: lint-helm-charts
           env: development
-      - build:
-          name: build
-          context: hmpps-integration-api-development
+      - create-and-push-image-to-ecr:
+          name: create-and-push-image-to-development-ecr
           requires:
-            - lint
-            - test
-            - helm_lint
+            - lint-code
+            - unit-tests
+            - lint-helm-charts
+          context: hmpps-integration-api-development
       - hmpps/deploy_env:
-          name: deploy_dev
+          name: deploy-to-development
+          requires:
+            - create-and-push-image-to-development-ecr
           context:
             - hmpps-integration-api-development
             - hmpps-common-vars
@@ -95,12 +97,6 @@ workflows:
           helm_timeout: 5m
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           slack_notification: false
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - build
   security:
     triggers:
       - schedule:


### PR DESCRIPTION
## In this PR

- Split the previously named job `validate` into two separate clearly named jobs called `unit-tests` and `lint-code`. Also run them in parallel for quicker feedback.
- Improve naming of jobs and steps.
- Ensure that building and pushing the image to ECR is only done on `main`.
- Remove duplicated tagging and pushing to ECR.

Before | After
-- | --
![image](https://user-images.githubusercontent.com/42817036/207671372-c00547b9-ad64-4522-9b82-be01f95b2bdc.png)  |  ![image](https://user-images.githubusercontent.com/42817036/207671292-3fac89c1-5021-49d2-8d2b-4704fe4f5fe2.png)


</figure>

## Guidance to review

- Possible question around whether we want to at least try and build an image but just not push it?