### PR TITLE
Update handling of 404 Not Found for person addresses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -40,7 +40,8 @@ class PersonController(
 
   @GetMapping("{id}/addresses")
   fun getPersonAddresses(@PathVariable id: String): Map<String, List<Address>> {
-    val addresses = getAddressesForPersonService.execute(id)
+    val addresses =
+      getAddressesForPersonService.execute(id) ?: throw EntityNotFoundException("Could not find person with id: $id")
 
     return mapOf("addresses" to addresses)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -78,7 +78,7 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
     }
   }
 
-  fun getAddressesForPerson(id: String): List<Address> {
+  fun getAddressesForPerson(id: String): List<Address>? {
     val token = hmppsAuthGateway.getClientToken("NOMIS")
 
     return try {
@@ -92,7 +92,7 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
         .collectList()
         .block() as List<Address>
     } catch (exception: WebClientResponseException.NotFound) {
-      throw EntityNotFoundException("Could not find person with id: $id")
+      null
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch.Offender
@@ -41,7 +40,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
     }
   }
 
-  fun getAddressesForPerson(id: String): List<Address> {
+  fun getAddressesForPerson(id: String): List<Address>? {
     val token = hmppsAuthGateway.getClientToken("Probation Offender Search")
 
     val offender = webClient
@@ -51,7 +50,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
       .body(BodyInserters.fromValue(mapOf("nomsNumber" to id, "valid" to true)))
       .retrieve()
       .bodyToFlux(Offender::class.java)
-      .blockFirst() ?: throw EntityNotFoundException("Could not find person with id: $id")
+      .blockFirst() ?: return null
 
     return offender.contactDetails.addresses.map { address -> address.toAddress() }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
@@ -11,10 +11,14 @@ class GetAddressesForPersonService(
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
   @Autowired val nomisGateway: NomisGateway
 ) {
-  fun execute(id: String): List<Address> {
+  fun execute(id: String): List<Address>? {
     val addressesFromProbationOffenderSearch = probationOffenderSearchGateway.getAddressesForPerson(id)
     val addressesFromNomis = nomisGateway.getAddressesForPerson(id)
 
-    return addressesFromProbationOffenderSearch + addressesFromNomis
+    if (addressesFromNomis == null && addressesFromProbationOffenderSearch == null) {
+      return null
+    }
+
+    return addressesFromProbationOffenderSearch?.plus(addressesFromNomis.orEmpty())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -194,5 +194,13 @@ internal class PersonControllerTest(
         """.removeWhitespaceAndNewlines()
       )
     }
+
+    it("responds with a 404 NOT FOUND status when person isn't found") {
+      whenever(getAddressesForPersonService.execute(id)).thenReturn(null)
+
+      val result = mockMvc.perform(get("/persons/$id/addresses")).andReturn()
+
+      result.response.status.shouldBe(404)
+    }
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGatewayTest.kt
@@ -131,7 +131,7 @@ class ProbationOffenderSearchGatewayTest(
       person?.shouldBeNull()
     }
 
-    it("returns null when no results are returned") {
+    it("returns null when no offenders are returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
         "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
         "[]"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAddressesForPersonTest.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.nomis
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
@@ -14,7 +13,6 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
@@ -63,7 +61,7 @@ class GetAddressesForPersonTest(
   it("returns addresses for a person with the matching ID") {
     val addresses = nomisGateway.getAddressesForPerson(offenderNo)
 
-    addresses.shouldContain(Address(postcode = "SA1 1DP"))
+    addresses?.shouldContain(Address(postcode = "SA1 1DP"))
   }
 
   it("returns an empty list when no addresses are found") {
@@ -74,7 +72,7 @@ class GetAddressesForPersonTest(
     addresses.shouldBeEmpty()
   }
 
-  it("throws an exception when 404 Not Found is returned") {
+  it("returns null when 404 Not Found is returned") {
     nomisApiMockServer.stubGetOffenderAddresses(
       offenderNo,
       """
@@ -85,10 +83,8 @@ class GetAddressesForPersonTest(
       HttpStatus.NOT_FOUND
     )
 
-    val exception = shouldThrow<EntityNotFoundException> {
-      nomisGateway.getAddressesForPerson(offenderNo)
-    }
+    val addresses = nomisGateway.getAddressesForPerson(offenderNo)
 
-    exception.message.shouldBe("Could not find person with id: $offenderNo")
+    addresses.shouldBeNull()
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -1,10 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.probationoffendersearch
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldBeNull
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
@@ -13,7 +12,6 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
@@ -75,7 +73,7 @@ class GetAddressesForPersonTest(
   it("returns addresses for a person with the matching ID") {
     val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
 
-    addresses.shouldContain(Address(postcode = "M3 2JA"))
+    addresses?.shouldContain(Address(postcode = "M3 2JA"))
   }
 
   it("returns an empty list when no addresses are found") {
@@ -102,16 +100,14 @@ class GetAddressesForPersonTest(
     addresses.shouldBeEmpty()
   }
 
-  it("throws an exception when no results are returned") {
+  it("returns null when no results are returned") {
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
       "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
       "[]"
     )
 
-    val exception = shouldThrow<EntityNotFoundException> {
-      probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
-    }
+    val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
 
-    exception.message.shouldBe("Could not find person with id: $nomsNumber")
+    addresses.shouldBeNull()
   }
 })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldBeNull
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
@@ -53,7 +54,16 @@ internal class GetAddressesForPersonServiceTest(
 
     val result = getAddressesForPersonService.execute(id)
 
-    result.shouldContain(addressesFromProbationOffenderSearch)
-    result.shouldContain(addressesFromNomis)
+    result?.shouldContain(addressesFromProbationOffenderSearch)
+    result?.shouldContain(addressesFromNomis)
+  }
+
+  it("returns null when person cannot be found in all APIs") {
+    whenever(probationOffenderSearchGateway.getAddressesForPerson(id)).thenReturn(null)
+    whenever(nomisGateway.getAddressesForPerson(id)).thenReturn(null)
+
+    val result = getAddressesForPersonService.execute(id)
+
+    result.shouldBeNull()
   }
 })


### PR DESCRIPTION
## Context

For getting addresses for a person, we were throwing a not found exception when one of the external APIs we use couldn't find the person. This means that if the person was found in another API this was disregarded.

## Changes proposed in this PR

- Only throw a not found exception when a person can't be found in both external APIs.

![image](https://user-images.githubusercontent.com/42817036/221555160-ad130ede-2519-4f82-bd0e-12a221e1cf2b.png)
