### PR TITLE
Fix inaccurate Probation Offender Search stub for searching a person

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
@@ -131,15 +131,10 @@ class ProbationOffenderSearchGatewayTest(
       person?.shouldBeNull()
     }
 
-    it("returns null when 404 Not Found is returned") {
+    it("returns null when no results are returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
         "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
-        """
-          {
-            "developerMessage": "cannot find person"
-          }
-          """,
-        HttpStatus.NOT_FOUND
+        "[]"
       )
 
       val person = probationOffenderSearchGateway.getPerson(nomsNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
@@ -103,15 +102,10 @@ class GetAddressesForPersonTest(
     addresses.shouldBeEmpty()
   }
 
-  it("throws an exception when 404 Not Found is returned") {
+  it("throws an exception when no results are returned") {
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
       "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
-      """
-        {
-          "developerMessage": "cannot find person"
-        }
-        """,
-      HttpStatus.NOT_FOUND
+      "[]"
     )
 
     val exception = shouldThrow<EntityNotFoundException> {


### PR DESCRIPTION
The search endpoint for Probation Offender Search doesn't respond with a 404 NOT FOUND when it can't find a person with a NOMIS number, instead it just returns an empty list.