### PR TITLE
Add guidance for setting up a CircleCI context for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [Updating diagrams](#updating-diagrams)
         - [Using Visual Studio Code](#using-visual-studio-code)
         - [Using PlantUML Web Server](#using-plantuml-web-server)
+- [Documentation](#documentation)
 - [Useful commands](#useful-commands)
     - [kubectl](#kubectl)
     - [aws](#aws)
@@ -188,62 +189,10 @@ To run all the tests and linting:
 make check
 ```
 
-### Updating diagrams
+## Documentation
 
-Diagrams such as our [context diagram](/docs/diagrams/context-diagram.png) are created
-using [PlantUML](https://plantuml.com/) i.e. diagrams as code.
-
-> 💡 **Hint:** For [C4 diagrams](https://c4model.com/),
-> see [PlantUML library for C4](https://github.com/plantuml-stdlib/C4-PlantUML) for more information.
-
-#### Using Visual Studio Code
-
-1. Install the [PlantUML extension](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml).
-2. Create a `.vscode/settings.json` if one does not exist.
-3. Within the `settings.json` file, add the follow properties:
-
-```json
-{
-  "plantuml.server": "https://www.plantuml.com/plantuml",
-  "plantuml.render": "PlantUMLServer"
-}
-```
-
-This tells the PlantUML extension to use the PlantUML server to render diagrams. It's also possible to point to a
-locally hosted server by changing the value of `plantuml.server`.
-
-4. Edit the `.puml` file for the diagram.
-5. Preview any changes to the diagram by using `Alt + D` on Windows or `Option + D` on MacOS.
-
-When all changes have been made:
-
-6. With the diagram file open, using `Ctrl + shift + P` on Windows or `command + shift + P` on MacOS and searching "
-   export current diagram", choose the `PlantUML: Export Current Diagram` option.
-
-This will display options for different file types to export to.
-
-7. Choose the `png` option.
-
-The exported diagram will then appear in an `out` directory in the root of the repository.
-
-8. Move the exported diagram to where the current diagram is located to replace it.
-
-#### Using PlantUML Web Server
-
-[PlantUML Web Server](http://www.plantuml.com/plantuml/uml/) allows live editing through the browser.
-
-1. Go to [PlantUML Web Server](http://www.plantuml.com/plantuml/uml/) in a browser.
-2. Copy the contents of the `.puml` file of the diagram from the repository.
-3. Paste the contents into the box of PlantUML Web Server browser tab.
-4. Make the changes to the code to update the diagram.
-
-When all changes have been made:
-
-5. Click the `PNG` link.
-
-This will open the diagram on the current tab.
-
-6. Download and replace the exported diagram in the repository.
+- [Updating diagrams](/docs/updating-diagrams.md)
+- [Setting up a CircleCI context for deployment](/docs/setting-up-circleci-context-for-deployment.md)
 
 ## Useful commands
 

--- a/docs/setting-up-circleci-context-for-deployment.md
+++ b/docs/setting-up-circleci-context-for-deployment.md
@@ -1,0 +1,72 @@
+# Setting up a CircleCI context for deployment
+
+To set up deployment for an environment using [CircleCI](https://circleci.com/), a
+new [context](https://circleci.com/docs/contexts/) must be created for it that contains the following:
+
+- `AWS_DEFAULT_REGION`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `KUBE_ENV_TOKEN`
+- `KUBE_ENV_CACERT`
+- `KUBE_ENV_NAME`
+- `KUBE_ENV_NAMESPACE`
+- `KUBE_ENV_API`
+
+## Prerequisites
+
+- Access to CircleCI
+- [Cloud Platform CLI](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/cloud-platform-cli.html#cloud-platform-cli)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [Access to Cloud Platform’s Kubernetes cluster](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#installing-kubectl)
+- [ECR repository for the environment](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html)
+- [Service account for CircleCI for the environment](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html#creating-a-service-account-for-circleci)
+
+## Creating a CircleCI context
+
+1. Go to [Contexts for the Ministry of Justice's CircleCI organisation](https://app.circleci.com/settings/organization/github/ministryofjustice/contexts?return-to=https%3A%2F%2Fapp.circleci.com%2Fprojects%2Fproject-dashboard%2Fgithub%2Fministryofjustice%2F).
+2. Click on "Create Context" button.
+3. Name the context using the name of this project and the name of the
+   environment: `hmpps-integration-api-<environment>` e.g. `hmpps-integration-api-development`.
+4. Click on "Add Environment Variable" button.
+5. Add an environment variable called `AWS_DEFAULT_REGION` and set the value to `eu-west-2`.
+6. Using the command-line, retrieve the AWS credentials to access the ECR repository for the environment.
+
+```bash
+cloud-platform decode-secret -n hmpps-integration-api-<environment> -s ecr-repo-hmpps-integration-api-<environment>
+# E.g. cloud-platform decode-secret -n hmpps-integration-api-development -s ecr-repo-hmpps-integration-api-development
+```
+
+7. Add an environment variable called `AWS_ACCESS_KEY_ID` and set the value to value in the `access_key_id` in the
+   response of the previous command.
+8. Add an environment variable called `AWS_SECRET_ACCESS_KEY` and set the value to value in the `secret_access_key` in
+   the response of step 6.
+9. Add an environment variable called `KUBE_ENV_NAMESPACE` and set the value to the Kubernetes namespace for the
+   environment e.g. `hmpps-integration-api-development`.
+10. Add an environment variable called `KUBE_ENV_NAME` and set the value
+    to `DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`.
+11. Add an environment variable called `KUBE_ENV_API` and set the value
+    to `https://DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`.
+
+12. Using the command-line, list the name of all the secrets within the Kubernetes namespace for the environment.
+
+```bash
+kubectl get secrets -n hmpps-integration-api-<environment>
+# E.g. kubectl get secrets -n hmpps-integration-api-development
+```
+
+13. Using the name of the CircleCI service account secret, retrieve the token for it.
+
+```bash
+cloud-platform decode-secret -n hmpps-integration-api-<environment> -s <circleci-token-secret-name> | jq -r '.data."token"'
+# E.g. cloud-platform decode-secret -n hmpps-integration-api-development -s circleci-token-z123 | jq -r '.data."token"'
+```
+
+14. Add an environment variable called `KUBE_ENV_TOKEN` and set the value to the response of the previous command.
+15. Using the command-line, retrieve the CA certificate for the CircleCI service account.
+
+```bash
+kubectl -n hmpps-integration-api-<environment> get secrets <circleci-token-secret-name> -o json | jq -r '.data."ca.crt"'
+# E.g. kubectl -n hmpps-integration-api-development get secrets circleci-token-z123 -o json | jq -r '.data."ca.crt"'
+```
+
+16. Add an environment variable called `KUBE_ENV_CACERT` and set the value to the response of the previous command.

--- a/docs/updating-diagrams.md
+++ b/docs/updating-diagrams.md
@@ -1,0 +1,56 @@
+# Updating diagrams
+
+Diagrams such as our [context diagram](/docs/diagrams/context-diagram.png) are created
+using [PlantUML](https://plantuml.com/) i.e. diagrams as code.
+
+> 💡 **Hint:** For [C4 diagrams](https://c4model.com/),
+> see [PlantUML library for C4](https://github.com/plantuml-stdlib/C4-PlantUML) for more information.
+
+## Using Visual Studio Code
+
+1. Install the [PlantUML extension](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml).
+2. Create a `.vscode/settings.json` if one does not exist.
+3. Within the `settings.json` file, add the follow properties:
+
+```json
+{
+  "plantuml.server": "https://www.plantuml.com/plantuml",
+  "plantuml.render": "PlantUMLServer"
+}
+```
+
+This tells the PlantUML extension to use the PlantUML server to render diagrams. It's also possible to point to a
+locally hosted server by changing the value of `plantuml.server`.
+
+4. Edit the `.puml` file for the diagram.
+5. Preview any changes to the diagram by using `Alt + D` on Windows or `Option + D` on MacOS.
+
+When all changes have been made:
+
+6. With the diagram file open, using `Ctrl + shift + P` on Windows or `command + shift + P` on MacOS and searching "
+   export current diagram", choose the `PlantUML: Export Current Diagram` option.
+
+This will display options for different file types to export to.
+
+7. Choose the `png` option.
+
+The exported diagram will then appear in an `out` directory in the root of the repository.
+
+8. Move the exported diagram to where the current diagram is located to replace it.
+
+## Using PlantUML Web Server
+
+[PlantUML Web Server](http://www.plantuml.com/plantuml/uml/) allows live editing through the browser.
+
+1. Go to [PlantUML Web Server](http://www.plantuml.com/plantuml/uml/) in a browser.
+2. Copy the contents of the `.puml` file of the diagram from the repository.
+3. Paste the contents into the box of PlantUML Web Server browser tab.
+4. Make the changes to the code to update the diagram.
+
+When all changes have been made:
+
+5. Click the `PNG` link.
+
+This will open the diagram on the current tab.
+
+6. Download and replace the exported diagram in the repository.


### PR DESCRIPTION
## Changes proposed in this PR

- Add guidance for setting up a CircleCI context for deployment i.e. what environment variables and how to get them.
- Move updating diagrams documentation into its own file.
- Update README to link to documentation in /docs.

