### PR TITLE
Made postcode nullable as it sometimes is from probation offender search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Address.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class Address(
-  val postcode: String
+  val postcode: String?
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address as IntegrationAPIAddress
 
 data class Address(
   val postalCode: String
 ) {
-  fun toAddress() = Address(postcode = this.postalCode)
+  fun toAddress() = IntegrationAPIAddress(postcode = this.postalCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address as IntegrationAPIAddress
 
 data class Address(
-  val postcode: String
+  val postcode: String?
 ) {
-  fun toAddress() = Address(postcode = this.postcode)
+  fun toAddress() = IntegrationAPIAddress(postcode = this.postcode)
 }


### PR DESCRIPTION
Postcode can frequently be null from probation offender search. In these cases we were getting an error. Postcode should be nullable in our address model.

```
{
    "status": 500,
    "errorCode": null,
    "userMessage": "Unexpected error: JSON decoding error: Instantiation of [simple type, class uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch.Address] value failed for JSON property postcode due to missing (therefore NULL) value for creator parameter postcode which is a non-nullable type",
    "developerMessage": "JSON decoding error: Instantiation of [simple type, class uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch.Address] value failed for JSON property postcode due to missing (therefore NULL) value for creator parameter postcode which is a non-nullable type",
    "moreInfo": null
}
```