### PR TITLE
Add OpenAPI documentation for API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,10 @@ configurations {
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
 
+  implementation("org.springdoc:springdoc-openapi-data-rest:1.6.14")
+  implementation("org.springdoc:springdoc-openapi-ui:1.6.14")
+  implementation("org.springdoc:springdoc-openapi-kotlin:1.6.14")
+
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.5.4")
   testImplementation("io.kotest:kotest-assertions-core-jvm:5.5.4")
   testImplementation("io.kotest.extensions:kotest-extensions-wiremock:1.0.3")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/HmppsIntegrationApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/HmppsIntegrationApi.kt
@@ -2,18 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RestController
 
-@SpringBootApplication()
+@SpringBootApplication
 class HmppsIntegrationApi
 
 fun main(args: Array<String>) {
   runApplication<HmppsIntegrationApi>(*args)
-}
-
-@RestController
-class TestApiController {
-  @GetMapping("/")
-  fun index(): String = "Test!"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/OpenApiConfiguration.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfiguration {
+  @Bean
+  fun customConfiguration(): OpenAPI = OpenAPI()
+    .servers(
+      listOf(
+        Server().url("https://hmpps-integration-api-development.apps.live.cloud-platform.service.justice.gov.uk")
+          .description("Development"),
+        Server().url("http://localhost:8080").description("Local"),
+      )
+    )
+    .info(
+      Info().title("HMPPS Integration API Documentation")
+        .description(
+          """
+            A long-lived API that exposes data from HMPPS systems such as the National Offender Management Information
+            System (NOMIS), nDelius (probation system) and Offender Assessment System (OASys), providing a single point
+            of entry for consumers.
+          """.trimIndent()
+        )
+        .license(License().name("MIT").url("https://opensource.org/licenses/MIT"))
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -1,17 +1,57 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 
 @RestController
 @RequestMapping("/persons")
+@Tag(name = "persons")
 class PersonController(@Autowired val getPersonService: GetPersonService) {
+  @Operation(summary = "Get person by ID.", description = "Returns a person.")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200", description = "Successfully found a person with the provided ID.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = Person::class)
+          )
+        ]
+      ),
+      ApiResponse(
+        responseCode = "404", description = "Failed to find a person with the provided ID.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ]
+      ),
+      ApiResponse(
+        responseCode = "500", description = "Unable to serve request.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ]
+      ),
+    ]
+  )
   @GetMapping("{id}")
   fun getPerson(@PathVariable id: String): Person? {
     val result = getPersonService.execute(id) ?: throw EntityNotFoundException("Could not find person with id: $id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -1,3 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
-data class Person(val firstName: String, val lastName: String)
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class Person(
+  @field:Schema(
+    description = "First name",
+    example = "Arthur",
+    type = "string",
+  )
+  val firstName: String,
+
+  @field:Schema(
+    description = "Last name",
+    example = "Morgan",
+    type = "string",
+  )
+  val lastName: String
+)


### PR DESCRIPTION
## Changes proposed in this PR

- Add basic OpenAPI documentation page at `/swagger-ui/index.html` by annotating existing models and controllers.
- Remove `/` test endpoint, this was used for testing purposes when creating our CI/CD pipeline.

![image](https://user-images.githubusercontent.com/42817036/209328228-6d5b5e56-727a-4ba1-998b-22bbf0b0be20.png)

## Guidance to review

- Descriptions aren't very useful at the moment, we'll improve this when our endpoints and models are more interesting!