### PR TITLE
Update Prison API and Probation Offender Search to use local Dockerfile

### DIFF
--- a/Dockerfile.setup-prison-api
+++ b/Dockerfile.setup-prison-api
@@ -1,0 +1,8 @@
+FROM node:current-alpine3.17
+
+RUN apk update && apk add bash curl
+
+RUN curl https://api-dev.prison.service.justice.gov.uk/v3/api-docs > prison-api.json && \
+    npm install -g @stoplight/prism-cli
+
+CMD prism mock -p 4010 -h 0.0.0.0 /prison-api.json

--- a/Dockerfile.setup-probation-offender-search
+++ b/Dockerfile.setup-probation-offender-search
@@ -1,0 +1,8 @@
+FROM node:current-alpine3.17
+
+RUN apk update && apk add bash curl
+
+RUN curl https://probation-offender-search-dev.hmpps.service.justice.gov.uk/v3/api-docs > probation-offender-search.json && \
+    npm install -g @stoplight/prism-cli
+
+CMD prism mock -p 4010 -h 0.0.0.0 /probation-offender-search.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,10 @@ services:
       - LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB=TRACE
 
   prison-api:
-    image: stoplight/prism:4
+    build:
+      context: .
+      dockerfile: Dockerfile.setup-prison-api
     container_name: prison-api
-    command: 'mock -h 0.0.0.0 https://api-dev.prison.service.justice.gov.uk/v3/api-docs'
     healthcheck:
       test: 'wget --header="Authorization: Bearer abc" http://127.0.0.1:4010/api/offenders/A1234AL -O /dev/null'
     ports:
@@ -52,9 +53,10 @@ services:
       - "4010:4010"
 
   probation-offender-search:
-    image: stoplight/prism:4
+    build:
+      context: .
+      dockerfile: Dockerfile.setup-probation-offender-search
     container_name: probation-offender-search
-    command: 'mock -h 0.0.0.0 https://probation-offender-search-dev.hmpps.service.justice.gov.uk/v3/api-docs'
     healthcheck:
       test: 'wget http://0.0.0.0:4010/synthetic-monitor -O /dev/null'
     ports:


### PR DESCRIPTION
## Context

We've been seeing some sporadic smoke tests failure as some containers (mainly the Probation Offender Search) struggle to pass the health check which our current theory is due to timeouts and not downloading the OpenAPI spec in time.

Example failures:

- https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-api/623/workflows/f865c5be-b3f5-4f27-b524-a1c0e445e8c0/jobs/2543
- https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-api/623/workflows/b96bc434-7e97-4926-9acb-af7042462c92/jobs/2545
- https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-api/586/workflows/33f2258f-cdd4-4266-8aea-b25f9e9edd18/jobs/2374
- https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-api/478/workflows/9e03acff-c33a-4bdc-a3a7-e4b4db54b1ee/jobs/1872

## Changes proposed in this PR

- Update Probation Offender Search and Prison API (for consistency) to use custom Dockerfiles that first downloads the OpenAPI spec and runs Prism afterwards. This ensures that the OpenAPI spec is downloaded and Prism doesn't have the responsibility for that.

