### PR TITLE
Added named arguments to DTOs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Offender.kt
@@ -13,10 +13,17 @@ data class Offender(
   val aliases: List<nomisAlias> = listOf()
 ) {
   fun toPerson(): Person = Person(
-    this.firstName,
-    this.lastName,
-    this.middleName,
-    this.dateOfBirth,
-    this.aliases.map { Alias(it.firstName, it.lastName, it.middleName, it.dob) }
+    firstName = this.firstName,
+    lastName = this.lastName,
+    middleName = this.middleName,
+    dateOfBirth = this.dateOfBirth,
+    aliases = this.aliases.map {
+      Alias(
+        it.firstName,
+        it.lastName,
+        it.middleName,
+        it.dob
+      )
+    }
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
@@ -12,11 +12,11 @@ data class Prisoner(
   val aliases: List<PrisonerAlias> = listOf(),
 ) {
   fun toPerson(): Person = Person(
-    this.firstName,
-    this.lastName,
-    this.middleNames,
-    this.dateOfBirth,
-    this.aliases.map {
+    firstName = this.firstName,
+    lastName = this.lastName,
+    middleName = this.middleNames,
+    dateOfBirth = this.dateOfBirth,
+    aliases = this.aliases.map {
       Alias(
         it.firstName,
         it.lastName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -12,10 +12,17 @@ data class Offender(
   val offenderAliases: List<OffenderAlias> = listOf(),
 ) {
   fun toPerson(): Person = Person(
-    this.firstName,
-    this.surname,
-    this.middleNames.joinToString(" "),
-    this.dateOfBirth,
-    this.offenderAliases.map { Alias(it.firstName, it.surname, it.middleNames.joinToString(" "), it.dateOfBirth) }
+    firstName = this.firstName,
+    lastName = this.surname,
+    middleName = this.middleNames.joinToString(" "),
+    dateOfBirth = this.dateOfBirth,
+    aliases = this.offenderAliases.map {
+      Alias(
+        it.firstName,
+        it.surname,
+        it.middleNames.joinToString(" "),
+        it.dateOfBirth
+      )
+    }
   )
 }


### PR DESCRIPTION
Our data transfer objects will soon become quite large when mapping the upstream system's properties to our own. This will result in much larger constructors for our domain models. I've added named arguments to each of the "toX" methods in the data transfer objects so it's crystal clear which fields are being mapped to where. This will also help avoid any fields accidentally being mapped to the wrong field in the future when we have more fields due to the old method being dependent on argument position.