### PR TITLE
Replace default alerts with alerts on failure only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,12 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - lint-code
-      - unit-tests
-      - smoke-tests
+      - lint-code:
+          <<: *slack-fail-post-step
+      - unit-tests:
+          <<: *slack-fail-post-step
+      - smoke-tests:
+          <<: *slack-fail-post-step
       - hmpps/helm_lint:
           <<: *slack-fail-post-step
           name: lint-helm-charts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,8 @@ workflows:
                 - main
           env: "development"
           helm_timeout: 5m
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          slack_notification: false
 
       - create-and-push-image-to-ecr:
           <<: *slack-fail-post-step
@@ -174,6 +176,8 @@ workflows:
                 - main
           env: "pre-production"
           helm_timeout: 5m
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          slack_notification: false
 
       - create-and-push-image-to-ecr:
           <<: *slack-fail-post-step
@@ -199,6 +203,8 @@ workflows:
                 - main
           env: "production"
           helm_timeout: 5m
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          slack_notification: false
   security:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,6 @@ jobs:
           name: Run smoke tests
           command: make smoke-test
   create-and-push-image-to-ecr:
-    <<: *slack-fail-post-step
     docker:
       - image: ministryofjustice/cloud-platform-tools
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ slack-fail-post-step: &slack-fail-post-step
 
 jobs:
   lint-code:
-    <<: *slack-fail-post-step
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -61,7 +60,6 @@ jobs:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
   unit-tests:
-    <<: *slack-fail-post-step
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -81,7 +79,6 @@ jobs:
       - store_test_results:
           path: build/test-results
   smoke-tests:
-    <<: *slack-fail-post-step
     machine:
       image: ubuntu-2204:2022.10.2
     steps:
@@ -118,9 +115,11 @@ workflows:
       - unit-tests
       - smoke-tests
       - hmpps/helm_lint:
+          <<: *slack-fail-post-step
           name: lint-helm-charts
           env: development
       - create-and-push-image-to-ecr:
+          <<: *slack-fail-post-step
           name: create-and-push-image-to-development-ecr
           context: hmpps-integration-api-development
           requires:
@@ -133,6 +132,7 @@ workflows:
               only:
                 - main
       - hmpps/deploy_env:
+          <<: *slack-fail-post-step
           name: deploy-to-development
           context:
             - hmpps-integration-api-development
@@ -145,9 +145,9 @@ workflows:
                 - main
           env: "development"
           helm_timeout: 5m
-          <<: *slack-fail-post-step
 
       - create-and-push-image-to-ecr:
+          <<: *slack-fail-post-step
           name: create-and-push-image-to-pre-production-ecr
           context: hmpps-integration-api-pre-production
           requires:
@@ -157,6 +157,7 @@ workflows:
               only:
                 - main
       - hmpps/deploy_env:
+          <<: *slack-fail-post-step
           name: deploy-to-pre-production
           context:
             - hmpps-integration-api-pre-production
@@ -169,9 +170,9 @@ workflows:
                 - main
           env: "pre-production"
           helm_timeout: 5m
-          <<: *slack-fail-post-step
 
       - create-and-push-image-to-ecr:
+          <<: *slack-fail-post-step
           name: create-and-push-image-to-production-ecr
           context: hmpps-integration-api-production
           requires:
@@ -180,8 +181,8 @@ workflows:
             branches:
               only:
                 - main
-          <<: *slack-fail-post-step
       - hmpps/deploy_env:
+          <<: *slack-fail-post-step
           name: deploy-to-production
           context:
             - hmpps-integration-api-production
@@ -194,7 +195,6 @@ workflows:
                 - main
           env: "production"
           helm_timeout: 5m
-          <<: *slack-fail-post-step
   security:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,39 @@ parameters:
     type: string
     default: hmpps-integration-api-alerts
 
+slack-fail-post-step: &slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        event: fail
+        branch_pattern: main
+        channel: << pipeline.parameters.alerts-slack-channel >>
+        custom: |
+          {
+            "text": "",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "❌ *Failure* `${CIRCLE_PROJECT_REPONAME}` - `${CIRCLE_JOB}` (Build: #${CIRCLE_BUILD_NUM}) on `${CIRCLE_BRANCH}`"
+                }
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": { "type": "plain_text", "text": "View Job" },
+                    "url": "${CIRCLE_BUILD_URL}"
+                  }
+                ]
+              }
+            ]
+          }
+
 jobs:
   lint-code:
+    <<: *slack-fail-post-step
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -30,6 +61,7 @@ jobs:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle.kts" }}
   unit-tests:
+    <<: *slack-fail-post-step
     executor:
       name: hmpps/java
       tag: "19.0"
@@ -49,6 +81,7 @@ jobs:
       - store_test_results:
           path: build/test-results
   smoke-tests:
+    <<: *slack-fail-post-step
     machine:
       image: ubuntu-2204:2022.10.2
     steps:
@@ -61,6 +94,7 @@ jobs:
           name: Run smoke tests
           command: make smoke-test
   create-and-push-image-to-ecr:
+    <<: *slack-fail-post-step
     docker:
       - image: ministryofjustice/cloud-platform-tools
     steps:
@@ -112,8 +146,7 @@ workflows:
                 - main
           env: "development"
           helm_timeout: 5m
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-          slack_notification: true
+          <<: *slack-fail-post-step
 
       - create-and-push-image-to-ecr:
           name: create-and-push-image-to-pre-production-ecr
@@ -137,8 +170,7 @@ workflows:
                 - main
           env: "pre-production"
           helm_timeout: 5m
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-          slack_notification: true
+          <<: *slack-fail-post-step
 
       - create-and-push-image-to-ecr:
           name: create-and-push-image-to-production-ecr
@@ -149,6 +181,7 @@ workflows:
             branches:
               only:
                 - main
+          <<: *slack-fail-post-step
       - hmpps/deploy_env:
           name: deploy-to-production
           context:
@@ -162,8 +195,7 @@ workflows:
                 - main
           env: "production"
           helm_timeout: 5m
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-          slack_notification: true
+          <<: *slack-fail-post-step
   security:
     triggers:
       - schedule:
@@ -174,9 +206,11 @@ workflows:
                 - main
     jobs:
       - hmpps/gradle_owasp_dependency_check:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
       - hmpps/veracode_pipeline_scan:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - veracode-credentials
             - hmpps-common-vars
@@ -190,6 +224,7 @@ workflows:
                 - main
     jobs:
       - hmpps/veracode_policy_scan:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - veracode-credentials
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@6
+  slack: circleci/slack@4.12.1
 
 parameters:
   alerts-slack-channel:


### PR DESCRIPTION
For now we're only interested in build pipeline failures being reported to Slack.

This should alert on the following:
1. Failed automated tests
2. Failed build/deploy in any of the 3 environments
3. Failed dependency checks
4. Failed security scans