### PR TITLE
Correct pre-production url and remove unnecessary decoding of secret

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Credentials.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Credentials.kt
@@ -4,11 +4,7 @@ import java.util.Base64
 
 data class Credentials(val username: String, val password: String) {
   fun toBasicAuth(): String {
-    val decodedUsername = String(Base64.getDecoder().decode(username)).trim()
-    val decodedPassword = String(Base64.getDecoder().decode(password)).trim()
-
-    val encodedCredentials = Base64.getEncoder().encodeToString("$decodedUsername:$decodedPassword".toByteArray())
-
+    val encodedCredentials = Base64.getEncoder().encodeToString("$username:$password".toByteArray())
     return "Basic $encodedCredentials"
   }
 }

--- a/src/main/resources/application-pre-production.yml
+++ b/src/main/resources/application-pre-production.yml
@@ -6,6 +6,6 @@ services:
   probation-offender-search:
     base-url: https://probation-offender-search-preprod.hmpps.service.justice.gov.uk
   hmpps-auth:
-    base-url: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    base-url: https://sign-in-preprod.hmpps.service.justice.gov.uk
     username: ${CLIENT_ID}
     password: ${CLIENT_SECRET}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,8 +10,8 @@ services:
     base-url: http://localhost:4000
   hmpps-auth:
     base-url: http://localhost:3000
-    username: Y2xpZW50Cg==
-    password: Y2xpZW50LXNlY3JldAo=
+    username: client
+    password: client-secret
   prisoner-offender-search:
     base-url: http://localhost:4001
   probation-offender-search:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,8 +57,8 @@ services:
     base-url: "TestURL"
   hmpps-auth:
     base-url: "OtherTestURL"
-    username: aG1wcHMtaW50ZWdyYXRpb24tYXBpLWNsaWVudAo=
-    password: Y2xpZW50c2VjcmV0Cg==
+    username: hmpps-integration-api-client
+    password: clientsecret
   probation-offender-search:
     base-url: http://localhost:4002
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/CredentialsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/CredentialsTest.kt
@@ -6,9 +6,9 @@ import io.kotest.matchers.shouldBe
 class CredentialsTest : DescribeSpec({
   describe("#toBasicAuth") {
     it("returns username and password for basic authentication header") {
-      val credentials = Credentials("dXNlcm5hbWUK", "cGFzc3dvcmQK")
+      val credentials = Credentials("my-client-id", "my-client-secret")
 
-      credentials.toBasicAuth().shouldBe("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")
+      credentials.toBasicAuth().shouldBe("Basic bXktY2xpZW50LWlkOm15LWNsaWVudC1zZWNyZXQ=")
     }
   }
 },)


### PR DESCRIPTION
This should break Development, the development secrets are 'doubly' encoded. `Credentials.toBasicAuth()` no longer decodes secrets which means the encoded values will be being passed into the header for HMPPS auth.

However, this _should_ fix Pre-Production and Production. 

Following this we'll need to address why our development secrets are doubly encoded and fix it.