### PR TITLE
Fix use of PNC ID within person API endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -21,7 +21,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  fun getPerson(id: String): Person? {
+  fun getPerson(pncId: String): Person? {
     val token = hmppsAuthGateway.getClientToken("Probation Offender Search")
 
     return try {
@@ -29,8 +29,8 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
         HttpMethod.POST,
         "/search",
         token,
-        mapOf("nomsNumber" to id, "valid" to true)
-      ) ?: return null
+        mapOf("pncNumber" to pncId, "valid" to true)
+      )
 
       if (offenders.isNotEmpty()) offenders.first().toPerson() else null
     } catch (exception: WebClientResponseException.BadRequest) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -49,10 +49,10 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
       .map { it.toPerson() }
   }
 
-  fun getAddressesForPerson(id: String): List<Address>? {
+  fun getAddressesForPerson(pncId: String): List<Address>? {
     val token = hmppsAuthGateway.getClientToken("Probation Offender Search")
 
-    val requestBody = mapOf("nomsNumber" to id, "valid" to true)
+    val requestBody = mapOf("pncNumber" to pncId, "valid" to true)
 
     val offender = webClient.requestList<Offender>(HttpMethod.POST, "/search", token, requestBody)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -2,30 +2,25 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 
 @Service
 class GetPersonService(
-  @Autowired val nomisGateway: NomisGateway,
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway
 ) {
+  fun execute(pncId: String): Map<String, Person?>? {
+    val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
+    val personFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(pncId)
 
-  fun execute(id: String): Map<String, Person?>? {
-    val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPerson(id)
-    val personFromNomis = nomisGateway.getPerson(id)
-    val personFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(id)
-
-    if (personFromPrisonerOffenderSearch == null && personFromNomis == null && personFromProbationOffenderSearch == null) {
+    if (personFromPrisonerOffenderSearch.isEmpty() && personFromProbationOffenderSearch == null) {
       return null
     }
 
     return mapOf(
-      "nomis" to personFromNomis,
-      "prisonerOffenderSearch" to personFromPrisonerOffenderSearch,
+      "prisonerOffenderSearch" to personFromPrisonerOffenderSearch.first(),
       "probationOffenderSearch" to personFromProbationOffenderSearch
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -145,9 +145,7 @@ internal class PersonControllerTest(
   }
 
   describe("GET /persons/{id}") {
-
     val person = mapOf(
-      "nomis" to null,
       "prisonerOffenderSearch" to Person("Sally", "Sob"),
       "probationOffenderSearch" to Person("Silly", "Sobbers")
     )
@@ -185,7 +183,6 @@ internal class PersonControllerTest(
       result.response.contentAsString.shouldBe(
         """
         {
-          "nomis": null,
           "prisonerOffenderSearch": {
             "firstName": "Sally",
             "lastName": "Sob",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -28,20 +28,17 @@ class GetAddressesForPersonTest(
   private val probationOffenderSearchGateway: ProbationOffenderSearchGateway
 ) : DescribeSpec({
   val probationOffenderSearchApiMockServer = ProbationOffenderSearchApiMockServer()
-  val nomsNumber = "qwe678"
+  val pncId = "2002/1121M"
 
   beforeEach {
     probationOffenderSearchApiMockServer.start()
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
       """
         [
           {
             "firstName": "English",
             "surname": "Breakfast",
-            "otherIds": {
-              "nomsNumber": "$nomsNumber"
-            },
             "contactDetails": {
               "addresses": [
                 {
@@ -65,28 +62,25 @@ class GetAddressesForPersonTest(
   }
 
   it("authenticates using HMPPS Auth with credentials") {
-    probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+    probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
     verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Probation Offender Search")
   }
 
   it("returns addresses for a person with the matching ID") {
-    val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+    val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
     addresses?.shouldContain(Address(postcode = "M3 2JA"))
   }
 
   it("returns an empty list when no addresses are found") {
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
       """
         [
           {
             "firstName": "English",
             "surname": "Breakfast",
-            "otherIds": {
-              "nomsNumber": "$nomsNumber"
-            },
             "contactDetails": {
               "addresses": []
             }
@@ -95,18 +89,18 @@ class GetAddressesForPersonTest(
         """
     )
 
-    val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+    val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
     addresses.shouldBeEmpty()
   }
 
   it("returns null when no results are returned") {
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
       "[]"
     )
 
-    val addresses = probationOffenderSearchGateway.getAddressesForPerson(nomsNumber)
+    val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
     addresses.shouldBeNull()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -123,11 +123,11 @@ class ProbationOffenderSearchGatewayTest(
   }
 
   describe("#getPerson") {
-    val nomsNumber = "xyz4321"
+    val pncId = "2002/1121M"
 
     beforeEach {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
         """
         [
            {
@@ -139,7 +139,7 @@ class ProbationOffenderSearchGatewayTest(
             "surname": "Bravo",
             "dateOfBirth": "1970-02-07",
             "otherIds": {
-              "nomsNumber": "$nomsNumber"
+              "pncNumber": "$pncId"
             },
             "offenderAliases": [
               {
@@ -158,13 +158,13 @@ class ProbationOffenderSearchGatewayTest(
     }
 
     it("authenticates using HMPPS Auth with credentials") {
-      probationOffenderSearchGateway.getPerson(nomsNumber)
+      probationOffenderSearchGateway.getPerson(pncId)
 
       verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Probation Offender Search")
     }
 
     it("returns a person with the matching ID") {
-      val person = probationOffenderSearchGateway.getPerson(nomsNumber)
+      val person = probationOffenderSearchGateway.getPerson(pncId)
 
       person?.firstName.shouldBe("Jonathan")
       person?.middleName.shouldBe("Echo Fred")
@@ -178,7 +178,7 @@ class ProbationOffenderSearchGatewayTest(
 
     it("returns a person without aliases when no aliases are found") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
         """
           [
            {
@@ -186,7 +186,7 @@ class ProbationOffenderSearchGatewayTest(
             "surname": "Bravo",
             "dateOfBirth": "1970-02-07",
             "otherIds": {
-              "nomsNumber": "$nomsNumber"
+              "pncNumber": "$pncId"
             },
             "offenderAliases": []
           }
@@ -194,14 +194,14 @@ class ProbationOffenderSearchGatewayTest(
         """
       )
 
-      val person = probationOffenderSearchGateway.getPerson(nomsNumber)
+      val person = probationOffenderSearchGateway.getPerson(pncId)
 
       person?.aliases.shouldBeEmpty()
     }
 
     it("returns null when 400 Bad Request is returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
         """
           {
             "developerMessage": "reason for bad request"
@@ -210,18 +210,18 @@ class ProbationOffenderSearchGatewayTest(
         HttpStatus.BAD_REQUEST
       )
 
-      val person = probationOffenderSearchGateway.getPerson(nomsNumber)
+      val person = probationOffenderSearchGateway.getPerson(pncId)
 
       person?.shouldBeNull()
     }
 
     it("returns null when no offenders are returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"nomsNumber\": \"$nomsNumber\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
         "[]"
       )
 
-      val person = probationOffenderSearchGateway.getPerson(nomsNumber)
+      val person = probationOffenderSearchGateway.getPerson(pncId)
 
       person?.shouldBeNull()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -138,9 +138,6 @@ class ProbationOffenderSearchGatewayTest(
             ],
             "surname": "Bravo",
             "dateOfBirth": "1970-02-07",
-            "otherIds": {
-              "pncNumber": "$pncId"
-            },
             "offenderAliases": [
               {
                 "dateOfBirth": "2000-02-07",
@@ -185,9 +182,6 @@ class ProbationOffenderSearchGatewayTest(
             "firstName": "Jonathan",
             "surname": "Bravo",
             "dateOfBirth": "1970-02-07",
-            "otherIds": {
-              "pncNumber": "$pncId"
-            },
             "offenderAliases": []
           }
         ]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -52,7 +52,42 @@ class PersonSmokeTest : DescribeSpec({
       HttpResponse.BodyHandlers.ofString()
     )
 
-    response.body().shouldContain("\"nomis\":null")
+    response.body().shouldBe(
+      """
+        {
+          "prisonerOffenderSearch": {
+            "firstName": "Robert",
+            "lastName": "Larsen",
+            "middleName": "John James",
+            "dateOfBirth": "1975-04-02",
+            "aliases": [
+              {
+                "firstName": "Robert",
+                "lastName": "Lorsen",
+                "middleName": "Trevor",
+                "dateOfBirth": "1975-04-02"
+              }
+            ],
+            "prisonerId": "A1234AA"
+          },
+          "probationOffenderSearch": {
+            "firstName": "string",
+            "lastName": "string",
+            "middleName": "string",
+            "dateOfBirth": "2019-08-24",
+            "aliases": [
+              {
+                "firstName": "string",
+                "lastName": "string",
+                "middleName": "string",
+                "dateOfBirth": "2019-08-24"
+              }
+            ],
+            "prisonerId": null
+          }
+        }
+      """.removeWhitespaceAndNewlines()
+    )
   }
 
   it("returns image metadata for a person") {


### PR DESCRIPTION
## Context

We were incorrectly using endpoints of external APIs by providing them a PNC ID when they don't accept one.

## Changes proposed in this PR

- Remove call to NOMIS via Prison API for getting a person.
- Fix getting addresses for a person in Probation Offender Search by allowing to search via a PNC ID instead.