### PR TITLE
NoSuchElementException searching for person on PNC Id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -12,15 +12,17 @@ class GetPersonService(
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) {
   fun execute(pncId: String): Map<String, Person?>? {
-    val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
+    val personsFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
     val personFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(pncId)
 
-    if (personFromPrisonerOffenderSearch.isEmpty() && personFromProbationOffenderSearch == null) {
+    if (personsFromPrisonerOffenderSearch.isEmpty() && personFromProbationOffenderSearch == null) {
       return null
     }
 
+    val personFromPrisonerOffenderSearch = if (personsFromPrisonerOffenderSearch.isEmpty()) null else personsFromPrisonerOffenderSearch.first()
+
     return mapOf(
-      "prisonerOffenderSearch" to personFromPrisonerOffenderSearch.first(),
+      "prisonerOffenderSearch" to personFromPrisonerOffenderSearch,
       "probationOffenderSearch" to personFromProbationOffenderSearch,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -19,10 +19,8 @@ class GetPersonService(
       return null
     }
 
-    val personFromPrisonerOffenderSearch = if (personsFromPrisonerOffenderSearch.isEmpty()) null else personsFromPrisonerOffenderSearch.first()
-
     return mapOf(
-      "prisonerOffenderSearch" to personFromPrisonerOffenderSearch,
+      "prisonerOffenderSearch" to personsFromPrisonerOffenderSearch.firstOrNull(),
       "probationOffenderSearch" to personFromProbationOffenderSearch,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -77,4 +77,20 @@ internal class GetPersonServiceTest(
 
     result.shouldBeNull()
   }
+
+  it("returns no results from prisoner offender search, but one from probation offender search") {
+    val personFromProbationOffenderSearch = Person("Molly", "Mob")
+
+    whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(emptyList())
+    whenever(probationOffenderSearchGateway.getPerson(pncId)).thenReturn(personFromProbationOffenderSearch)
+
+    val expectedResult = mapOf(
+      "prisonerOffenderSearch" to null,
+      "probationOffenderSearch" to Person("Molly", "Mob"),
+    )
+
+    val result = getPersonService.execute(pncId)
+
+    result.shouldBe(expectedResult);
+  }
 },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -91,6 +91,6 @@ internal class GetPersonServiceTest(
 
     val result = getPersonService.execute(pncId)
 
-    result.shouldBe(expectedResult);
+    result.shouldBe(expectedResult)
   }
 },)


### PR DESCRIPTION
When searching for a person, if PrisonerOffenderSearch returned no results, but ProbationOffenderSearch did, we were getting an EmptyList exception. More detail can be found on the exception in Sentry.

```
{
    "status": 500,
    "errorCode": null,
    "userMessage": "Unexpected error: List is empty.",
    "developerMessage": "List is empty.",
    "moreInfo": null
}
```

This is because we were using .first() without first checking the list is empty.

We do check if BOTH results are empty/null and return null if this was the case. But we should have also checked this one explicitly.

I've also added a unit test which helped me test my fix, and will help us prevent regression.