### PR TITLE
Add error handling for GET /persons/{id}

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ configurations {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
 
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.5.4")
   testImplementation("io.kotest:kotest-assertions-core-jvm:5.5.4")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -1,15 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Offender
 
 @Component
 class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
   private val webClient: WebClient = WebClient.builder().baseUrl(baseUrl).build()
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
@@ -17,13 +22,20 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
   fun getPerson(id: String): Person? {
     val token = hmppsAuthGateway.getClientToken("NOMIS")
 
-    return webClient
-      .get()
-      .uri("/api/offenders/$id")
-      .header("Authorization", "Bearer $token")
-      .retrieve()
-      .bodyToFlux(Offender::class.java)
-      .map { offender -> offender.toPerson() }
-      .blockFirst()
+    return try {
+      webClient
+        .get()
+        .uri("/api/offenders/$id")
+        .header("Authorization", "Bearer $token")
+        .retrieve()
+        .bodyToFlux(Offender::class.java)
+        .map { offender -> offender.toPerson() }
+        .blockFirst()
+    } catch (exception: WebClientResponseException.BadRequest) {
+      log.error("${exception.message} - ${Json.parseToJsonElement(exception.responseBodyAsString).jsonObject["developerMessage"]}")
+      null
+    } catch (exception: WebClientResponseException.NotFound) {
+      null
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -1,15 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch.Prisoner
 
 @Component
 class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search.base-url}") baseUrl: String) {
   private val webClient: WebClient = WebClient.builder().baseUrl(baseUrl).build()
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
@@ -17,13 +22,20 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
   fun getPerson(id: String): Person? {
     val token = hmppsAuthGateway.getClientToken("Prisoner Offender Search")
 
-    return webClient
-      .get()
-      .uri("/prisoner/$id")
-      .header("Authorization", "Bearer $token")
-      .retrieve()
-      .bodyToFlux(Prisoner::class.java)
-      .map { prisoner -> prisoner.toPerson() }
-      .blockFirst()
+    return try {
+      webClient
+        .get()
+        .uri("/prisoner/$id")
+        .header("Authorization", "Bearer $token")
+        .retrieve()
+        .bodyToFlux(Prisoner::class.java)
+        .map { prisoner -> prisoner.toPerson() }
+        .blockFirst()
+    } catch (exception: WebClientResponseException.BadRequest) {
+      log.error("${exception.message} - ${Json.parseToJsonElement(exception.responseBodyAsString).jsonObject["developerMessage"]}")
+      null
+    } catch (exception: WebClientResponseException.NotFound) {
+      null
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -1,16 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch.Offender
 
 @Component
 class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-search.base-url}") baseUrl: String) {
   private val webClient: WebClient = WebClient.builder().baseUrl(baseUrl).build()
+  private val log = LoggerFactory.getLogger(this::class.java)
 
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
@@ -18,14 +23,21 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   fun getPerson(id: String): Person? {
     val token = hmppsAuthGateway.getClientToken("Probation Offender Search")
 
-    return webClient
-      .post()
-      .uri("/search")
-      .header("Authorization", "Bearer $token")
-      .body(BodyInserters.fromValue(mapOf("nomsNumber" to id, "valid" to true)))
-      .retrieve()
-      .bodyToFlux(Offender::class.java)
-      .map { offender -> offender.toPerson() }
-      .blockFirst()
+    return try {
+      webClient
+        .post()
+        .uri("/search")
+        .header("Authorization", "Bearer $token")
+        .body(BodyInserters.fromValue(mapOf("nomsNumber" to id, "valid" to true)))
+        .retrieve()
+        .bodyToFlux(Offender::class.java)
+        .map { offender -> offender.toPerson() }
+        .blockFirst()
+    } catch (exception: WebClientResponseException.BadRequest) {
+      log.error("${exception.message} - ${Json.parseToJsonElement(exception.responseBodyAsString).jsonObject["developerMessage"]}")
+      null
+    } catch (exception: WebClientResponseException.NotFound) {
+      null
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -13,10 +13,14 @@ class GetPersonService(
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway
 ) {
-  fun execute(id: String): Map<String, Person?> {
+  fun execute(id: String): Map<String, Person?>? {
     val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPerson(id)
     val personFromNomis = nomisGateway.getPerson(id)
     val personFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(id)
+
+    if (personFromPrisonerOffenderSearch == null && personFromNomis == null && personFromProbationOffenderSearch == null) {
+      return null
+    }
 
     return mapOf(
       "nomis" to personFromNomis,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -24,18 +24,23 @@ internal class PersonControllerTest(
 ) : DescribeSpec({
   describe("GET /persons/{id}") {
     val id = "abc123"
+    val person = mapOf(
+      "nomis" to Person(
+        "Billy",
+        "Bob",
+        dateOfBirth = LocalDate.parse("1970-10-10"),
+        aliases = listOf(Alias("Bill", "Bobbers", dateOfBirth = LocalDate.parse("1970-03-01")))
+      ),
+      "prisonerOffenderSearch" to Person("Sally", "Sob"),
+      "probationOffenderSearch" to Person("Silly", "Sobbers"),
+    )
 
     beforeTest {
       Mockito.reset(getPersonService)
+      whenever(getPersonService.execute(id)).thenReturn(person)
     }
 
     it("responds with a 200 OK status") {
-      val person = mapOf(
-        "nomis" to Person("Billy", "Bob"),
-        "prisonerOffenderSearch" to Person("Sally", "Sob")
-      )
-      whenever(getPersonService.execute(id)).thenReturn(person)
-
       val result = mockMvc.perform(get("/persons/$id")).andReturn()
 
       result.response.status.shouldBe(200)
@@ -57,21 +62,9 @@ internal class PersonControllerTest(
     }
 
     it("returns a person with the matching ID") {
-      val stubbedResponse = mapOf<String, Person?>(
-        "nomis" to Person(
-          "Billy",
-          "Bob",
-          dateOfBirth = LocalDate.parse("1970-10-10"),
-          aliases = listOf(Alias("Bill", "Bobbers", dateOfBirth = LocalDate.parse("1970-03-01")))
-        ),
-        "prisonerOffenderSearch" to Person("Sally", "Sob")
-      )
+      val result = mockMvc.perform(get("/persons/$id")).andReturn()
 
-      whenever(getPersonService.execute(id)).thenReturn(stubbedResponse)
-
-      val expectedResult = mockMvc.perform(get("/persons/$id")).andReturn()
-      println(expectedResult.response.contentAsString)
-      expectedResult.response.contentAsString.shouldBe(
+      result.response.contentAsString.shouldBe(
         """
          {
           "nomis": {
@@ -91,6 +84,13 @@ internal class PersonControllerTest(
           "prisonerOffenderSearch": {
             "firstName": "Sally",
             "lastName": "Sob",
+            "middleName": null,
+            "dateOfBirth": null,
+            "aliases": []
+          },
+          "probationOffenderSearch": {
+            "firstName": "Silly",
+            "lastName": "Sobbers",
             "middleName": null,
             "dateOfBirth": null,
             "aliases": []

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGatewayTest.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
@@ -15,7 +17,7 @@ import java.time.LocalDate
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [NomisGateway::class, HmppsAuthGateway::class]
+  classes = [NomisGateway::class]
 )
 class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private val nomisGateway: NomisGateway) :
   DescribeSpec({
@@ -88,6 +90,38 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
         val person = nomisGateway.getPerson(offenderNo)
 
         person?.aliases.shouldBeEmpty()
+      }
+
+      it("returns null when 400 Bad Request is returned") {
+        nomisApiMockServer.stubGetOffender(
+          offenderNo,
+          """
+          {
+            "developerMessage": "reason for bad request"
+          }
+          """,
+          HttpStatus.BAD_REQUEST
+        )
+
+        val person = nomisGateway.getPerson(offenderNo)
+
+        person?.shouldBeNull()
+      }
+
+      it("returns null when 404 Not Found is returned") {
+        nomisApiMockServer.stubGetOffender(
+          offenderNo,
+          """
+          {
+            "developerMessage": "cannot find person"
+          }
+          """,
+          HttpStatus.NOT_FOUND
+        )
+
+        val person = nomisGateway.getPerson(offenderNo)
+
+        person?.shouldBeNull()
       }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGatewayTest.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.PrisonerOffenderSearchApiMockServer
@@ -15,7 +17,7 @@ import java.time.LocalDate
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [PrisonerOffenderSearchGateway::class, HmppsAuthGateway::class]
+  classes = [PrisonerOffenderSearchGateway::class]
 )
 class PrisonerOffenderSearchGatewayTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
@@ -90,6 +92,38 @@ class PrisonerOffenderSearchGatewayTest(
       val person = prisonerOffenderSearchGateway.getPerson(offenderNo)
 
       person?.aliases.shouldBeEmpty()
+    }
+
+    it("returns null when 400 Bad Request is returned") {
+      prisonerOffenderSearchApiMockServer.stubGetPrisoner(
+        offenderNo,
+        """
+          {
+            "developerMessage": "reason for bad request"
+          }
+          """,
+        HttpStatus.BAD_REQUEST
+      )
+
+      val person = prisonerOffenderSearchGateway.getPerson(offenderNo)
+
+      person?.shouldBeNull()
+    }
+
+    it("returns null when 404 Not Found is returned") {
+      prisonerOffenderSearchApiMockServer.stubGetPrisoner(
+        offenderNo,
+        """
+          {
+            "developerMessage": "cannot find person"
+          }
+          """,
+        HttpStatus.NOT_FOUND
+      )
+
+      val person = prisonerOffenderSearchGateway.getPerson(offenderNo)
+
+      person?.shouldBeNull()
     }
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
@@ -17,7 +17,7 @@ import java.time.LocalDate
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [ProbationOffenderSearchGateway::class, HmppsAuthGateway::class],
+  classes = [ProbationOffenderSearchGateway::class],
 )
 class ProbationOffenderSearchGatewayTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ProbationOffenderSearchApiMockServer
@@ -109,6 +111,38 @@ class ProbationOffenderSearchGatewayTest(
       val person = probationOffenderSearchGateway.getPerson(nomsNumber)
 
       person?.aliases.shouldBeEmpty()
+    }
+
+    it("returns null when 400 Bad Request is returned") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+        """
+          {
+            "developerMessage": "reason for bad request"
+          }
+          """,
+        HttpStatus.BAD_REQUEST
+      )
+
+      val person = probationOffenderSearchGateway.getPerson(nomsNumber)
+
+      person?.shouldBeNull()
+    }
+
+    it("returns null when 404 Not Found is returned") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+        """
+          {
+            "developerMessage": "cannot find person"
+          }
+          """,
+        HttpStatus.NOT_FOUND
+      )
+
+      val person = probationOffenderSearchGateway.getPerson(nomsNumber)
+
+      person?.shouldBeNull()
     }
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -4,13 +4,14 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.matching
+import org.springframework.http.HttpStatus
 
 class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
     private const val WIREMOCK_PORT = 4000
   }
 
-  fun stubGetOffender(offenderNo: String, body: String) {
+  fun stubGetOffender(offenderNo: String, body: String, status: HttpStatus = HttpStatus.OK) {
     stubFor(
       get("/api/offenders/$offenderNo")
         .withHeader(
@@ -18,7 +19,7 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
         ).willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withStatus(200)
+            .withStatus(status.value())
             .withBody(body.trimIndent())
         )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
@@ -4,13 +4,14 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.matching
+import org.springframework.http.HttpStatus
 
 class PrisonerOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
     private const val WIREMOCK_PORT = 4001
   }
 
-  fun stubGetPrisoner(prisonerId: String, body: String) {
+  fun stubGetPrisoner(prisonerId: String, body: String, status: HttpStatus = HttpStatus.OK) {
     stubFor(
       get("/prisoner/$prisonerId")
         .withHeader(
@@ -18,7 +19,7 @@ class PrisonerOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
         ).willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withStatus(200)
+            .withStatus(status.value())
             .withBody(body.trimIndent())
         )
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ProbationOffenderSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ProbationOffenderSearchApiMockServer.kt
@@ -5,13 +5,14 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.matching
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import org.springframework.http.HttpStatus
 
 class ProbationOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
     private const val WIREMOCK_PORT = 4002
   }
 
-  fun stubPostOffenderSearch(requestBody: String, responseBody: String) {
+  fun stubPostOffenderSearch(requestBody: String, responseBody: String, status: HttpStatus = HttpStatus.OK) {
     stubFor(
       post("/search")
         .withHeader(
@@ -22,7 +23,7 @@ class ProbationOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
         .willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
-            .withStatus(200)
+            .withStatus(status.value())
             .withBody(responseBody.trimIndent()),
         ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
@@ -68,5 +69,15 @@ internal class GetPersonServiceTest(
     )
 
     result.shouldBe(expectedResult)
+  }
+
+  it("returns null when a person isn't found in any APIs") {
+    whenever(nomisGateway.getPerson(id)).thenReturn(null)
+    whenever(prisonerOffenderSearchGateway.getPerson(id)).thenReturn(null)
+    whenever(probationOffenderSearchGateway.getPerson(id)).thenReturn(null)
+
+    val result = getPersonService.execute(id)
+
+    result.shouldBeNull()
   }
 })


### PR DESCRIPTION
## Context

At the moment, when Prison API, Probation Offender Search or Prisoner Offender Search returns a 400 Bad Request or 404 Request, our `GET /persons/{id}` returns 500 because when we make a HTTP request to one of those services, an unhandled exception is thrown by the web client.

## Changes proposed in this PR

- Return 404 Not Found when a person isn't found from every external API.
- Log the error when a 400 Bad Request is received from an external API.
- Return null for the key for the external service when a person isn't found in one API but are found in others e.g.

```json
{
    "nomis": null,
    "prisonerOffenderSearch": {
        "firstName": "Robert",
        "lastName": "Larsen",
        "middleName": "John James",
        "dateOfBirth": "1975-04-02",
        "aliases": [
            {
                "firstName": "Robert",
                "lastName": "Lorsen",
                "middleName": "Trevor",
                "dateOfBirth": "1975-04-02"
            }
        ]
    },
    "probationOffenderSearch": {
        "firstName": "string",
        "lastName": "string",
        "middleName": "string",
        "dateOfBirth": "2019-08-24",
        "aliases": [
            {
                "firstName": "string",
                "lastName": "string",
                "middleName": "string",
                "dateOfBirth": "2019-08-24"
            }
        ]
    }
}
```

![image](https://user-images.githubusercontent.com/42817036/218142827-d5eb9633-439d-4ac4-985c-36c917586b3a.png)


