### PR TITLE
Remove skip for get image smoke test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/ImageSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/ImageSmokeTest.kt
@@ -13,9 +13,7 @@ class ImageSmokeTest : DescribeSpec({
   val httpClient = HttpClient.newBuilder().build()
   val httpRequest = HttpRequest.newBuilder()
 
-  // This test is skipped because the Prison API's endpoint for getting image data/content
-  // has changed and Prism is unable to return a valid response.
-  xit("returns an image from NOMIS") {
+  it("returns an image from NOMIS") {
     val id = 2461788
 
     val response = httpClient.send(


### PR DESCRIPTION
The get image smoke test was temporarily skipped because of a change in the Prison API. This has now be rectified so we can re-enable this test.