### PR TITLE
Replace Prison API dependency with Prism version

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ make serve
 Each service is then accessible at:
 
 - [http://localhost:8080](http://localhost:8080) for this application
-- [http://localhost:8081](http://localhost:8081) for the Prison API
+- [http://localhost:4030](http://localhost:4030) for the Prison API
+- [http://localhost:4020](http://localhost:4020) for the Probation Offender Search
+- [http://localhost:4010](http://localhost:4010) for the Prisoner Offender Search
 - [http://localhost:9090](http://localhost:9090) for the HMPPS Auth service
 
 As part of getting the HMPPS Auth service running locally, [the in-memory database is seeded with data including a number of clients](https://github.com/ministryofjustice/hmpps-auth/blob/main/src/main/resources/db/dev/data/auth/V900_0__clients.sql). A client can have different permissions i.e. read, write, reporting, although strangely the column name is called `​​autoapprove`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,9 @@ services:
       prison-api:
         condition: service_healthy
       prisoner-offender-search:
-        condition: service_started
+        condition: service_healthy
       probation-offender-search:
-        condition: service_started
+        condition: service_healthy
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=local-docker
@@ -42,27 +42,27 @@ services:
       - LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB=TRACE
 
   prison-api:
-    image: quay.io/hmpps/prison-api:latest
+    image: stoplight/prism:4
     container_name: prison-api
-    depends_on:
-      - hmpps-auth
-    ports:
-      - "8081:8080"
+    command: 'mock -h 0.0.0.0 https://api-dev.prison.service.justice.gov.uk/v3/api-docs'
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
-      interval: 1s
-      timeout: 120s
-      retries: 100
-    environment:
-      - SERVER_PORT=8080
-      - SPRING_PROFILES_ACTIVE=nomis-hsqldb
-      - LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB=TRACE
+      test: 'wget --header="Authorization: Bearer abc" http://127.0.0.1:4010/api/offenders/A1234AL -O /dev/null'
+    depends_on:
+      hmpps-auth:
+        condition: service_healthy
+    ports:
+      - '4030:4010'
 
   prisoner-offender-search:
     build:
       context: .
       dockerfile: Dockerfile.setup-prisoner-offender-search
     container_name: prisoner-offender-search
+    healthcheck:
+      test: 'wget --header="Authorization: Bearer abc" http://127.0.0.1:4010/prisoner/A1234AL -O /dev/null'
+    depends_on:
+      hmpps-auth:
+        condition: service_healthy
     ports:
       - "4010:4010"
 
@@ -70,6 +70,11 @@ services:
     image: stoplight/prism:4
     container_name: probation-offender-search
     command: 'mock -h 0.0.0.0 https://probation-offender-search-dev.hmpps.service.justice.gov.uk/v3/api-docs'
+    healthcheck:
+      test: 'wget http://0.0.0.0:4010/synthetic-monitor -O /dev/null'
+    depends_on:
+      hmpps-auth:
+        condition: service_healthy
     ports:
       - '4020:4010'
 

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -4,7 +4,7 @@ set -e
 
 existing_person_id=A1234AL
 curl http://hmpps-integration-api:8080/persons/${existing_person_id} > /tmp/result
-expected_substring='"firstName":"DANIEL","lastName":"SMELLEY"'
+expected_substring='"nomis":{"firstName":"string","lastName":"string"'
 
 echo "Running smoke test for GET /persons/${existing_person_id}..."
 cat /tmp/result

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -4,6 +4,6 @@ services:
   prisoner-offender-search:
     base-url: http://prisoner-offender-search:4010
   prison-api:
-    base-url: http://prison-api:8080
+    base-url: http://prison-api:4010
   hmpps-auth:
     base-url: http://hmpps-auth:8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,6 @@ services:
   prisoner-offender-search:
     base-url: http://localhost:4010
   prison-api:
-    base-url: http://localhost:8081
+    base-url: http://localhost:4030
   hmpps-auth:
     base-url: http://localhost:9090


### PR DESCRIPTION
Our smoke testing will test schemas against the Prism emulators, not the actual running docker containers. Update the Prison API to be inline with the other dependencies.