### PR TITLE
Change unit tests to consistently use HttpStatus

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/ImageControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/ImageControllerTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageService
@@ -30,7 +31,7 @@ internal class ImageControllerTest(
     it("responds with a 200 OK status") {
       val result = mockMvc.perform(get("/images/$id")).andReturn()
 
-      result.response.status.shouldBe(200)
+      result.response.status.shouldBe(HttpStatus.OK.value())
     }
 
     it("retrieves a image with the matching ID") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -61,7 +61,7 @@ internal class PersonControllerTest(
     it("responds with a 200 OK status") {
       val result = mockMvc.perform(get("/persons?first_name=$firstName&last_name=$lastName")).andReturn()
 
-      result.response.status.shouldBe(200)
+      result.response.status.shouldBe(HttpStatus.OK.value())
     }
 
     it("returns an empty list embedded in a JSON object when no matching people") {
@@ -134,7 +134,7 @@ internal class PersonControllerTest(
     it("responds with a 400 BAD REQUEST status when no search criteria provided") {
       val result = mockMvc.perform(get("/persons")).andReturn()
 
-      result.response.status.shouldBe(400)
+      result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
       result.response.contentAsString.shouldContain("No query parameters specified.")
     }
   }
@@ -161,7 +161,7 @@ internal class PersonControllerTest(
     it("responds with a 200 OK status") {
       val result = mockMvc.perform(get("/persons/$id")).andReturn()
 
-      result.response.status.shouldBe(200)
+      result.response.status.shouldBe(HttpStatus.OK.value())
     }
 
     it("responds with a 404 NOT FOUND status") {
@@ -170,7 +170,7 @@ internal class PersonControllerTest(
 
       val result = mockMvc.perform(get("/persons/$idThatDoesNotExist")).andReturn()
 
-      result.response.status.shouldBe(404)
+      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
     }
 
     it("retrieves a person with the matching ID") {
@@ -240,7 +240,7 @@ internal class PersonControllerTest(
     it("responds with a 200 OK status") {
       val result = mockMvc.perform(get("/persons/$id/images")).andReturn()
 
-      result.response.status.shouldBe(200)
+      result.response.status.shouldBe(HttpStatus.OK.value())
     }
 
     it("retrieves the metadata of images for a person with the matching ID") {


### PR DESCRIPTION
Previously, unit tests have sometimes checked status codes manually (i.e. result.response.status.shouldBe(404)) and other times used import org.springframework.http.HttpStatus. 

This PR makes the code base consistently use HttpStatus. 