### PR TITLE
Added audit section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Below is a list of protected resources that make up the service, and access leve
 | Kibana               | Via GitHub account                                            | All engineers in MOJ            |
 
 ## Audit
-This section contains information as to where areas of logging can be located in the event of an audit.
+This section contains information as to where relevant areas of logging can be located in the event of an audit.
 
 ### Data Logs
 The HMPPS Integration API doesn't store any data itself; Further to this, It is also not capable of creating or modifying 
@@ -126,20 +126,26 @@ standardised and pass the resulting data back to the requester.
 
 ### Deployment Logs
 Logs of each deployment can be located within the following areas:
-#### Git
+#### [Git](https://github.com/ministryofjustice/hmpps-integration-api)
 A list of the changes made to project can be found through the history of commits and pull requests.
-#### CircleCI
+#### [CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-integration-api) 
 Build and deployment information. This is on a per-build basis.
 
 ### Access Logs
 Logs that contain access to various endpoints throughout our system can be located through Elasticsearch. Our interface 
 to Elasticsearch is a tool called [Kibana](https://kibana.cloud-platform.service.justice.gov.uk/). 
 
-> Logs contained within Elasticsearch will not contain any sensitive data. The logs will contain a request details as well 
-> as a timestamp as to when the record was accessed; This allows identification of the record. This information 
-> does not include any response data.
+Logs contained within Elasticsearch will not contain any sensitive data. The logs will contain a request details as well 
+as a timestamp as to when the record was accessed; This allows identification of the record. This information 
+does not include any response data.
 
-Elasticsearch logs have a retention period of 30 days.
+Elasticsearch logs have a retention period of 30 days. See the [Application Log Collection and Storage](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/log-collection-and-storage.html)
+section of the Cloud Platform documentation for more detail.
+
+> Further information on how to use the access logs in Kibana can be found within the [Accessing Application Log Data](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/access-logs.html#accessing-ingress-logs) 
+> section of the Cloud Platform documentation.
+> 
+> To locate the logs you'll need the Cloud Platform namespace for this API.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [These things depend upon this solution](#these-things-depend-upon-this-solution)
 - [High Availability](#high-availability)
 - [Security](#security)
+- [Audit](#audit)
 - [Getting started](#getting-started)
   - [Using IntelliJ IDEA](#using-intellij-idea)
 - [Usage](#usage)
@@ -114,6 +115,31 @@ Below is a list of protected resources that make up the service, and access leve
 | Sentry               | Via GitHub account                                            | All engineers in MOJ            |
 | Application Insights | Via GitHub account                                            | All engineers in MOJ            |
 | Kibana               | Via GitHub account                                            | All engineers in MOJ            |
+
+## Audit
+This section contains information as to where areas of logging can be located in the event of an audit.
+
+### Data Logs
+The HMPPS Integration API doesn't store any data itself; Further to this, It is also not capable of creating or modifying 
+the data it works with. The API is a single point of contact which will query upstream system's. It will then consolidate, 
+standardised and pass the resulting data back to the requester.
+
+### Deployment Logs
+Logs of each deployment can be located within the following areas:
+#### Git
+A list of the changes made to project can be found through the history of commits and pull requests.
+#### CircleCI
+Build and deployment information. This is on a per-build basis.
+
+### Access Logs
+Logs that contain access to various endpoints throughout our system can be located through Elasticsearch. Our interface 
+to Elasticsearch is a tool called [Kibana](https://kibana.cloud-platform.service.justice.gov.uk/). 
+
+> Logs contained within Elasticsearch will not contain any sensitive data. The logs will contain a request details as well 
+> as a timestamp as to when the record was accessed; This allows identification of the record. This information 
+> does not include any response data.
+
+Elasticsearch logs have a retention period of 30 days.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -142,10 +142,8 @@ does not include any response data.
 Elasticsearch logs have a retention period of 30 days. See the [Application Log Collection and Storage](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/log-collection-and-storage.html)
 section of the Cloud Platform documentation for more detail.
 
-> Further information on how to use the access logs in Kibana can be found within the [Accessing Application Log Data](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/access-logs.html#accessing-ingress-logs) 
-> section of the Cloud Platform documentation.
-> 
-> To locate the logs you'll need the Cloud Platform namespace for this API.
+Further information on how to use the access logs in Kibana can be found within the [Accessing Application Log Data](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/access-logs.html#accessing-ingress-logs) 
+section of the Cloud Platform documentation. To locate the logs you'll need the Cloud Platform namespace for this API.
 
 ## Getting started
 


### PR DESCRIPTION
The purpose of this section is to give someone a point in the right direction as to where they might go in the event that an audit occurs. Obviously since we don't store or create any data, the auditor will need to do a bit of digging after they go through us as to actually get the record data itself. 

> To locate the logs you'll need the Cloud Platform namespace for this API.

I wanted to link to another part of this document where we actually list our namespaces, but we don't have one and I didn't want to go too far off track. So I left this a bit vague intentionally.