### PR TITLE
Upgraded hmpps gradle springboot from 5.1.0 to 5.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.2"
   kotlin("plugin.spring") version "1.8.0"
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
@@ -23,8 +23,8 @@ class HmppsIntegrationApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
-          developerMessage = e.message
-        )
+          developerMessage = e.message,
+        ),
       )
   }
 
@@ -37,8 +37,8 @@ class HmppsIntegrationApiExceptionHandler {
         ErrorResponse(
           status = NOT_FOUND,
           userMessage = "404 Not found error: ${e.message}",
-          developerMessage = e.message
-        )
+          developerMessage = e.message,
+        ),
       )
   }
 
@@ -51,8 +51,8 @@ class HmppsIntegrationApiExceptionHandler {
         ErrorResponse(
           status = INTERNAL_SERVER_ERROR,
           userMessage = "Authentication error: ${e.message}",
-          developerMessage = e.message
-        )
+          developerMessage = e.message,
+        ),
       )
   }
 
@@ -65,8 +65,8 @@ class HmppsIntegrationApiExceptionHandler {
         ErrorResponse(
           status = INTERNAL_SERVER_ERROR,
           userMessage = "Unexpected error: ${e.message}",
-          developerMessage = e.message
-        )
+          developerMessage = e.message,
+        ),
       )
   }
 
@@ -80,14 +80,14 @@ data class ErrorResponse(
   val errorCode: Int? = null,
   val userMessage: String? = null,
   val developerMessage: String? = null,
-  val moreInfo: String? = null
+  val moreInfo: String? = null,
 ) {
   constructor(
     status: HttpStatus,
     errorCode: Int? = null,
     userMessage: String? = null,
     developerMessage: String? = null,
-    moreInfo: String? = null
+    moreInfo: String? = null,
   ) :
     this(status.value(), errorCode, userMessage, developerMessage, moreInfo)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/RequestLogger.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/RequestLogger.kt
@@ -14,8 +14,9 @@ class RequestLogger() : HandlerInterceptor {
 
   override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
     // log. allows us ot log at different levels
-    if (log.isDebugEnabled)
+    if (log.isDebugEnabled) {
       log.debug(RetrieveRequestData(request))
+    }
 
     // Informs the super to continue processing this request
     return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/TomcatConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/TomcatConfig.kt
@@ -16,7 +16,7 @@ class TomcatConfig {
       factory.addConnectorCustomizers(
         TomcatConnectorCustomizer { connector: Connector ->
           connector.encodedSolidusHandling = EncodedSolidusHandling.PASS_THROUGH.value
-        }
+        },
       )
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/ImageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/ImageController.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageService
 @RestController
 @RequestMapping("/images")
 class ImageController(
-  @Autowired val getImageService: GetImageService
+  @Autowired val getImageService: GetImageService,
 ) {
   @GetMapping("{id}")
   fun getImage(@PathVariable id: Int): ResponseEntity<ByteArray> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonController.kt
@@ -24,13 +24,13 @@ class PersonController(
   @Autowired val getPersonService: GetPersonService,
   @Autowired val getPersonsService: GetPersonsService,
   @Autowired val getImageMetadataForPersonService: GetImageMetadataForPersonService,
-  @Autowired val getAddressesForPersonService: GetAddressesForPersonService
+  @Autowired val getAddressesForPersonService: GetAddressesForPersonService,
 ) {
 
   @GetMapping
   fun getPersons(
     @RequestParam(required = false, name = "first_name") firstName: String?,
-    @RequestParam(required = false, name = "last_name") lastName: String?
+    @RequestParam(required = false, name = "last_name") lastName: String?,
   ): Map<String, List<Person?>> {
     if (firstName == null && lastName == null) {
       throw ValidationException("No query parameters specified.")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -5,7 +5,7 @@ import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 
 class WebClientWrapper(
-  val baseUrl: String
+  val baseUrl: String,
 ) {
   val client: WebClient = WebClient
     .builder()
@@ -17,8 +17,9 @@ class WebClientWrapper(
       .uri(uri)
       .header("Authorization", "Bearer $token")
 
-    if (method == HttpMethod.POST && requestBody != null)
+    if (method == HttpMethod.POST && requestBody != null) {
       responseBodySpec.body(BodyInserters.fromValue(requestBody))
+    }
 
     return responseBodySpec.retrieve()
       .bodyToMono(T::class.java)
@@ -30,8 +31,9 @@ class WebClientWrapper(
       .uri(uri)
       .header("Authorization", "Bearer $token")
 
-    if (method == HttpMethod.POST && requestBody != null)
+    if (method == HttpMethod.POST && requestBody != null) {
       responseBodySpec.body(BodyInserters.fromValue(requestBody))
+    }
 
     return responseBodySpec.retrieve()
       .bodyToFlux(T::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -29,7 +29,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
         HttpMethod.POST,
         "/search",
         token,
-        mapOf("pncNumber" to pncId, "valid" to true)
+        mapOf("pncNumber" to pncId, "valid" to true),
       )
 
       if (offenders.isNotEmpty()) offenders.first().toPerson() else null
@@ -58,9 +58,10 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
 
     if (offender.isEmpty()) return null
 
-    return if (offender.first().contactDetails.addresses.isNotEmpty())
+    return if (offender.first().contactDetails.addresses.isNotEmpty()) {
       offender.first().contactDetails.addresses.map { it.toAddress() }
-    else
+    } else {
       listOf()
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/health/ExternalHealthIndicator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/health/ExternalHealthIndicator.kt
@@ -34,10 +34,11 @@ open class ExternalHealthIndicator(url: String) : HealthIndicator {
         .build()
     }
 
-    if (response.statusCode() != 200)
+    if (response.statusCode() != 200) {
       return healthStatus.up()
         .withDetail("httpStatusCode", response.statusCode())
         .build()
+    }
 
     return healthStatus.build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Address.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class Address(
-  val postcode: String?
+  val postcode: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Alias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Alias.kt
@@ -10,5 +10,5 @@ data class Alias(
   @JsonAlias("middleNames")
   val middleName: String? = null,
   @JsonAlias("dob")
-  var dateOfBirth: LocalDate? = null
+  var dateOfBirth: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ImageMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ImageMetadata.kt
@@ -7,5 +7,5 @@ data class ImageMetadata(
   val captureDate: LocalDate,
   val view: String,
   val orientation: String,
-  val type: String
+  val type: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -12,5 +12,5 @@ data class Person(
   val dateOfBirth: LocalDate? = null,
   @JsonAlias("offenderAliases")
   val aliases: List<Alias> = listOf(),
-  val prisonerId: String? = null
+  val prisonerId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Address.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address as IntegrationAPIAddress
 
 data class Address(
-  val postalCode: String
+  val postalCode: String,
 ) {
   fun toAddress() = IntegrationAPIAddress(postcode = this.postalCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Alias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Alias.kt
@@ -6,5 +6,5 @@ data class Alias(
   val firstName: String,
   val lastName: String,
   val middleName: String? = null,
-  var dob: LocalDate? = null
+  var dob: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/ImageDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/ImageDetail.kt
@@ -8,13 +8,13 @@ class ImageDetail(
   val captureDate: LocalDate,
   val imageView: String,
   val imageOrientation: String,
-  val imageType: String
+  val imageType: String,
 ) {
   fun toImageMetadata(): ImageMetadata = ImageMetadata(
     id = this.imageId,
     captureDate = this.captureDate,
     view = this.imageView,
     orientation = this.imageOrientation,
-    type = this.imageType
+    type = this.imageType,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Offender.kt
@@ -10,7 +10,7 @@ data class Offender(
   val lastName: String,
   val middleName: String? = null,
   val dateOfBirth: LocalDate? = null,
-  val aliases: List<nomisAlias> = listOf()
+  val aliases: List<nomisAlias> = listOf(),
 ) {
   fun toPerson(): Person = Person(
     firstName = this.firstName,
@@ -22,8 +22,8 @@ data class Offender(
         it.firstName,
         it.lastName,
         it.middleName,
-        it.dob
+        it.dob,
       )
-    }
+    },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/GlobalSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/GlobalSearch.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch
 
 class GlobalSearch(
-  val content: List<Prisoner>
+  val content: List<Prisoner>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
@@ -10,7 +10,7 @@ data class Prisoner(
   val middleNames: String? = null,
   val dateOfBirth: LocalDate? = null,
   val aliases: List<PrisonerAlias> = listOf(),
-  val prisonerNumber: String? = null
+  val prisonerNumber: String? = null,
 ) {
   fun toPerson(): Person = Person(
     firstName = this.firstName,
@@ -22,9 +22,9 @@ data class Prisoner(
         it.firstName,
         it.lastName,
         it.middleNames,
-        it.dateOfBirth
+        it.dateOfBirth,
       )
     },
-    prisonerId = this.prisonerNumber
+    prisonerId = this.prisonerNumber,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAlias.kt
@@ -6,5 +6,5 @@ data class PrisonerAlias(
   val firstName: String,
   val lastName: String,
   val middleNames: String? = null,
-  var dateOfBirth: LocalDate? = null
+  var dateOfBirth: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffende
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address as IntegrationAPIAddress
 
 data class Address(
-  val postcode: String?
+  val postcode: String?,
 ) {
   fun toAddress() = IntegrationAPIAddress(postcode = this.postcode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/ContactDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/ContactDetails.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
 data class ContactDetails(
-  val addresses: List<Address> = listOf()
+  val addresses: List<Address> = listOf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -10,7 +10,7 @@ data class Offender(
   val middleNames: List<String> = listOf(),
   val dateOfBirth: LocalDate? = null,
   val offenderAliases: List<OffenderAlias> = listOf(),
-  val contactDetails: ContactDetails = ContactDetails()
+  val contactDetails: ContactDetails = ContactDetails(),
 ) {
   fun toPerson(): Person = Person(
     firstName = this.firstName,
@@ -22,8 +22,8 @@ data class Offender(
         it.firstName,
         it.surname,
         it.middleNames.joinToString(" "),
-        it.dateOfBirth
+        it.dateOfBirth,
       )
-    }
+    },
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
@@ -6,5 +6,5 @@ data class OffenderAlias(
   val firstName: String,
   val surname: String,
   val middleNames: List<String> = listOf(),
-  var dateOfBirth: LocalDate? = null
+  var dateOfBirth: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 class GetAddressesForPersonService(
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
-  @Autowired val nomisGateway: NomisGateway
+  @Autowired val nomisGateway: NomisGateway,
 ) {
   fun execute(pncId: String): List<Address>? {
     val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
@@ -19,8 +19,9 @@ class GetAddressesForPersonService(
     val addressesFromNomis = nomisGateway.getAddressesForPerson(personFromPrisonerOffenderSearch.first().prisonerId!!)
     val addressesFromProbationOffenderSearch = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    if (addressesFromNomis == null && addressesFromProbationOffenderSearch == null)
+    if (addressesFromNomis == null && addressesFromProbationOffenderSearch == null) {
       return null
+    }
 
     return addressesFromProbationOffenderSearch?.plus(addressesFromNomis.orEmpty())
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 @Service
 class GetImageMetadataForPersonService(
   @Autowired val nomisGateway: NomisGateway,
-  @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway
+  @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
 ) {
   fun execute(pncId: String): List<ImageMetadata> {
     val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 @Service
 class GetPersonService(
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
-  @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway
+  @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) {
   fun execute(pncId: String): Map<String, Person?>? {
     val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
@@ -21,7 +21,7 @@ class GetPersonService(
 
     return mapOf(
       "prisonerOffenderSearch" to personFromPrisonerOffenderSearch.first(),
-      "probationOffenderSearch" to personFromProbationOffenderSearch
+      "probationOffenderSearch" to personFromProbationOffenderSearch,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 @Service
 class GetPersonsService(
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
-  @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway
+  @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) {
 
   fun execute(firstName: String?, lastName: String?): List<Person?> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/ImageControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/ImageControllerTest.kt
@@ -46,4 +46,4 @@ internal class ImageControllerTest(
       result.response.contentAsByteArray.shouldBe(image)
     }
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -49,15 +49,15 @@ internal class PersonControllerTest(
             firstName = "Barry",
             lastName = "Allen",
             middleName = "Jonas",
-            dateOfBirth = LocalDate.parse("2023-03-01")
+            dateOfBirth = LocalDate.parse("2023-03-01"),
           ),
           Person(
             firstName = "Barry",
             lastName = "Allen",
             middleName = "Rock",
-            dateOfBirth = LocalDate.parse("2022-07-22")
-          )
-        )
+            dateOfBirth = LocalDate.parse("2022-07-22"),
+          ),
+        ),
       )
     }
 
@@ -72,7 +72,7 @@ internal class PersonControllerTest(
       val lastNameThatDoesNotExist = "Gun36773"
 
       whenever(getPersonsService.execute(firstNameThatDoesNotExist, lastNameThatDoesNotExist)).thenReturn(
-        listOf()
+        listOf(),
       )
 
       val result =
@@ -84,7 +84,7 @@ internal class PersonControllerTest(
           {
             "persons":[]
           }
-          """.removeWhitespaceAndNewlines()
+          """.removeWhitespaceAndNewlines(),
       )
     }
 
@@ -120,7 +120,7 @@ internal class PersonControllerTest(
                }
              ]
            }
-        """.removeWhitespaceAndNewlines()
+        """.removeWhitespaceAndNewlines(),
       )
     }
 
@@ -147,7 +147,7 @@ internal class PersonControllerTest(
   describe("GET /persons/{id}") {
     val person = mapOf(
       "prisonerOffenderSearch" to Person("Sally", "Sob"),
-      "probationOffenderSearch" to Person("Silly", "Sobbers")
+      "probationOffenderSearch" to Person("Silly", "Sobbers"),
     )
 
     beforeTest {
@@ -200,7 +200,7 @@ internal class PersonControllerTest(
             "prisonerId":null
           }
         }
-        """.removeWhitespaceAndNewlines()
+        """.removeWhitespaceAndNewlines(),
       )
     }
   }
@@ -249,7 +249,7 @@ internal class PersonControllerTest(
             }
           ]
         }
-        """.removeWhitespaceAndNewlines()
+        """.removeWhitespaceAndNewlines(),
       )
     }
   }
@@ -288,7 +288,7 @@ internal class PersonControllerTest(
             }
           ]
         }
-        """.removeWhitespaceAndNewlines()
+        """.removeWhitespaceAndNewlines(),
       )
     }
 
@@ -300,4 +300,4 @@ internal class PersonControllerTest(
       result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
     }
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/StringExtensionTest.kt
@@ -23,4 +23,4 @@ class StringExtensionTest : DescribeSpec({
       """.removeWhitespaceAndNewlines().shouldBe("{\"cat\":\"meow meow\"}")
     }
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -34,7 +34,7 @@ class WebClientWrapperTest : DescribeSpec({
           {
             "sourceName" : "Harold"
           }
-          """.removeWhitespaceAndNewlines()
+          """.removeWhitespaceAndNewlines(),
     )
 
     val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
@@ -55,7 +55,7 @@ class WebClientWrapperTest : DescribeSpec({
             "sourceName": "Paul"
           }
         ]
-      """.removeWhitespaceAndNewlines()
+      """.removeWhitespaceAndNewlines(),
     )
 
     val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
@@ -63,7 +63,7 @@ class WebClientWrapperTest : DescribeSpec({
       HttpMethod.POST,
       "/testPost",
       token,
-      mapOf("sourceName" to "Paul")
+      mapOf("sourceName" to "Paul"),
     )
 
     val testDomainModels = testModels.map { it.toDomain() }
@@ -87,7 +87,7 @@ class WebClientWrapperTest : DescribeSpec({
             }
           ]
         }
-      """.removeWhitespaceAndNewlines()
+      """.removeWhitespaceAndNewlines(),
     )
 
     val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
@@ -98,4 +98,4 @@ class WebClientWrapperTest : DescribeSpec({
     testDomainModels.first().lastName.shouldBe("Paper")
     testDomainModels.last().lastName.shouldBe("Card")
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGatewayTest.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMoc
 @ActiveProfiles("test")
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [(HmppsAuthGateway::class)]
+  classes = [(HmppsAuthGateway::class)],
 )
 class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
   DescribeSpec({
@@ -57,4 +57,4 @@ class HmppsAuthGatewayTest(hmppsAuthGateway: HmppsAuthGateway) :
 
       exception.message.shouldBe("Invalid credentials used for NOMIS.")
     }
-  })
+  },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAddressesForPersonTest.kt
@@ -22,11 +22,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 @ActiveProfiles("test")
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [NomisGateway::class]
+  classes = [NomisGateway::class],
 )
 class GetAddressesForPersonTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
-  private val nomisGateway: NomisGateway
+  private val nomisGateway: NomisGateway,
 ) : DescribeSpec({
   val nomisApiMockServer = NomisApiMockServer()
   val offenderNo = "abc123"
@@ -41,7 +41,7 @@ class GetAddressesForPersonTest(
               "postalCode": "SA1 1DP"
             }
           ]
-        """
+        """,
     )
 
     Mockito.reset(hmppsAuthGateway)
@@ -80,11 +80,11 @@ class GetAddressesForPersonTest(
           "developerMessage": "cannot find person"
         }
         """,
-      HttpStatus.NOT_FOUND
+      HttpStatus.NOT_FOUND,
     )
 
     val addresses = nomisGateway.getAddressesForPerson(offenderNo)
 
     addresses.shouldBeNull()
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/NomisGatewayTest.kt
@@ -25,7 +25,7 @@ import java.time.LocalDate
 @ActiveProfiles("test")
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [NomisGateway::class]
+  classes = [NomisGateway::class],
 )
 class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private val nomisGateway: NomisGateway) :
   DescribeSpec({
@@ -63,7 +63,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
             }
           ]
         }
-        """
+        """,
         )
       }
 
@@ -96,7 +96,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
             "lastName": "Smith",
             "aliases": []
           }
-          """
+          """,
         )
 
         val person = nomisGateway.getPerson(offenderNo)
@@ -112,7 +112,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
             "developerMessage": "reason for bad request"
           }
           """,
-          HttpStatus.BAD_REQUEST
+          HttpStatus.BAD_REQUEST,
         )
 
         val person = nomisGateway.getPerson(offenderNo)
@@ -128,7 +128,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
             "developerMessage": "cannot find person"
           }
           """,
-          HttpStatus.NOT_FOUND
+          HttpStatus.NOT_FOUND,
         )
 
         val person = nomisGateway.getPerson(offenderNo)
@@ -151,7 +151,7 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
               "imageType": "OFF_BKG"
             }
           ]
-        """
+        """,
         )
       }
 
@@ -220,4 +220,4 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
         exception.message.shouldBe("Could not find image with id: $imageId")
       }
     }
-  })
+  },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -24,11 +24,11 @@ import java.time.LocalDate
 @ActiveProfiles("test")
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [PrisonerOffenderSearchGateway::class]
+  classes = [PrisonerOffenderSearchGateway::class],
 )
 class PrisonerOffenderSearchGatewayTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
-  private val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway
+  private val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
 ) : DescribeSpec({
   val prisonerOffenderSearchApiMockServer = PrisonerOffenderSearchApiMockServer()
 
@@ -58,7 +58,7 @@ class PrisonerOffenderSearchGatewayTest(
               "includeAliases":true
             }
           """.removeWhitespaceAndNewlines(),
-        File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/fixtures/GetPrisonersResponse.json").readText()
+        File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/fixtures/GetPrisonersResponse.json").readText(),
       )
     }
 
@@ -99,7 +99,7 @@ class PrisonerOffenderSearchGatewayTest(
             }
           ]
         }
-        """.trimIndent()
+        """.trimIndent(),
       )
 
       val persons = prisonerOffenderSearchGateway.getPersons("Obi-Wan", null)
@@ -127,7 +127,7 @@ class PrisonerOffenderSearchGatewayTest(
             }
           ]
         }
-        """.trimIndent()
+        """.trimIndent(),
       )
 
       val persons = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
@@ -155,7 +155,7 @@ class PrisonerOffenderSearchGatewayTest(
             }
           ]
         }
-        """.trimIndent()
+        """.trimIndent(),
       )
 
       val persons = prisonerOffenderSearchGateway.getPersons(null, "Binks")
@@ -181,7 +181,7 @@ class PrisonerOffenderSearchGatewayTest(
         {
           "content": []
         }
-        """
+        """,
       )
 
       val persons = prisonerOffenderSearchGateway.getPersons(firstNameThatDoesNotExist, lastNameThatDoesNotExist)
@@ -212,7 +212,7 @@ class PrisonerOffenderSearchGatewayTest(
             }
           ]
         }
-        """
+        """,
       )
     }
 
@@ -245,7 +245,7 @@ class PrisonerOffenderSearchGatewayTest(
             "lastName": "Smith",
             "aliases": []
           }
-          """
+          """,
       )
 
       val person = prisonerOffenderSearchGateway.getPerson(offenderNo)
@@ -261,7 +261,7 @@ class PrisonerOffenderSearchGatewayTest(
             "developerMessage": "reason for bad request"
           }
           """,
-        HttpStatus.BAD_REQUEST
+        HttpStatus.BAD_REQUEST,
       )
 
       val person = prisonerOffenderSearchGateway.getPerson(offenderNo)
@@ -277,7 +277,7 @@ class PrisonerOffenderSearchGatewayTest(
             "developerMessage": "cannot find person"
           }
           """,
-        HttpStatus.NOT_FOUND
+        HttpStatus.NOT_FOUND,
       )
 
       val person = prisonerOffenderSearchGateway.getPerson(offenderNo)
@@ -285,4 +285,4 @@ class PrisonerOffenderSearchGatewayTest(
       person?.shouldBeNull()
     }
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -21,11 +21,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 @ActiveProfiles("test")
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [ProbationOffenderSearchGateway::class]
+  classes = [ProbationOffenderSearchGateway::class],
 )
 class GetAddressesForPersonTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
-  private val probationOffenderSearchGateway: ProbationOffenderSearchGateway
+  private val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) : DescribeSpec({
   val probationOffenderSearchApiMockServer = ProbationOffenderSearchApiMockServer()
   val pncId = "2002/1121M"
@@ -48,12 +48,12 @@ class GetAddressesForPersonTest(
             }
           }
         ]
-      """
+      """,
     )
 
     Mockito.reset(hmppsAuthGateway)
     whenever(hmppsAuthGateway.getClientToken("Probation Offender Search")).thenReturn(
-      HmppsAuthMockServer.TOKEN
+      HmppsAuthMockServer.TOKEN,
     )
   }
 
@@ -86,7 +86,7 @@ class GetAddressesForPersonTest(
             }
           }
         ]
-        """
+        """,
     )
 
     val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
@@ -97,11 +97,11 @@ class GetAddressesForPersonTest(
   it("returns null when no results are returned") {
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
       "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      "[]"
+      "[]",
     )
 
     val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
     addresses.shouldBeNull()
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -24,11 +24,11 @@ import java.time.LocalDate
 @ActiveProfiles("test")
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [ProbationOffenderSearchGateway::class]
+  classes = [ProbationOffenderSearchGateway::class],
 )
 class ProbationOffenderSearchGatewayTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
-  private val probationOffenderSearchGateway: ProbationOffenderSearchGateway
+  private val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) : DescribeSpec({
   val probationOffenderSearchApiMockServer = ProbationOffenderSearchApiMockServer()
 
@@ -56,7 +56,7 @@ class ProbationOffenderSearchGatewayTest(
               "valid":true
             }
           """.removeWhitespaceAndNewlines(),
-        File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json").readText()
+        File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json").readText(),
       )
     }
 
@@ -88,7 +88,7 @@ class ProbationOffenderSearchGatewayTest(
             "surname": "Tano"
           }
         ]
-        """.trimIndent()
+        """.trimIndent(),
       )
       val persons = probationOffenderSearchGateway.getPersons("Ahsoka", null)
 
@@ -112,7 +112,7 @@ class ProbationOffenderSearchGatewayTest(
             "surname": "Tano"
           }
         ]
-        """.trimIndent()
+        """.trimIndent(),
       )
       val persons = probationOffenderSearchGateway.getPersons(null, "Tano")
 
@@ -150,7 +150,7 @@ class ProbationOffenderSearchGatewayTest(
             ]
           }
         ]
-      """
+      """,
       )
     }
 
@@ -185,7 +185,7 @@ class ProbationOffenderSearchGatewayTest(
             "offenderAliases": []
           }
         ]
-        """
+        """,
       )
 
       val person = probationOffenderSearchGateway.getPerson(pncId)
@@ -201,7 +201,7 @@ class ProbationOffenderSearchGatewayTest(
             "developerMessage": "reason for bad request"
           }
           """,
-        HttpStatus.BAD_REQUEST
+        HttpStatus.BAD_REQUEST,
       )
 
       val person = probationOffenderSearchGateway.getPerson(pncId)
@@ -212,7 +212,7 @@ class ProbationOffenderSearchGatewayTest(
     it("returns null when no offenders are returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
         "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-        "[]"
+        "[]",
       )
 
       val person = probationOffenderSearchGateway.getPerson(pncId)
@@ -220,4 +220,4 @@ class ProbationOffenderSearchGatewayTest(
       person?.shouldBeNull()
     }
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/health/HealthCheckTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/health/HealthCheckTest.kt
@@ -28,7 +28,7 @@ class HealthCheckTest : IntegrationTestBase() {
       .expectBody().jsonPath("components.healthInfo.details.version").value(
         Consumer<String> {
           assertThat(it).startsWith(LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-        }
+        },
       )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/GenericApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/GenericApiMockServer.kt
@@ -16,8 +16,8 @@ class GenericApiMockServer : WireMockServer(WIREMOCK_PORT) {
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
-          .withBody(body.trimIndent())
-      )
+          .withBody(body.trimIndent()),
+      ),
     )
   }
 
@@ -27,8 +27,8 @@ class GenericApiMockServer : WireMockServer(WIREMOCK_PORT) {
         WireMock.aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
-          .withBody(body.trimIndent())
-      )
+          .withBody(body.trimIndent()),
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/HmppsAuthMockServer.kt
@@ -24,9 +24,9 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
                 { 
                   "access_token": "$TOKEN"
                 }
-              """.trimIndent()
-            )
-        )
+              """.trimIndent(),
+            ),
+        ),
     )
   }
 
@@ -34,8 +34,8 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       WireMock.post(authUrl)
         .willReturn(
-          WireMock.serviceUnavailable()
-        )
+          WireMock.serviceUnavailable(),
+        ),
     )
   }
 
@@ -43,8 +43,8 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       WireMock.post(authUrl)
         .willReturn(
-          WireMock.unauthorized()
-        )
+          WireMock.unauthorized(),
+        ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -15,13 +15,14 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       get("/api/offenders/$offenderNo")
         .withHeader(
-          "Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}")
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
         ).willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(body.trimIndent())
-        )
+            .withBody(body.trimIndent()),
+        ),
     )
   }
 
@@ -29,13 +30,14 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       get("/api/images/offenders/$offenderNo")
         .withHeader(
-          "Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}")
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
         ).willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(body.trimIndent())
-        )
+            .withBody(body.trimIndent()),
+        ),
     )
   }
 
@@ -43,13 +45,14 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       get("/api/images/$imageId/data")
         .withHeader(
-          "Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}")
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
         ).willReturn(
           aResponse()
             .withHeader("Content-Type", "image/jpeg")
             .withStatus(status.value())
-            .withBodyFile("example.jpg")
-        )
+            .withBodyFile("example.jpg"),
+        ),
     )
   }
 
@@ -57,13 +60,14 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     stubFor(
       get("/api/offenders/$offenderNo/addresses")
         .withHeader(
-          "Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}")
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
         ).willReturn(
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(body.trimIndent())
-        )
+            .withBody(body.trimIndent()),
+        ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
@@ -21,8 +21,8 @@ class PrisonerOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(responseBody.trimIndent())
-        )
+            .withBody(responseBody.trimIndent()),
+        ),
     )
   }
 
@@ -35,8 +35,8 @@ class PrisonerOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(responseBody.trimIndent())
-        )
+            .withBody(responseBody.trimIndent()),
+        ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ProbationOffenderSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ProbationOffenderSearchApiMockServer.kt
@@ -21,8 +21,8 @@ class ProbationOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
           aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(responseBody.trimIndent())
-        )
+            .withBody(responseBody.trimIndent()),
+        ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/CredentialsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/CredentialsTest.kt
@@ -11,4 +11,4 @@ class CredentialsTest : DescribeSpec({
       credentials.toBasicAuth().shouldBe("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
     }
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
@@ -18,13 +18,13 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [GetAddressesForPersonService::class]
+  classes = [GetAddressesForPersonService::class],
 )
 internal class GetAddressesForPersonServiceTest(
   @MockBean val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
   @MockBean val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @MockBean val nomisGateway: NomisGateway,
-  private val getAddressesForPersonService: GetAddressesForPersonService
+  private val getAddressesForPersonService: GetAddressesForPersonService,
 ) : DescribeSpec({
   val pncId = "2003/13116M"
   val prisonerNumber = "A5553AA"
@@ -39,9 +39,9 @@ internal class GetAddressesForPersonServiceTest(
         Person(
           firstName = "Qui-gon",
           lastName = "Jin",
-          prisonerId = prisonerNumber
-        )
-      )
+          prisonerId = prisonerNumber,
+        ),
+      ),
     )
   }
 
@@ -69,8 +69,8 @@ internal class GetAddressesForPersonServiceTest(
 
     whenever(probationOffenderSearchGateway.getAddressesForPerson(pncId)).thenReturn(
       listOf(
-        addressesFromProbationOffenderSearch
-      )
+        addressesFromProbationOffenderSearch,
+      ),
     )
     whenever(nomisGateway.getAddressesForPerson(prisonerNumber)).thenReturn(listOf(addressesFromNomis))
 
@@ -88,4 +88,4 @@ internal class GetAddressesForPersonServiceTest(
 
     result.shouldBeNull()
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
@@ -17,12 +17,12 @@ import java.time.LocalDate
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [GetImageMetadataForPersonService::class]
+  classes = [GetImageMetadataForPersonService::class],
 )
 internal class GetImageMetadataForPersonServiceTest(
   @MockBean val nomisGateway: NomisGateway,
   @MockBean val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
-  private val getImageMetadataForPersonService: GetImageMetadataForPersonService
+  private val getImageMetadataForPersonService: GetImageMetadataForPersonService,
 ) : DescribeSpec({
   val pncId = "2003/13116M"
   val prisonerNumber = "abc123"
@@ -35,9 +35,9 @@ internal class GetImageMetadataForPersonServiceTest(
         Person(
           firstName = "Joey",
           lastName = "Tribbiani",
-          prisonerId = prisonerNumber
-        )
-      )
+          prisonerId = prisonerNumber,
+        ),
+      ),
     )
   }
 
@@ -60,8 +60,8 @@ internal class GetImageMetadataForPersonServiceTest(
         captureDate = LocalDate.parse("2023-03-01"),
         view = "FACE",
         orientation = "FRONT",
-        type = "OFF_BKG"
-      )
+        type = "OFF_BKG",
+      ),
     )
     whenever(nomisGateway.getImageMetadataForPerson(prisonerNumber)).thenReturn(imageMetadataFromNomis)
 
@@ -69,4 +69,4 @@ internal class GetImageMetadataForPersonServiceTest(
 
     result.shouldBe(imageMetadataFromNomis)
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageServiceTest.kt
@@ -13,11 +13,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [GetImageService::class]
+  classes = [GetImageService::class],
 )
 internal class GetImageServiceTest(
   @MockBean val nomisGateway: NomisGateway,
-  private val getImageService: GetImageService
+  private val getImageService: GetImageService,
 ) : DescribeSpec({
   val id = 12345
 
@@ -40,4 +40,4 @@ internal class GetImageServiceTest(
 
     result.shouldBe(image)
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -16,12 +16,12 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [GetPersonService::class]
+  classes = [GetPersonService::class],
 )
 internal class GetPersonServiceTest(
   @MockBean val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @MockBean val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
-  private val getPersonService: GetPersonService
+  private val getPersonService: GetPersonService,
 ) : DescribeSpec({
   val pncId = "2003/13116M"
 
@@ -34,9 +34,9 @@ internal class GetPersonServiceTest(
         Person(
           firstName = "Qui-gon",
           lastName = "Jin",
-          prisonerId = "A1234AA"
-        )
-      )
+          prisonerId = "A1234AA",
+        ),
+      ),
     )
   }
 
@@ -63,7 +63,7 @@ internal class GetPersonServiceTest(
 
     val expectedResult = mapOf(
       "prisonerOffenderSearch" to Person("Sally", "Sob"),
-      "probationOffenderSearch" to Person("Molly", "Mob")
+      "probationOffenderSearch" to Person("Molly", "Mob"),
     )
 
     result.shouldBe(expectedResult)
@@ -77,4 +77,4 @@ internal class GetPersonServiceTest(
 
     result.shouldBeNull()
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
@@ -15,12 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [GetPersonsService::class]
+  classes = [GetPersonsService::class],
 )
 internal class GetPersonsServiceTest(
   @MockBean val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @MockBean val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
-  private val getPersonsService: GetPersonsService
+  private val getPersonsService: GetPersonsService,
 ) : DescribeSpec({
   val firstName = "Bruce"
   val lastName = "Wayne"
@@ -61,4 +61,4 @@ internal class GetPersonsServiceTest(
     val result = getPersonsService.execute(firstName, lastName)
     result.shouldBe(emptyList())
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/ImageSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/ImageSmokeTest.kt
@@ -18,10 +18,10 @@ class ImageSmokeTest : DescribeSpec({
 
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/images/$id")).build(),
-      HttpResponse.BodyHandlers.ofString()
+      HttpResponse.BodyHandlers.ofString(),
     )
 
     response.statusCode().shouldBe(HttpStatus.OK.value())
     response.headers().map()["content-type"]?.first().shouldBe("image/jpeg")
   }
-})
+},)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -27,7 +27,7 @@ class PersonSmokeTest : DescribeSpec({
 
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons?$queryParams")).build(),
-      HttpResponse.BodyHandlers.ofString()
+      HttpResponse.BodyHandlers.ofString(),
     )
 
     response.statusCode().shouldBe(HttpStatus.OK.value())
@@ -36,20 +36,20 @@ class PersonSmokeTest : DescribeSpec({
       """
         "firstName":"Robert",
         "lastName":"Larsen"
-      """.removeWhitespaceAndNewlines()
+      """.removeWhitespaceAndNewlines(),
     )
     response.body().shouldContain(
       """
         "firstName":"string",
         "lastName":"string"
-      """.removeWhitespaceAndNewlines()
+      """.removeWhitespaceAndNewlines(),
     )
   }
 
   it("returns a person from NOMIS, Prisoner Offender Search and Probation Offender Search") {
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons/$encodedPncId")).build(),
-      HttpResponse.BodyHandlers.ofString()
+      HttpResponse.BodyHandlers.ofString(),
     )
 
     response.body().shouldBe(
@@ -86,14 +86,14 @@ class PersonSmokeTest : DescribeSpec({
             "prisonerId": null
           }
         }
-      """.removeWhitespaceAndNewlines()
+      """.removeWhitespaceAndNewlines(),
     )
   }
 
   it("returns image metadata for a person") {
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons/$encodedPncId/images")).build(),
-      HttpResponse.BodyHandlers.ofString()
+      HttpResponse.BodyHandlers.ofString(),
     )
 
     response.body().shouldBe(
@@ -109,14 +109,14 @@ class PersonSmokeTest : DescribeSpec({
         }
       ]
     }
-    """.removeWhitespaceAndNewlines()
+    """.removeWhitespaceAndNewlines(),
     )
   }
 
   it("returns addresses for a person") {
     val response = httpClient.send(
       httpRequest.uri(URI.create("$baseUrl/persons/$encodedPncId/addresses")).build(),
-      HttpResponse.BodyHandlers.ofString()
+      HttpResponse.BodyHandlers.ofString(),
     )
 
     response.statusCode().shouldBe(HttpStatus.OK.value())
@@ -132,7 +132,7 @@ class PersonSmokeTest : DescribeSpec({
         }
       ]
     }
-    """.removeWhitespaceAndNewlines()
+    """.removeWhitespaceAndNewlines(),
     )
   }
-})
+},)


### PR DESCRIPTION
It looks like the git changelog for hmpps gradle spring boot isn’t being updated so I had to do some manual digging to have any confidence that the issue will be fixed by upgrading from 5.1.0 to 5.1.2.

CVE-2020-8908 should have been suppressed 13 days ago.
![image](https://user-images.githubusercontent.com/109950424/225562029-3e787b15-18df-4c56-9aba-747981afa13d.png)

CVE-2022-45688 was suppressed on 1st Feb.
![image](https://user-images.githubusercontent.com/109950424/225562062-d587f3c1-c1f1-4664-bc64-4e640e8dd8dd.png)

What concerns me here is we definitely upgraded prior to this, version 5.1.0 was released on 8th Feb so we should have had at least the second change.