### PR TITLE
Simplify Mockito syntax for stubbing methods

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -33,7 +34,7 @@ internal class PersonControllerTest(
         "nomis" to Person("Billy", "Bob"),
         "prisonerOffenderSearch" to Person("Sally", "Sob")
       )
-      Mockito.`when`(getPersonService.execute(id)).thenReturn(person)
+      whenever(getPersonService.execute(id)).thenReturn(person)
 
       val result = mockMvc.perform(get("/persons/$id")).andReturn()
 
@@ -42,7 +43,7 @@ internal class PersonControllerTest(
 
     it("responds with a 404 NOT FOUND status") {
       val idThatDoesNotExist = "zyx987"
-      Mockito.`when`(getPersonService.execute(id)).thenReturn(null)
+      whenever(getPersonService.execute(id)).thenReturn(null)
 
       val result = mockMvc.perform(get("/persons/$idThatDoesNotExist")).andReturn()
 
@@ -66,7 +67,7 @@ internal class PersonControllerTest(
         "prisonerOffenderSearch" to Person("Sally", "Sob")
       )
 
-      Mockito.`when`(getPersonService.execute(id)).thenReturn(stubbedResponse)
+      whenever(getPersonService.execute(id)).thenReturn(stubbedResponse)
 
       val expectedResult = mockMvc.perform(get("/persons/$id")).andReturn()
       println(expectedResult.response.contentAsString)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
@@ -45,7 +45,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
         """
       )
 
-      Mockito.`when`(hmppsAuthGateway.getClientToken()).thenReturn(
+      whenever(hmppsAuthGateway.getClientToken()).thenReturn(
         HmppsAuthMockServer.TOKEN
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGatewayTest.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
-import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
@@ -47,9 +47,7 @@ class PrisonerOffenderSearchGatewayTest(
         """
     )
 
-    Mockito.`when`(hmppsAuthGateway.getClientToken()).thenReturn(
-      HmppsAuthMockServer.TOKEN
-    )
+    whenever(hmppsAuthGateway.getClientToken()).thenReturn(HmppsAuthMockServer.TOKEN)
   }
 
   afterTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.boot.test.mock.mockito.MockBean
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
@@ -43,8 +44,8 @@ internal class GetPersonServiceTest(
     val personFromNomis = Person("Billy", "Bob")
     val personFromPrisonerOffenderSearch = Person("Sally", "Sob")
 
-    Mockito.`when`(nomisGateway.getPerson(id)).thenReturn(personFromNomis)
-    Mockito.`when`(prisonerOffenderSearchGateway.getPerson(id)).thenReturn(personFromPrisonerOffenderSearch)
+    whenever(nomisGateway.getPerson(id)).thenReturn(personFromNomis)
+    whenever(prisonerOffenderSearchGateway.getPerson(id)).thenReturn(personFromPrisonerOffenderSearch)
 
     val result = getPersonService.execute(id)
 


### PR DESCRIPTION
## Context

The syntax for stubbing methods using Mockito is a bit spooky and strange to read particularly the backticks around the `when`.

## Changes proposed in this PR

Refactor for readability where we stub methods from:

```kotlin
Mockito.`when`(getPersonService.execute(id)).thenReturn(person)
```
to:

```kotlin
whenever(getPersonService.execute(id)).thenReturn(person)
```