### PR TITLE
Add basic endpoint for getting addresses for a person

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -75,6 +75,39 @@ paths:
               examples:
                 PersonNotFoundError:
                   $ref: "#/components/examples/PersonNotFoundError"
+  /persons/{id}/addresses:
+    get:
+      tags:
+        - persons
+      summary: Returns addresses associated with a person.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successfully found a person with the provided ID.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  addresses:
+                    type: array
+                    minItems: 0
+                    items:
+                      $ref: "#/components/schemas/Address"
+        "404":
+          description: Failed to find a person with the provided ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                PersonNotFoundError:
+                  $ref: "#/components/examples/PersonNotFoundError"
 
   /images/{id}:
     get:
@@ -107,6 +140,12 @@ paths:
 
 components:
   schemas:
+    Address:
+      type: object
+      properties:
+        postcode:
+          type: string
+          example: SW1H 9AJ
     Alias:
       type: object
       properties:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 
@@ -15,7 +17,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonServic
 @RequestMapping("/persons")
 class PersonController(
   @Autowired val getPersonService: GetPersonService,
-  @Autowired val getImageMetadataForPersonService: GetImageMetadataForPersonService
+  @Autowired val getImageMetadataForPersonService: GetImageMetadataForPersonService,
+  @Autowired val getAddressesForPersonService: GetAddressesForPersonService
 ) {
   @GetMapping("{id}")
   fun getPerson(@PathVariable id: String): Map<String, Person?> {
@@ -33,5 +36,12 @@ class PersonController(
     val images = getImageMetadataForPersonService.execute(id)
 
     return mapOf("images" to images)
+  }
+
+  @GetMapping("{id}/addresses")
+  fun getPersonAddresses(@PathVariable id: String): Map<String, List<Address>> {
+    val addresses = getAddressesForPersonService.execute(id)
+
+    return mapOf("addresses" to addresses)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -9,10 +9,12 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.ImageDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Offender
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Address as AddressFromNomis
 
 @Component
 class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
@@ -73,6 +75,24 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
         .block()!!
     } catch (exception: WebClientResponseException.NotFound) {
       throw EntityNotFoundException("Could not find image with id: $id")
+    }
+  }
+
+  fun getAddressesForPerson(id: String): List<Address> {
+    val token = hmppsAuthGateway.getClientToken("NOMIS")
+
+    return try {
+      webClient
+        .get()
+        .uri("/api/offenders/$id/addresses")
+        .header("Authorization", "Bearer $token")
+        .retrieve()
+        .bodyToFlux(AddressFromNomis::class.java)
+        .map { addressFromNomis -> addressFromNomis.toAddress() }
+        .collectList()
+        .block() as List<Address>
+    } catch (exception: WebClientResponseException.NotFound) {
+      throw EntityNotFoundException("Could not find person with id: $id")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Address.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class Address(
+  val postcode: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+
+data class Address(
+  val postalCode: String
+) {
+  fun toAddress(): Address = Address(postcode = this.postalCode)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
@@ -5,5 +5,5 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 data class Address(
   val postalCode: String
 ) {
-  fun toAddress(): Address = Address(postcode = this.postalCode)
+  fun toAddress() = Address(postcode = this.postalCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+
+data class Address(
+  val postcode: String
+) {
+  fun toAddress(): Address = Address(postcode = this.postcode)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -5,5 +5,5 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 data class Address(
   val postcode: String
 ) {
-  fun toAddress(): Address = Address(postcode = this.postcode)
+  fun toAddress() = Address(postcode = this.postcode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/ContactDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/ContactDetails.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+data class ContactDetails(
+  val addresses: List<Address> = listOf()
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -10,6 +10,7 @@ data class Offender(
   val middleNames: List<String> = listOf(),
   val dateOfBirth: LocalDate? = null,
   val offenderAliases: List<OffenderAlias> = listOf(),
+  val contactDetails: ContactDetails = ContactDetails()
 ) {
   fun toPerson(): Person = Person(
     firstName = this.firstName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+
+@Service
+class GetAddressesForPersonService(
+  @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
+  @Autowired val nomisGateway: NomisGateway
+) {
+  fun execute(id: String): List<Address> {
+    val addressesFromProbationOffenderSearch = probationOffenderSearchGateway.getAddressesForPerson(id)
+    val addressesFromNomis = nomisGateway.getAddressesForPerson(id)
+
+    return addressesFromProbationOffenderSearch + addressesFromNomis
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -12,9 +12,11 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 import java.time.LocalDate
@@ -23,7 +25,8 @@ import java.time.LocalDate
 internal class PersonControllerTest(
   @Autowired val mockMvc: MockMvc,
   @MockBean val getPersonService: GetPersonService,
-  @MockBean val getImageMetadataForPersonService: GetImageMetadataForPersonService
+  @MockBean val getImageMetadataForPersonService: GetImageMetadataForPersonService,
+  @MockBean val getAddressesForPersonService: GetAddressesForPersonService,
 ) : DescribeSpec({
 
   val id = "abc123"
@@ -70,7 +73,7 @@ internal class PersonControllerTest(
 
       result.response.contentAsString.shouldBe(
         """
-         {
+        {
           "nomis": {
             "firstName": "Billy",
             "lastName": "Bob",
@@ -146,6 +149,45 @@ internal class PersonControllerTest(
               "view": "FACE",
               "orientation": "FRONT",
               "type": "OFF_BKG"
+            }
+          ]
+        }
+        """.removeWhitespaceAndNewlines()
+      )
+    }
+  }
+
+  describe("GET /persons/{id}/addresses") {
+    beforeTest {
+      Mockito.reset(getAddressesForPersonService)
+      whenever(getAddressesForPersonService.execute(id)).thenReturn(
+        listOf(
+          Address(postcode = "SE1 1TE")
+        )
+      )
+    }
+
+    it("responds with a 200 OK status") {
+      val result = mockMvc.perform(get("/persons/$id/addresses")).andReturn()
+
+      result.response.status.shouldBe(200)
+    }
+
+    it("retrieves the addresses for a person with the matching ID") {
+      mockMvc.perform(get("/persons/$id/addresses")).andReturn()
+
+      verify(getAddressesForPersonService, times(1)).execute(id)
+    }
+
+    it("returns the addresses for a person with the matching ID") {
+      val result = mockMvc.perform(get("/persons/$id/addresses")).andReturn()
+
+      result.response.contentAsString.shouldBe(
+        """
+        {
+          "addresses": [
+            {
+              "postcode": "SE1 1TE"
             }
           ]
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAddressesForPersonTest.kt
@@ -1,0 +1,94 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.nomis
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [NomisGateway::class]
+)
+class GetAddressesForPersonTest(
+  @MockBean val hmppsAuthGateway: HmppsAuthGateway,
+  private val nomisGateway: NomisGateway
+) : DescribeSpec({
+  val nomisApiMockServer = NomisApiMockServer()
+  val offenderNo = "abc123"
+
+  beforeEach {
+    nomisApiMockServer.start()
+    nomisApiMockServer.stubGetOffenderAddresses(
+      offenderNo,
+      """
+          [
+            {
+              "postalCode": "SA1 1DP"
+            }
+          ]
+        """
+    )
+
+    Mockito.reset(hmppsAuthGateway)
+    whenever(hmppsAuthGateway.getClientToken("NOMIS")).thenReturn(HmppsAuthMockServer.TOKEN)
+  }
+
+  afterTest {
+    nomisApiMockServer.stop()
+  }
+
+  it("authenticates using HMPPS Auth with credentials") {
+    nomisGateway.getAddressesForPerson(offenderNo)
+
+    verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+  }
+
+  it("returns addresses for a person with the matching ID") {
+    val addresses = nomisGateway.getAddressesForPerson(offenderNo)
+
+    addresses.shouldContain(Address(postcode = "SA1 1DP"))
+  }
+
+  it("returns an empty list when no addresses are found") {
+    nomisApiMockServer.stubGetOffenderAddresses(offenderNo, "[]")
+
+    val addresses = nomisGateway.getAddressesForPerson(offenderNo)
+
+    addresses.shouldBeEmpty()
+  }
+
+  it("throws an exception when 404 Not Found is returned") {
+    nomisApiMockServer.stubGetOffenderAddresses(
+      offenderNo,
+      """
+        {
+          "developerMessage": "cannot find person"
+        }
+        """,
+      HttpStatus.NOT_FOUND
+    )
+
+    val exception = shouldThrow<EntityNotFoundException> {
+      nomisGateway.getAddressesForPerson(offenderNo)
+    }
+
+    exception.message.shouldBe("Could not find person with id: $offenderNo")
+  }
+})

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -1,0 +1,123 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.probationoffendersearch
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ProbationOffenderSearchApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [ProbationOffenderSearchGateway::class]
+)
+class GetAddressesForPersonTest(
+  @MockBean val hmppsAuthGateway: HmppsAuthGateway,
+  private val probationOffenderSearchGateway: ProbationOffenderSearchGateway
+) : DescribeSpec({
+  val probationOffenderSearchApiMockServer = ProbationOffenderSearchApiMockServer()
+  val nomsNumber = "qwe678"
+
+  beforeEach {
+    probationOffenderSearchApiMockServer.start()
+    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+      "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+      """
+        [
+          {
+            "firstName": "English",
+            "surname": "Breakfast",
+            "otherIds": {
+              "nomsNumber": "$nomsNumber"
+            },
+            "contactDetails": {
+              "addresses": [
+                {
+                 "postcode": "M3 2JA"
+                }
+              ]
+            }
+          }
+        ]
+      """
+    )
+
+    Mockito.reset(hmppsAuthGateway)
+    whenever(hmppsAuthGateway.getClientToken("Probation Offender Search")).thenReturn(
+      HmppsAuthMockServer.TOKEN
+    )
+  }
+
+  afterTest {
+    probationOffenderSearchApiMockServer.stop()
+  }
+
+  it("authenticates using HMPPS Auth with credentials") {
+    probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+
+    verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Probation Offender Search")
+  }
+
+  it("returns addresses for a person with the matching ID") {
+    val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+
+    addresses.shouldContain(Address(postcode = "M3 2JA"))
+  }
+
+  it("returns an empty list when no addresses are found") {
+    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+      "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+      """
+        [
+          {
+            "firstName": "English",
+            "surname": "Breakfast",
+            "otherIds": {
+              "nomsNumber": "$nomsNumber"
+            },
+            "contactDetails": {
+              "addresses": []
+            }
+          }
+        ]
+        """
+    )
+
+    val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+
+    addresses.shouldBeEmpty()
+  }
+
+  it("throws an exception when 404 Not Found is returned") {
+    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+      "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+      """
+        {
+          "developerMessage": "cannot find person"
+        }
+        """,
+      HttpStatus.NOT_FOUND
+    )
+
+    val exception = shouldThrow<EntityNotFoundException> {
+      probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+    }
+
+    exception.message.shouldBe("Could not find person with id: $nomsNumber")
+  }
+})

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -52,4 +52,18 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
         )
     )
   }
+
+  fun stubGetOffenderAddresses(offenderNo: String, body: String, status: HttpStatus = HttpStatus.OK) {
+    stubFor(
+      get("/api/offenders/$offenderNo/addresses")
+        .withHeader(
+          "Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}")
+        ).willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+            .withBody(body.trimIndent())
+        )
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContain
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [GetAddressesForPersonService::class]
+)
+internal class GetAddressesForPersonServiceTest(
+  @MockBean val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
+  @MockBean val nomisGateway: NomisGateway,
+  private val getAddressesForPersonService: GetAddressesForPersonService
+) : DescribeSpec({
+  val id = "abc123"
+
+  beforeEach {
+    Mockito.reset(probationOffenderSearchGateway)
+    Mockito.reset(nomisGateway)
+  }
+
+  it("retrieves addresses for a person from Probation Offender Search") {
+    getAddressesForPersonService.execute(id)
+
+    verify(probationOffenderSearchGateway, VerificationModeFactory.times(1)).getAddressesForPerson(id)
+  }
+
+  it("retrieves addresses for a person from NOMIS") {
+    getAddressesForPersonService.execute(id)
+
+    verify(nomisGateway, VerificationModeFactory.times(1)).getAddressesForPerson(id)
+  }
+
+  it("returns all addresses for a person") {
+    val addressesFromProbationOffenderSearch = Address(postcode = "SE1 1TE")
+    val addressesFromNomis = Address(postcode = "BS1 6PU")
+    whenever(probationOffenderSearchGateway.getAddressesForPerson(id)).thenReturn(
+      listOf(
+        addressesFromProbationOffenderSearch
+      )
+    )
+    whenever(nomisGateway.getAddressesForPerson(id)).thenReturn(listOf(addressesFromNomis))
+
+    val result = getAddressesForPersonService.execute(id)
+
+    result.shouldContain(addressesFromProbationOffenderSearch)
+    result.shouldContain(addressesFromNomis)
+  }
+})

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import java.net.URI
 import java.net.http.HttpClient
@@ -13,10 +14,9 @@ class PersonSmokeTest : DescribeSpec({
   val baseUrl = "http://localhost:8080"
   val httpClient = HttpClient.newBuilder().build()
   val httpRequest = HttpRequest.newBuilder()
+  val id = "A1234AL"
 
   it("returns a person from NOMIS, Prisoner Offender Search and Probation Offender Search") {
-    val id = "A1234AL"
-
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons/$id")).build(),
       HttpResponse.BodyHandlers.ofString()
@@ -26,8 +26,6 @@ class PersonSmokeTest : DescribeSpec({
   }
 
   it("returns image metadata for a person") {
-    val id = "A1234AL"
-
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons/$id/images")).build(),
       HttpResponse.BodyHandlers.ofString()
@@ -43,6 +41,29 @@ class PersonSmokeTest : DescribeSpec({
             "view": "FACE",
             "orientation": "FRONT",
             "type": "OFF_BKG"
+          }
+        ]
+      }
+      """.removeWhitespaceAndNewlines()
+    )
+  }
+
+  it("returns addresses for a person") {
+    val response = httpClient.send(
+      httpRequest.uri(URI.create("$baseUrl/persons/$id/addresses")).build(),
+      HttpResponse.BodyHandlers.ofString()
+    )
+
+    response.statusCode().shouldBe(HttpStatus.OK.value())
+    response.body().shouldBe(
+      """
+      {
+        "addresses": [
+          {
+            "postcode": "string"
+          },
+          {
+            "postcode": "LI1 5TH"
           }
         ]
       }


### PR DESCRIPTION
## Changes proposed in this PR

- Add a `GET /persons/{id}/addresses` that merges addresses found in NOMIS via the Prison API and Probation Offender Search. However, as a first thin slice, we only return the postcode e.g.

```json
{
  "addresses": [
    {
      "postcode": "N12 9UI"
    },
    {
      "postcode": "LI1 5TH"
    }
  ]
}
```

![image](https://user-images.githubusercontent.com/42817036/220974933-132b008b-d3e1-4bf4-b818-27f26e8677e9.png)

## Next steps

- Add more properties to addresses returned.