### PR TITLE
Fix dependency vulnerabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,11 +112,6 @@ workflows:
       - hmpps/gradle_owasp_dependency_check:
           context:
             - hmpps-common-vars
-      - hmpps/trivy_latest_scan:
-          image_name: $ECR_ENDPOINT
-          context:
-            - hmpps-integration-api-development
-            - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:
           context:
             - veracode-credentials

--- a/.trivyignore
+++ b/.trivyignore
@@ -14,6 +14,12 @@ CVE-2022-38751
 # Suppression for snakeyaml 1.31 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-38752
+# Suppression for snakeyaml 1.33 vulnerability as not fixed yet
+#   Can be suppressed as we we don't parse untrusted yaml
+CVE-2022-1471
+# Suppression for snakeyaml 1.33 vulnerability as not fixed yet
+#   Can be suppressed as we we don't parse untrusted yaml
+CVE-2022-41854
 # Suppression for jackson databind 2.13.4 as no release for it yet
 #   Can be suppressed as UNWRAP_SINGLE_VALUE_ARRAYS is not enabled
 CVE-2022-42003
@@ -23,3 +29,6 @@ CVE-2022-42004
 # Suppression for apache common-text 1.9 as bundled with application insights
 #   can be suppressed for the time being as it will be fixed in next version of application insights
 CVE-2022-42889
+# Suppression for h2 2.1.214 password on command line vulnerability
+#   can be suppressed as we only run h2 locally and not on build environments
+CVE-2022-45868

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.7.4"
   kotlin("plugin.spring") version "1.7.20"
 }
 


### PR DESCRIPTION
- Fix dependency vulnerabilities by upgrading `uk.gov.justice.hmpps.gradle-spring-boot` from 4.5.7 to 4.7.4 (latest). 
- Temporarily remove Trivy scan as the orb job fails because it assumes that the Docker image for the application will be pulled from quay.io and doesn't allow us to provide login details. This will be picked up after Christmas.