### PR TITLE
Prefix unimplemented paths with /tbc/

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -167,109 +167,122 @@ paths:
                 ImageNotFoundError:
                   $ref: "#/components/examples/ImageNotFoundError"
 
-  /persons/{Id}/accommodations:
+  /tbc/persons/{Id}/accommodations:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns accommodation and referral information associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/adjudications:
+  /tbc/persons/{Id}/adjudications:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns adjudications associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/interventions:
+  /tbc/persons/{Id}/interventions:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns activities and Non-Statutory Interventions (NSIs) associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/key-workers:
+  /tbc/persons/{Id}/key-workers:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns responsible officer history, transfer history and consolidated transfer review associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/licenses:
+  /tbc/persons/{Id}/licenses:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns license conditions associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/offences:
+  /tbc/persons/{Id}/offences:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns offences associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/prisoner-visits:
+  /tbc/persons/{Id}/prisoner-visits:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns prisoner visits associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/probation-contact-events:
+  /tbc/persons/{Id}/probation-contact-events:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns probation contact events associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/release-information:
+  /tbc/persons/{Id}/release-information:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns release dates and information associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/risks:
+  /tbc/persons/{Id}/risks:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns prisoner risks, alerts, personal circumstances, prisoner category, person assessments, risk of re-offending, OASys General Predictor (OGP) scores, OASys Violence Predictor (OVP) scores, likelihood of serious harm to others, concerns, RoSH (Risk of serious harm) summary, registration summary associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/sentences:
+  /tbc/persons/{Id}/sentences:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns prisoner sentences, bookings / incarceration associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/security:
+  /tbc/persons/{Id}/security:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns security information such as prisoner non-associations and prisoner incidents for a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
-  /persons/{Id}/special-needs:
+  /tbc/persons/{Id}/special-needs:
     get:
-      tags:
-        - Future Endpoints
       summary: Returns special needs such as drugs test summaries, drug history and drugs test lists associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
+      responses:
+        "200":
+          description: Success.
 
 components:
   parameters:

--- a/openapi.yml
+++ b/openapi.yml
@@ -167,117 +167,117 @@ paths:
                 ImageNotFoundError:
                   $ref: "#/components/examples/ImageNotFoundError"
 
-  /tbc/persons/{Id}/accommodations:
+  /{TBC}/persons/{Id}/accommodations:
     get:
-      summary: Returns accommodation and referral information associated with a person.
+      summary: FUTURE ENDPOINT - Returns accommodation and referral information associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/adjudications:
+  /{TBC}/persons/{Id}/adjudications:
     get:
-      summary: Returns adjudications associated with a person.
+      summary: FUTURE ENDPOINT - Returns adjudications associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/interventions:
+  /{TBC}/persons/{Id}/interventions:
     get:
-      summary: Returns activities and Non-Statutory Interventions (NSIs) associated with a person.
+      summary: FUTURE ENDPOINT - Returns activities and Non-Statutory Interventions (NSIs) associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/key-workers:
+  /{TBC}/persons/{Id}/key-workers:
     get:
-      summary: Returns responsible officer history, transfer history and consolidated transfer review associated with a person.
+      summary: FUTURE ENDPOINT - Returns responsible officer history, transfer history and consolidated transfer review associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/licenses:
+  /{TBC}/persons/{Id}/licenses:
     get:
-      summary: Returns license conditions associated with a person.
+      summary: FUTURE ENDPOINT - Returns license conditions associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/offences:
+  /{TBC}/persons/{Id}/offences:
     get:
-      summary: Returns offences associated with a person.
+      summary: FUTURE ENDPOINT -  Returns offences associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/prisoner-visits:
+  /{TBC}/persons/{Id}/prisoner-visits:
     get:
-      summary: Returns prisoner visits associated with a person.
+      summary: FUTURE ENDPOINT -  Returns prisoner visits associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/probation-contact-events:
+  /{TBC}/persons/{Id}/probation-contact-events:
     get:
-      summary: Returns probation contact events associated with a person.
+      summary: FUTURE ENDPOINT - Returns probation contact events associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/release-information:
+  /{TBC}/persons/{Id}/release-information:
     get:
-      summary: Returns release dates and information associated with a person.
+      summary: FUTURE ENDPOINT - Returns release dates and information associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/risks:
+  /{TBC}/persons/{Id}/risks:
     get:
-      summary: Returns prisoner risks, alerts, personal circumstances, prisoner category, person assessments, risk of re-offending, OASys General Predictor (OGP) scores, OASys Violence Predictor (OVP) scores, likelihood of serious harm to others, concerns, RoSH (Risk of serious harm) summary, registration summary associated with a person.
+      summary: FUTURE ENDPOINT - Returns prisoner risks, alerts, personal circumstances, prisoner category, person assessments, risk of re-offending, OASys General Predictor (OGP) scores, OASys Violence Predictor (OVP) scores, likelihood of serious harm to others, concerns, RoSH (Risk of serious harm) summary, registration summary associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/sentences:
+  /{TBC}/persons/{Id}/sentences:
     get:
-      summary: Returns prisoner sentences, bookings / incarceration associated with a person.
+      summary: FUTURE ENDPOINT - Returns prisoner sentences, bookings / incarceration associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/security:
+  /{TBC}/persons/{Id}/security:
     get:
-      summary: Returns security information such as prisoner non-associations and prisoner incidents for a person.
+      summary: FUTURE ENDPOINT - Returns security information such as prisoner non-associations and prisoner incidents for a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
         "200":
           description: Success.
 
-  /tbc/persons/{Id}/special-needs:
+  /{TBC}/persons/{Id}/special-needs:
     get:
-      summary: Returns special needs such as drugs test summaries, drug history and drugs test lists associated with a person.
+      summary: FUTURE ENDPOINT -  Returns special needs such as drugs test summaries, drug history and drugs test lists associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:


### PR DESCRIPTION
Swagger doesn't show tags and we are unable to show which endpoints are work in progress. Move this to the path instead so it can be seen when browsing endpoints without having to click into them first.

Add dummy 200 response, OpenAPI requires that the 'responses' field be filled out.