### PR TITLE
Add string extension for decoding URLs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrl
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
@@ -42,7 +42,7 @@ class PersonController(
 
   @GetMapping("{encodedPncId}")
   fun getPerson(@PathVariable encodedPncId: String): Map<String, Person?> {
-    val pncId = encodedPncId.decodeUrl()
+    val pncId = encodedPncId.decodeUrlCharacters()
     val result = getPersonService.execute(pncId)
 
     if (result.isNullOrEmpty()) {
@@ -54,7 +54,7 @@ class PersonController(
 
   @GetMapping("{encodedPncId}/images")
   fun getPersonImages(@PathVariable encodedPncId: String): Map<String, List<ImageMetadata>> {
-    val pncId = encodedPncId.decodeUrl()
+    val pncId = encodedPncId.decodeUrlCharacters()
     val images = getImageMetadataForPersonService.execute(pncId)
 
     return mapOf("images" to images)
@@ -62,7 +62,7 @@ class PersonController(
 
   @GetMapping("{encodedPncId}/addresses")
   fun getPersonAddresses(@PathVariable encodedPncId: String): Map<String, List<Address>> {
-    val pncId = encodedPncId.decodeUrl()
+    val pncId = encodedPncId.decodeUrlCharacters()
     val addresses = getAddressesForPersonService.execute(pncId)
       ?: throw EntityNotFoundException("Could not find person with id: $pncId")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrl
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
@@ -15,8 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesFor
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonsService
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets
 
 @RestController
 @RequestMapping("/persons")
@@ -43,7 +42,7 @@ class PersonController(
 
   @GetMapping("{encodedPncId}")
   fun getPerson(@PathVariable encodedPncId: String): Map<String, Person?> {
-    val pncId = URLDecoder.decode(encodedPncId, StandardCharsets.UTF_8)
+    val pncId = encodedPncId.decodeUrl()
     val result = getPersonService.execute(pncId)
 
     if (result.isNullOrEmpty()) {
@@ -55,7 +54,7 @@ class PersonController(
 
   @GetMapping("{encodedPncId}/images")
   fun getPersonImages(@PathVariable encodedPncId: String): Map<String, List<ImageMetadata>> {
-    val pncId = URLDecoder.decode(encodedPncId, StandardCharsets.UTF_8)
+    val pncId = encodedPncId.decodeUrl()
     val images = getImageMetadataForPersonService.execute(pncId)
 
     return mapOf("images" to images)
@@ -63,9 +62,9 @@ class PersonController(
 
   @GetMapping("{encodedPncId}/addresses")
   fun getPersonAddresses(@PathVariable encodedPncId: String): Map<String, List<Address>> {
-    val pncId = URLDecoder.decode(encodedPncId, StandardCharsets.UTF_8)
-    val addresses =
-      getAddressesForPersonService.execute(pncId) ?: throw EntityNotFoundException("Could not find person with id: $pncId")
+    val pncId = encodedPncId.decodeUrl()
+    val addresses = getAddressesForPersonService.execute(pncId)
+      ?: throw EntityNotFoundException("Could not find person with id: $pncId")
 
     return mapOf("addresses" to addresses)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtension.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtension.kt
@@ -1,3 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
 fun String.removeWhitespaceAndNewlines(): String = this.replace("(\"[^\"]*\")|\\s".toRegex(), "\$1")
+
+fun String.decodeUrl(): String = URLDecoder.decode(this, StandardCharsets.UTF_8)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtension.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtension.kt
@@ -5,4 +5,4 @@ import java.nio.charset.StandardCharsets
 
 fun String.removeWhitespaceAndNewlines(): String = this.replace("(\"[^\"]*\")|\\s".toRegex(), "\$1")
 
-fun String.decodeUrl(): String = URLDecoder.decode(this, StandardCharsets.UTF_8)
+fun String.decodeUrlCharacters(): String = URLDecoder.decode(this, StandardCharsets.UTF_8)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
@@ -23,4 +23,10 @@ class StringExtensionTest : DescribeSpec({
       """.removeWhitespaceAndNewlines().shouldBe("{\"cat\":\"meow meow\"}")
     }
   }
+
+  describe("#decodeUrl") {
+    it("decodes URL encoded string") {
+      "never%21gonna%26give%2Fyou%23up".decodeUrl().shouldBe("never!gonna&give/you#up")
+    }
+  }
 },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
@@ -24,9 +24,9 @@ class StringExtensionTest : DescribeSpec({
     }
   }
 
-  describe("#decodeUrl") {
+  describe("#decodeUrlCharacters") {
     it("decodes URL encoded string") {
-      "never%21gonna%26give%2Fyou%23up".decodeUrl().shouldBe("never!gonna&give/you#up")
+      "never%21gonna%26give%2Fyou%23up".decodeUrlCharacters().shouldBe("never!gonna&give/you#up")
     }
   }
 },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
@@ -28,5 +28,9 @@ class StringExtensionTest : DescribeSpec({
     it("decodes URL encoded string") {
       "never%21gonna%26give%2Fyou%23up".decodeUrlCharacters().shouldBe("never!gonna&give/you#up")
     }
+
+    it("returns same string when no URL encoded characters") {
+      "never/gonna/give/you/up".decodeUrlCharacters().shouldBe("never/gonna/give/you/up")
+    }
   }
 },)


### PR DESCRIPTION
Not sure about the naming of the extension as `encodedPncId.decodeUrl()` looks a bit weird... Wonder if `.decodeUrlCharacters()` or `.decodeUrlEncodedCharacters()` is better, would appreciate feedback on this!