### PR TITLE
Update API endpoints to return PNC ID for a person

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -275,6 +275,10 @@ components:
           type: string
           example: A1234AA
           description: A prisoner identifier from Prison API (NOMIS)
+        pncId:
+          type: string
+          example: 2008/0545166T
+          description: An identifier from the Police National Computer (PNC)
 
   examples:
     PersonNotFoundError:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -13,4 +13,5 @@ data class Person(
   @JsonAlias("offenderAliases")
   val aliases: List<Alias> = listOf(),
   val prisonerId: String? = null,
+  val pncId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
@@ -11,6 +11,7 @@ data class Prisoner(
   val dateOfBirth: LocalDate? = null,
   val aliases: List<PrisonerAlias> = listOf(),
   val prisonerNumber: String? = null,
+  val pncNumber: String? = null,
 ) {
   fun toPerson(): Person = Person(
     firstName = this.firstName,
@@ -26,5 +27,6 @@ data class Prisoner(
       )
     },
     prisonerId = this.prisonerNumber,
+    pncId = this.pncNumber,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -11,6 +11,7 @@ data class Offender(
   val dateOfBirth: LocalDate? = null,
   val offenderAliases: List<OffenderAlias> = listOf(),
   val contactDetails: ContactDetails = ContactDetails(),
+  val otherIds: OtherIds = OtherIds(),
 ) {
   fun toPerson(): Person = Person(
     firstName = this.firstName,
@@ -25,5 +26,6 @@ data class Offender(
         it.dateOfBirth,
       )
     },
+    pncId = otherIds.pncNumber,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OtherIds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OtherIds.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+data class OtherIds(
+  val pncNumber: String? = null,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/PersonControllerTest.kt
@@ -108,7 +108,8 @@ internal class PersonControllerTest(
                 "middleName":"Jonas",
                 "dateOfBirth":"2023-03-01",
                 "aliases":[],
-                "prisonerId": null
+                "prisonerId": null,
+                "pncId": null
                },
                {
                  "firstName":"Barry",
@@ -116,7 +117,8 @@ internal class PersonControllerTest(
                  "middleName":"Rock",
                  "dateOfBirth":"2022-07-22",
                  "aliases":[],
-                "prisonerId": null
+                 "prisonerId": null,
+                 "pncId": null
                }
              ]
            }
@@ -189,7 +191,8 @@ internal class PersonControllerTest(
             "middleName": null,
             "dateOfBirth": null,
             "aliases": [],
-            "prisonerId":null
+            "prisonerId": null,
+            "pncId": null
           },
           "probationOffenderSearch": {
             "firstName": "Silly",
@@ -197,7 +200,8 @@ internal class PersonControllerTest(
             "middleName": null,
             "dateOfBirth": null,
             "aliases": [],
-            "prisonerId":null
+            "prisonerId": null,
+            "pncId": null
           }
         }
         """.removeWhitespaceAndNewlines(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -80,6 +80,11 @@ class PrisonerOffenderSearchGatewayTest(
       persons[1].prisonerId.shouldBe("G9347GV")
       persons[2].prisonerId.shouldBe("A5043DY")
       persons[3].prisonerId.shouldBe("A5083DY")
+
+      persons[0].pncId.shouldBeNull()
+      persons[1].pncId.shouldBe("95/289622B")
+      persons[2].pncId.shouldBeNull()
+      persons[3].pncId.shouldBe("03/11985X")
     }
 
     it("returns person(s) when searching on first name only") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -68,9 +68,10 @@ class ProbationOffenderSearchGatewayTest(
     it("returns person(s) when searching on first and last name") {
       val persons = probationOffenderSearchGateway.getPersons(firstName, surname)
 
-      persons?.count().shouldBe(1)
-      persons?.first()?.firstName.shouldBe(firstName)
-      persons?.first()?.lastName.shouldBe(surname)
+      persons.count().shouldBe(1)
+      persons.first().firstName.shouldBe(firstName)
+      persons.first().lastName.shouldBe(surname)
+      persons.first().pncId.shouldBe("2018/0123456X")
     }
 
     it("returns person(s) when searching on first name only") {
@@ -92,9 +93,9 @@ class ProbationOffenderSearchGatewayTest(
       )
       val persons = probationOffenderSearchGateway.getPersons("Ahsoka", null)
 
-      persons?.count().shouldBe(1)
-      persons?.first()?.firstName.shouldBe("Ahsoka")
-      persons?.first()?.lastName.shouldBe("Tano")
+      persons.count().shouldBe(1)
+      persons.first()?.firstName.shouldBe("Ahsoka")
+      persons.first()?.lastName.shouldBe("Tano")
     }
 
     it("returns person(s) when searching on last name only") {
@@ -116,9 +117,9 @@ class ProbationOffenderSearchGatewayTest(
       )
       val persons = probationOffenderSearchGateway.getPersons(null, "Tano")
 
-      persons?.count().shouldBe(1)
-      persons?.first()?.firstName.shouldBe("Ahsoka")
-      persons?.first()?.lastName.shouldBe("Tano")
+      persons.count().shouldBe(1)
+      persons.first()?.firstName.shouldBe("Ahsoka")
+      persons.first()?.lastName.shouldBe("Tano")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json
@@ -7,7 +7,8 @@
     "dateOfBirth": "1966-10-25",
     "gender": "Male",
     "otherIds": {
-      "crn": "X595043"
+      "crn": "X595043",
+      "pncNumber": "2018/0123456X"
     },
     "contactDetails": {
       "phoneNumbers": [],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -68,7 +68,8 @@ class PersonSmokeTest : DescribeSpec({
                 "dateOfBirth": "1975-04-02"
               }
             ],
-            "prisonerId": "A1234AA"
+            "prisonerId": "A1234AA",
+            "pncId": "12/394773H"
           },
           "probationOffenderSearch": {
             "firstName": "string",
@@ -83,7 +84,8 @@ class PersonSmokeTest : DescribeSpec({
                 "dateOfBirth": "2019-08-24"
               }
             ],
-            "prisonerId": null
+            "prisonerId": null,
+            "pncId": "string"
           }
         }
       """.removeWhitespaceAndNewlines(),


### PR DESCRIPTION
- Add PNC ID to our Person model and update DTOs for Prisoner Offender Search and Probation Offender Search.
- Update OpenAPI spec to document PNC ID in Person model.