### PR TITLE
Refactor auth username and password configuration

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -14,10 +14,10 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  @Value("\${hmpps-auth.username}")
+  @Value("\${services.hmpps-auth.username}")
   private lateinit var username: String
 
-  @Value("\${hmpps-auth.password}")
+  @Value("\${services.hmpps-auth.password}")
   private lateinit var password: String
 
   fun getPerson(id: String): Person? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -14,10 +14,10 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  @Value("\${services.prison-api.hmpps-auth.username}")
+  @Value("\${hmpps-auth.username}")
   private lateinit var username: String
 
-  @Value("\${services.prison-api.hmpps-auth.password}")
+  @Value("\${hmpps-auth.password}")
   private lateinit var password: String
 
   fun getPerson(id: String): Person? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -14,10 +14,10 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  @Value("\${hmpps-auth.username}")
+  @Value("\${services.hmpps-auth.username}")
   private lateinit var username: String
 
-  @Value("\${hmpps-auth.password}")
+  @Value("\${services.hmpps-auth.password}")
   private lateinit var password: String
 
   fun getPerson(id: String): Person? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -14,10 +14,10 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  @Value("\${services.prisoner-offender-search.hmpps-auth.username}")
+  @Value("\${hmpps-auth.username}")
   private lateinit var username: String
 
-  @Value("\${services.prisoner-offender-search.hmpps-auth.password}")
+  @Value("\${hmpps-auth.password}")
   private lateinit var password: String
 
   fun getPerson(id: String): Person? {

--- a/src/main/resources/application-development.yml
+++ b/src/main/resources/application-development.yml
@@ -1,7 +1,3 @@
-hmpps-auth:
-  username: ${CLIENT_ID}
-  password: ${CLIENT_SECRET}
-
 services:
   prison-api:
     base-url: https://api-dev.prison.service.justice.gov.uk
@@ -9,3 +5,5 @@ services:
     base-url: https://prisoner-offender-search-dev.prison.service.justice.gov.uk
   hmpps-auth:
     base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
+    username: ${CLIENT_ID}
+    password: ${CLIENT_SECRET}

--- a/src/main/resources/application-development.yml
+++ b/src/main/resources/application-development.yml
@@ -1,13 +1,11 @@
+hmpps-auth:
+  username: ${CLIENT_ID}
+  password: ${CLIENT_SECRET}
+
 services:
   prison-api:
     base-url: https://api-dev.prison.service.justice.gov.uk
-    hmpps-auth:
-      username: ${CLIENT_ID}
-      password: ${CLIENT_SECRET}
   prisoner-offender-search:
     base-url: https://prisoner-offender-search-dev.prison.service.justice.gov.uk
-    hmpps-auth:
-      username: ${CLIENT_ID}
-      password: ${CLIENT_SECRET}
   hmpps-auth:
     base-url: https://sign-in-dev.hmpps.service.justice.gov.uk

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -1,7 +1,3 @@
-hmpps-auth:
-  username: ZGVsaXVzCg==  # delius encoded in Base64
-  password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
-
 services:
   prisoner-offender-search:
     base-url: http://prisoner-offender-search:4010

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -1,13 +1,11 @@
+hmpps-auth:
+  username: ZGVsaXVzCg==  # delius encoded in Base64
+  password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
+
 services:
   prisoner-offender-search:
     base-url: http://prisoner-offender-search:4010
-    hmpps-auth:
-      username: ZGVsaXVzCg==  # delius encoded in Base64
-      password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
   prison-api:
     base-url: http://prison-api:8080
-    hmpps-auth:
-      username: ZGVsaXVzCg==  # delius encoded in Base64
-      password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
   hmpps-auth:
     base-url: http://oauth-server:8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,14 +1,7 @@
-hmpps-auth:
-  username: ZGVsaXVzCg==  # delius encoded in Base64
-  password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
-
 services:
   prisoner-offender-search:
     base-url: http://localhost:4010
   prison-api:
     base-url: http://localhost:8081
-    # Each application will likely have it's own credentials for its authentication method
-    # These are test values
   hmpps-auth:
     base-url: http://localhost:9090
-

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,16 +1,14 @@
+hmpps-auth:
+  username: ZGVsaXVzCg==  # delius encoded in Base64
+  password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
+
 services:
   prisoner-offender-search:
     base-url: http://localhost:4010
-    hmpps-auth:
-      username: ZGVsaXVzCg==  # delius encoded in Base64
-      password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
   prison-api:
     base-url: http://localhost:8081
     # Each application will likely have it's own credentials for its authentication method
     # These are test values
-    hmpps-auth:
-      username: ZGVsaXVzCg==  # delius encoded in Base64
-      password: Y2xpZW50c2VjcmV0Cg==  # clientsecret encoded in Base64
   hmpps-auth:
     base-url: http://localhost:9090
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,10 +50,6 @@ management:
       cache:
         time-to-live: 2000ms
 
-hmpps-auth:
-  username: fakeuser
-  password: fakepass
-
 services:
   prison-api:
     base-url: "TestURL"
@@ -61,3 +57,5 @@ services:
     base-url: "TestURL"
   hmpps-auth:
     base-url: "OtherTestURL"
+    username: ZGVsaXVzCg==
+    password: Y2xpZW50c2VjcmV0Cg==

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,16 +50,14 @@ management:
       cache:
         time-to-live: 2000ms
 
+hmpps-auth:
+  username: fakeuser
+  password: fakepass
+
 services:
   prison-api:
     base-url: "TestURL"
-    hmpps-auth:
-      username: fakeuser
-      password: fakepass
   prisoner-offender-search:
     base-url: "TestURL"
-    hmpps-auth:
-      username: fakeuser
-      password: fakepass
   hmpps-auth:
     base-url: "OtherTestURL"

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -8,13 +8,9 @@ management.endpoint:
 services:
   prison-api:
     base-url: http://localhost:4000
-    hmpps-auth:
-      username: Y2xpZW50Cg==  # client encoded in Base64
-      password: Y2xpZW50LXNlY3JldAo=  # client-secret encoded in Base64
   hmpps-auth:
     base-url: http://localhost:3000
+    username: Y2xpZW50Cg==
+    password: Y2xpZW50LXNlY3JldAo=
   prisoner-offender-search:
     base-url: http://localhost:4001
-    hmpps-auth:
-      username: Y2xpZW50Cg==
-      password: Y2xpZW50LXNlY3JldAo=


### PR DESCRIPTION
No need to specify the auth credentials for each API, we can use the same credentials. Simplify the configuration by promoting this to the root and removing duplicates.