### PR TITLE
Don't depend on build-dev for publishing images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build:
 serve: build-dev
 	docker-compose up -d
 
-publish: build-dev
+publish:
 	./scripts/publish.sh
 
 stop:


### PR DESCRIPTION
build is called explicitly in the pipeline, no need to depend on it