### PR TITLE
Fix hardcoded NOMIS in HmppsGateway#getClientToken errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGateway.kt
@@ -9,7 +9,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.AuthenticationFailedException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Credentials
 
-// Provides a place for all interaction with the auth gateway
 @Component
 class HmppsAuthGateway(@Value("\${services.hmpps-auth.base-url}") hmppsAuthUrl: String) : IAuthGateway {
   private val webClient: WebClient = WebClient.builder().baseUrl(hmppsAuthUrl).build()
@@ -20,7 +19,7 @@ class HmppsAuthGateway(@Value("\${services.hmpps-auth.base-url}") hmppsAuthUrl: 
   @Value("\${services.hmpps-auth.password}")
   private lateinit var password: String
 
-  override fun getClientToken(): String {
+  override fun getClientToken(service: String): String {
     val credentials = Credentials(username, password)
 
     return try {
@@ -34,11 +33,11 @@ class HmppsAuthGateway(@Value("\${services.hmpps-auth.base-url}") hmppsAuthUrl: 
 
       JSONParser(response).parseObject()["access_token"].toString()
     } catch (exception: WebClientRequestException) {
-      throw AuthenticationFailedException("Connection to ${exception.uri.authority} failed for NOMIS.")
+      throw AuthenticationFailedException("Connection to ${exception.uri.authority} failed for $service.")
     } catch (exception: WebClientResponseException.ServiceUnavailable) {
-      throw AuthenticationFailedException("${exception.request?.uri?.authority} is unavailable for NOMIS.")
+      throw AuthenticationFailedException("${exception.request?.uri?.authority} is unavailable for $service.")
     } catch (exception: WebClientResponseException.Unauthorized) {
-      throw AuthenticationFailedException("Invalid credentials used for NOMIS.")
+      throw AuthenticationFailedException("Invalid credentials used for $service.")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/IAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/IAuthGateway.kt
@@ -2,5 +2,5 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
 // A method of authenticating via basic authentication
 interface IAuthGateway {
-  fun getClientToken(): String
+  fun getClientToken(service: String): String
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -14,7 +14,7 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPerson(id: String): Person? {
-    val token = hmppsAuthGateway.getClientToken()
+    val token = hmppsAuthGateway.getClientToken("NOMIS")
 
     return webClient
       .get()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -14,7 +14,7 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPerson(id: String): Person? {
-    val token = hmppsAuthGateway.getClientToken()
+    val token = hmppsAuthGateway.getClientToken("Prisoner Offender Search")
 
     return webClient
       .get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGatewayTest.kt
@@ -8,7 +8,10 @@ import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.AuthenticationFailedException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 
-@ContextConfiguration(initializers = [ConfigDataApplicationContextInitializer::class], classes = [(HmppsAuthGateway::class)])
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [(HmppsAuthGateway::class)]
+)
 class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
   DescribeSpec({
     val hmppsAuthMockServer = HmppsAuthMockServer()
@@ -27,7 +30,7 @@ class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
       hmppsAuthMockServer.stop()
 
       val exception = shouldThrow<AuthenticationFailedException> {
-        hmppsAuthGateway.getClientToken()
+        hmppsAuthGateway.getClientToken("NOMIS")
       }
 
       exception.message.shouldBe("Connection to localhost:3000 failed for NOMIS.")
@@ -37,7 +40,7 @@ class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
       hmppsAuthMockServer.stubServiceUnavailableForGetOAuthToken()
 
       val exception = shouldThrow<AuthenticationFailedException> {
-        hmppsAuthGateway.getClientToken()
+        hmppsAuthGateway.getClientToken("NOMIS")
       }
 
       exception.message.shouldBe("localhost:3000 is unavailable for NOMIS.")
@@ -47,7 +50,7 @@ class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
       hmppsAuthMockServer.stubUnauthorizedForGetOAAuthToken()
 
       val exception = shouldThrow<AuthenticationFailedException> {
-        hmppsAuthGateway.getClientToken()
+        hmppsAuthGateway.getClientToken("NOMIS")
       }
 
       exception.message.shouldBe("Invalid credentials used for NOMIS.")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
@@ -45,9 +45,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
         """
       )
 
-      whenever(hmppsAuthGateway.getClientToken()).thenReturn(
-        HmppsAuthMockServer.TOKEN
-      )
+      whenever(hmppsAuthGateway.getClientToken("NOMIS")).thenReturn(HmppsAuthMockServer.TOKEN)
     }
 
     afterTest {
@@ -58,7 +56,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
       it("authenticates using HMPPS Auth with credentials") {
         nomisGateway.getPerson(offenderNo)
 
-        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken()
+        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
       }
 
       it("returns a person with the matching ID") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGatewayTest.kt
@@ -47,7 +47,7 @@ class PrisonerOffenderSearchGatewayTest(
         """
     )
 
-    whenever(hmppsAuthGateway.getClientToken()).thenReturn(HmppsAuthMockServer.TOKEN)
+    whenever(hmppsAuthGateway.getClientToken("Prisoner Offender Search")).thenReturn(HmppsAuthMockServer.TOKEN)
   }
 
   afterTest {
@@ -58,7 +58,7 @@ class PrisonerOffenderSearchGatewayTest(
     it("authenticates using HMPPS Auth with credentials") {
       prisonerOffenderSearchGateway.getPerson(offenderNo)
 
-      verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken()
+      verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Prisoner Offender Search")
     }
 
     it("returns a person with the matching ID") {


### PR DESCRIPTION
## Context

We've hardcoded "NOMIS" in the errors returned in the HMPPS Auth gateway which makes it misleading as it's used by both the NOMIS gateway and Prisoner Offender Search gateway now.

## Changes proposed in this PR

- Remove hardcoded "NOMIS" and add parameter when calling `getClientToken` so we know what to display in the error.