### PR TITLE
Allow person search on first OR last name

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -25,7 +25,7 @@ class PersonController(
 ) {
 
   @GetMapping
-  fun getPersons(@RequestParam firstName: String, @RequestParam lastName: String): Map<String, List<Person?>> {
+  fun getPersons(@RequestParam(required = false) firstName: String?, @RequestParam(required = false) lastName: String?): Map<String, List<Person?>> {
     val persons = getPersonsService.execute(firstName, lastName)
 
     return mapOf("persons" to persons)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -27,8 +27,8 @@ class PersonController(
 
   @GetMapping
   fun getPersons(
-    @RequestParam(required = false) firstName: String?,
-    @RequestParam(required = false) lastName: String?
+    @RequestParam(required = false, name = "first_name") firstName: String?,
+    @RequestParam(required = false, name = "last_name") lastName: String?
   ): Map<String, List<Person?>> {
     if (firstName == null && lastName == null) {
       throw ValidationException("No query parameters specified.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesFor
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonsService
+import javax.validation.ValidationException
 
 @RestController
 @RequestMapping("/persons")
@@ -25,7 +26,14 @@ class PersonController(
 ) {
 
   @GetMapping
-  fun getPersons(@RequestParam(required = false) firstName: String?, @RequestParam(required = false) lastName: String?): Map<String, List<Person?>> {
+  fun getPersons(
+    @RequestParam(required = false) firstName: String?,
+    @RequestParam(required = false) lastName: String?
+  ): Map<String, List<Person?>> {
+    if (firstName == null && lastName == null) {
+      throw ValidationException("No query parameters specified.")
+    }
+
     val persons = getPersonsService.execute(firstName, lastName)
 
     return mapOf("persons" to persons)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -41,7 +41,7 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
     }
   }
 
-  fun getPersons(firstName: String, lastName: String): List<Person> {
+  fun getPersons(firstName: String?, lastName: String?): List<Person> {
     val token = hmppsAuthGateway.getClientToken("Prisoner Offender Search")
 
     val response = webClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -44,11 +44,13 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
   fun getPersons(firstName: String?, lastName: String?): List<Person> {
     val token = hmppsAuthGateway.getClientToken("Prisoner Offender Search")
 
+    val requestBody = mapOf("firstName" to firstName, "lastName" to lastName, "includeAliases" to true)
+
     val response = webClient
       .post()
       .uri("/global-search")
       .header("Authorization", "Bearer $token")
-      .body(BodyInserters.fromValue(mapOf("firstName" to firstName, "lastName" to lastName, "includeAliases" to true)))
+      .body(BodyInserters.fromValue(requestBody.filterValues { it != null }))
       .retrieve()
       .bodyToMono(GlobalSearch::class.java)
       .block()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -40,7 +40,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
     }
   }
 
-  fun getPersons(firstName: String, surname: String): List<Person> {
+  fun getPersons(firstName: String?, surname: String?): List<Person> {
     val token = hmppsAuthGateway.getClientToken("Probation Offender Search")
 
     return webClient

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -43,11 +43,13 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   fun getPersons(firstName: String?, surname: String?): List<Person> {
     val token = hmppsAuthGateway.getClientToken("Probation Offender Search")
 
+    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "valid" to true)
+
     return webClient
       .post()
       .uri("/search")
       .header("Authorization", "Bearer $token")
-      .body(BodyInserters.fromValue(mapOf("firstName" to firstName, "surname" to surname, "valid" to true)))
+      .body(BodyInserters.fromValue(requestBody.filterValues { it != null }))
       .retrieve()
       .bodyToFlux(Offender::class.java)
       .map { offender -> offender.toPerson() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
@@ -12,7 +12,7 @@ class GetPersonsService(
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway
 ) {
 
-  fun execute(firstName: String, lastName: String): List<Person?> {
+  fun execute(firstName: String?, lastName: String?): List<Person?> {
     val personsFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(firstName, lastName)
     val personsFromProbationOffenderSearch = probationOffenderSearchGateway.getPersons(firstName, lastName)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
 import org.mockito.kotlin.verify
@@ -71,7 +72,9 @@ internal class PersonControllerTest(
         listOf()
       )
 
-      val result = mockMvc.perform(get("/persons?firstName=$firstNameThatDoesNotExist&lastName=$lastNameThatDoesNotExist")).andReturn()
+      val result =
+        mockMvc.perform(get("/persons?firstName=$firstNameThatDoesNotExist&lastName=$lastNameThatDoesNotExist"))
+          .andReturn()
 
       result.response.contentAsString.shouldBe(
         """
@@ -126,6 +129,13 @@ internal class PersonControllerTest(
       mockMvc.perform(get("/persons?lastName=$lastName")).andReturn()
 
       verify(getPersonsService, times(1)).execute(null, lastName)
+    }
+
+    it("responds with a 400 BAD REQUEST status when no search criteria provided") {
+      val result = mockMvc.perform(get("/persons")).andReturn()
+
+      result.response.status.shouldBe(400)
+      result.response.contentAsString.shouldContain("No query parameters specified.")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -88,7 +88,7 @@ internal class PersonControllerTest(
       verify(getPersonsService, times(1)).execute(firstName, lastName)
     }
 
-    it("returns a person with matching search criteria") {
+    it("returns a person with matching first and last name") {
       val result = mockMvc.perform(get("/persons?firstName=$firstName&lastName=$lastName")).andReturn()
 
       result.response.contentAsString.shouldBe(
@@ -114,6 +114,18 @@ internal class PersonControllerTest(
            }
         """.removeWhitespaceAndNewlines()
       )
+    }
+
+    it("retrieves a person with matching first name") {
+      mockMvc.perform(get("/persons?firstName=$firstName")).andReturn()
+
+      verify(getPersonsService, times(1)).execute(firstName, null)
+    }
+
+    it("retrieves a person with matching last name") {
+      mockMvc.perform(get("/persons?lastName=$lastName")).andReturn()
+
+      verify(getPersonsService, times(1)).execute(null, lastName)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -59,7 +59,7 @@ internal class PersonControllerTest(
     }
 
     it("responds with a 200 OK status") {
-      val result = mockMvc.perform(get("/persons?firstName=$firstName&lastName=$lastName")).andReturn()
+      val result = mockMvc.perform(get("/persons?first_name=$firstName&last_name=$lastName")).andReturn()
 
       result.response.status.shouldBe(200)
     }
@@ -73,7 +73,7 @@ internal class PersonControllerTest(
       )
 
       val result =
-        mockMvc.perform(get("/persons?firstName=$firstNameThatDoesNotExist&lastName=$lastNameThatDoesNotExist"))
+        mockMvc.perform(get("/persons?first_name=$firstNameThatDoesNotExist&last_name=$lastNameThatDoesNotExist"))
           .andReturn()
 
       result.response.contentAsString.shouldBe(
@@ -86,13 +86,13 @@ internal class PersonControllerTest(
     }
 
     it("retrieves a person with matching search criteria") {
-      mockMvc.perform(get("/persons?firstName=$firstName&lastName=$lastName")).andReturn()
+      mockMvc.perform(get("/persons?first_name=$firstName&last_name=$lastName")).andReturn()
 
       verify(getPersonsService, times(1)).execute(firstName, lastName)
     }
 
     it("returns a person with matching first and last name") {
-      val result = mockMvc.perform(get("/persons?firstName=$firstName&lastName=$lastName")).andReturn()
+      val result = mockMvc.perform(get("/persons?first_name=$firstName&last_name=$lastName")).andReturn()
 
       result.response.contentAsString.shouldBe(
         """
@@ -120,13 +120,13 @@ internal class PersonControllerTest(
     }
 
     it("retrieves a person with matching first name") {
-      mockMvc.perform(get("/persons?firstName=$firstName")).andReturn()
+      mockMvc.perform(get("/persons?first_name=$firstName")).andReturn()
 
       verify(getPersonsService, times(1)).execute(firstName, null)
     }
 
     it("retrieves a person with matching last name") {
-      mockMvc.perform(get("/persons?lastName=$lastName")).andReturn()
+      mockMvc.perform(get("/persons?last_name=$lastName")).andReturn()
 
       verify(getPersonsService, times(1)).execute(null, lastName)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -66,7 +66,7 @@ class PrisonerOffenderSearchGatewayTest(
       verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Prisoner Offender Search")
     }
 
-    it("returns person(s) when performing a search") {
+    it("returns person(s) when searching on first and last name") {
       val persons = prisonerOffenderSearchGateway.getPersons(firstName, lastName)
 
       persons.count().shouldBe(4)
@@ -74,6 +74,33 @@ class PrisonerOffenderSearchGatewayTest(
         it?.firstName.shouldBe(firstName)
         it?.lastName.shouldBe(lastName)
       }
+    }
+
+    it("returns person(s) when searching on first name only") {
+      prisonerOffenderSearchApiMockServer.stubPostPrisonerSearch(
+        """
+        {
+          "firstName":"Obi-Wan",
+          "includeAliases":true
+        }
+        """.removeWhitespaceAndNewlines(),
+        """
+        {
+          "content": [
+            {
+              "firstName": "Obi-Wan",
+              "lastName": "Kenobi"
+            }
+          ]
+        } 
+        """.trimIndent()
+      )
+
+      val persons = prisonerOffenderSearchGateway.getPersons("Obi-Wan", null)
+
+      persons.count().shouldBe(1)
+      persons.first().firstName.shouldBe("Obi-Wan")
+      persons.first().lastName.shouldBe("Kenobi")
     }
 
     it("returns an empty list of Person if no matching person") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -103,6 +103,33 @@ class PrisonerOffenderSearchGatewayTest(
       persons.first().lastName.shouldBe("Kenobi")
     }
 
+    it("returns person(s) when searching on last name only") {
+      prisonerOffenderSearchApiMockServer.stubPostPrisonerSearch(
+        """
+        {
+          "lastName":"Binks",
+          "includeAliases":true
+        }
+        """.removeWhitespaceAndNewlines(),
+        """
+        {
+          "content": [
+            {
+              "firstName": "Jar Jar",
+              "lastName": "Binks"
+            }
+          ]
+        } 
+        """.trimIndent()
+      )
+
+      val persons = prisonerOffenderSearchGateway.getPersons(null, "Binks")
+
+      persons.count().shouldBe(1)
+      persons.first().firstName.shouldBe("Jar Jar")
+      persons.first().lastName.shouldBe("Binks")
+    }
+
     it("returns an empty list of Person if no matching person") {
       val firstNameThatDoesNotExist = "ZYX321"
       val lastNameThatDoesNotExist = "GHJ345"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -62,16 +62,63 @@ class ProbationOffenderSearchGatewayTest(
 
     it("authenticates using HMPPS Auth with credentials") {
       probationOffenderSearchGateway.getPersons(firstName, surname)
-
       verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Probation Offender Search")
     }
 
-    it("returns person(s) when performing a search") {
+    it("returns person(s) when searching on first and last name") {
       val persons = probationOffenderSearchGateway.getPersons(firstName, surname)
 
       persons?.count().shouldBe(1)
       persons?.first()?.firstName.shouldBe(firstName)
       persons?.first()?.lastName.shouldBe(surname)
+    }
+
+    it("returns person(s) when searching on first name only") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        """
+        {
+          "firstName":"Ahsoka",
+          "valid":true
+        }
+        """.removeWhitespaceAndNewlines(),
+        """
+        [
+          {
+            "firstName": "Ahsoka",
+            "surname": "Tano"
+          }
+        ]
+        """.trimIndent()
+      )
+      val persons = probationOffenderSearchGateway.getPersons("Ahsoka", null)
+
+      persons?.count().shouldBe(1)
+      persons?.first()?.firstName.shouldBe("Ahsoka")
+      persons?.first()?.lastName.shouldBe("Tano")
+    }
+
+    it("returns person(s) when searching on last name only") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        """
+        {
+          "surname":"Tano",
+          "valid":true
+        }
+        """.removeWhitespaceAndNewlines(),
+        """
+        [
+          {
+            "firstName": "Ahsoka",
+            "surname": "Tano"
+          }
+        ]
+        """.trimIndent()
+      )
+      val persons = probationOffenderSearchGateway.getPersons(null, "Tano")
+
+      persons?.count().shouldBe(1)
+      persons?.first()?.firstName.shouldBe("Ahsoka")
+      persons?.first()?.lastName.shouldBe("Tano")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -20,7 +20,7 @@ class PersonSmokeTest : DescribeSpec({
   it("returns a list of persons using first name and last name as search parameters") {
     val firstName = "Example_First_Name"
     val lastName = "Example_Last_Name"
-    val queryParams = "firstName=$firstName&lastName=$lastName"
+    val queryParams = "first_name=$firstName&last_name=$lastName"
 
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons?$queryParams")).build(),


### PR DESCRIPTION
- Return 400 bad request when no search parameters passed
- Allow searching for persons on first OR last name 
- Change query parameter naming to snake case