### PR TITLE
Add Nginx Ingress TLS Annotations

### DIFF
--- a/helm_deploy/hmpps-integration-api/values.yaml
+++ b/helm_deploy/hmpps-integration-api/values.yaml
@@ -17,7 +17,7 @@ generic-service:
     tlsSecretName: ""
     annotations:
       - nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
-      - nginx.ingress.kubernetes.io/auth-tls-secret: "default/api-gateway-authentication"
+      - nginx.ingress.kubernetes.io/auth-tls-secret: "api-gateway-authentication"
       - nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
       - nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
 

--- a/helm_deploy/hmpps-integration-api/values.yaml
+++ b/helm_deploy/hmpps-integration-api/values.yaml
@@ -15,6 +15,11 @@ generic-service:
     v0_47_enabled: false
     host: app-hostname.local    # override per environment
     tlsSecretName: ""
+    annotations:
+      - nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+      - nginx.ingress.kubernetes.io/auth-tls-secret: "default/api-gateway-authentication"
+      - nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
+      - nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
 
   # Environment variables to load into the deployment
   env:


### PR DESCRIPTION
A kubernetes secret called "api-gateway-authentication" has been created which contains the contents of the following self-signed certificates:

- server.pem
- server.key
- truststore.pem

With this in place we can enable TLS authentication via annotations on the Nginx ingress.