### PR TITLE
Set Sentry environment

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -13,6 +13,7 @@ generic-service:
   env:
     SPRING_PROFILES_ACTIVE: development
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    SENTRY_ENV: development
 
   namespace_secrets:
     client-credentials:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,7 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    SENTRY_ENV: pre-production
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -5,6 +5,9 @@ generic-service:
   image:
     repository: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/hmpps-integration-api-admin-team/hmpps-integration-api-production-ecr
 
+  env:
+    SENTRY_ENV: production
+
   ingress:
     host: hmpps-integration-api-production.apps.live.cloud-platform.service.justice.gov.uk
 


### PR DESCRIPTION
Currently all environments are seen as production, set the correct environments explicitly with an environment variable.