### PR TITLE
Add explicit platform configuration to docker builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   hmpps-integration-api:
+    platform: "linux/amd64"
     build:
       context: .
     container_name: hmpps-integration-api

--- a/scripts/local_deploy.sh
+++ b/scripts/local_deploy.sh
@@ -20,7 +20,7 @@ authenticate_docker() {
 }
 
 build_image() {
-  docker build -t $namespace .
+  docker build --platform linux/amd64 -t $namespace .
   docker tag $namespace "${repo_url}:latest"
 }
 


### PR DESCRIPTION
Without this, any build from a M1 host machine will result in an error when running the container: "exec format error"