### PR TITLE
Update ECR repo for development to have the correct GitHub team name

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ To delete all ingress, services, pods and deployments:
 To list images in the ECR repository:
 
 ```bash
-aws ecr describe-images --repository-name=hmpps-integration-api-team/hmpps-integration-api-<environment>-ecr
+aws ecr describe-images --repository-name=hmpps-integration-api-admin-team/hmpps-integration-api-<environment>-ecr
 ```
 
 ## License

--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -5,7 +5,7 @@ generic-service:
   replicaCount: 2
 
   image:
-    repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/hmpps-integration-api-team/hmpps-integration-api-development-ecr
+    repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/hmpps-integration-api-admin-team/hmpps-integration-api-development-ecr
 
   ingress:
     host: hmpps-integration-api-development.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
We have removed the old unused team name, and now use the auto generated one.