### PR TITLE
Add aliases to get person endpoint from NOMIS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -21,6 +21,17 @@ data class Person(
 )
 
 data class Alias(
+  @field:Schema(
+    description = "First name",
+    example = "John",
+    type = "string",
+  )
   val firstName: String,
+
+  @field:Schema(
+    description = "Last name",
+    example = "Marston",
+    type = "string",
+  )
   val lastName: String
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -15,5 +15,12 @@ data class Person(
     example = "Morgan",
     type = "string",
   )
+  val lastName: String,
+
+  val aliases: List<Alias> = listOf()
+)
+
+data class Alias(
+  val firstName: String,
   val lastName: String
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
@@ -45,6 +45,8 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
 
         person?.firstName.shouldBe("John")
         person?.lastName.shouldBe("Smith")
+        person?.aliases?.first()?.firstName.shouldBe("Joey")
+        person?.aliases?.first()?.lastName.shouldBe("Smiles")
       }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
@@ -13,7 +13,10 @@ import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
 
-@ContextConfiguration(initializers = [ConfigDataApplicationContextInitializer::class], classes = [NomisGateway::class, HmppsAuthGateway::class])
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [NomisGateway::class, HmppsAuthGateway::class]
+)
 @ActiveProfiles("test")
 class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private val nomisGateway: NomisGateway) :
   DescribeSpec({

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -24,7 +24,13 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
               { 
                 "offenderNo": "$offenderNo",
                 "firstName": "John",
-                "lastName": "Smith"
+                "lastName": "Smith",
+                "aliases": [
+                  {
+                    "firstName": "Joey",
+                    "lastName": "Smiles"
+                  }
+                ]
               }
               """.trimIndent()
             )


### PR DESCRIPTION
## Context

At the moment, our get person endpoint just returns the first name and last name.

## Changes proposed in this PR

- Add aliases found in NOMIS as part of the `GET /api/offenders/{id}` to the response of our `GET /persons/{id}` endpoint e.g.

```json
{
  "firstName": "DANIEL",
  "lastName": "SMELLEY",
  "aliases": [
    {
      "firstName": "DANNY",
      "lastName": "SMILEY"
    }
  ]
}
```

## Guidance to review

For running things locally:

- http://localhost:8080/persons/A1234AL is an example of a person in NOMIS that has an alias.
- http://localhost:8080/persons/A1234AA is an example of a person in NOMIS that doesn't have an alias.