### PR TITLE
Document various monitoring and alerting services

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ Note, this will only specifically enable the `RequestLogger`.
 
 ## Further documentation
 
-- [Monitoring and Alerting](/docs/monitoring-and-alerting/README.md)
 - [Architecture Decision Records (ADRs)](/docs/adr)
 - [Architecture diagrams](/docs/diagrams)
 - [Audit](/docs/audit.md)
 - [Backups](/docs/backups.md)
 - [Environments](/docs/environments.md)
 - [High availability](/docs/high-availability.md)
+- [Monitoring and Alerting](/docs/monitoring-and-alerting/README.md)
 - [Security](/docs/security.md)
 
 ## Developer guides

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Note, this will only specifically enable the `RequestLogger`.
 
 ## Further documentation
 
+- [Monitoring and Alerting](/docs/monitoring-and-alerting/README.md)
 - [Architecture Decision Records (ADRs)](/docs/adr)
 - [Architecture diagrams](/docs/diagrams)
 - [Audit](/docs/audit.md)

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -32,5 +32,4 @@ does not include any response data.
 Elasticsearch logs have a retention period of 30 days. See the [Application Log Collection and Storage](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/log-collection-and-storage.html)
 section of the Cloud Platform documentation for more detail.
 
-Further information on how to use the access logs in Kibana can be found within the [Accessing Application Log Data](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/access-logs.html#accessing-ingress-logs)
-section of the Cloud Platform documentation. To locate the logs you'll need the Cloud Platform namespace for this API.
+> For further information on how to access our monitoring and alerting systems, please visit our [Monitoring and Alerting](monitoring-and-alerting/README.md) page.

--- a/docs/monitoring-and-alerting/README.md
+++ b/docs/monitoring-and-alerting/README.md
@@ -5,7 +5,7 @@ examples of where each may be useful. This ensures contributors are well-equippe
 
 ## Services
 - [Azure Application Insights](azure-application-insights.md): Access metrics
+- [Grafana](grafana.md): Performance metrics
 - [Kubernetes](kubernetes.md): Pod specific application logs
 - [Kibana](kibana.md): Kubernetes application logs
 - [Sentry](sentry.md): Error logs
-- [Grafana](grafana.md): Performance metrics

--- a/docs/monitoring-and-alerting/README.md
+++ b/docs/monitoring-and-alerting/README.md
@@ -1,0 +1,11 @@
+# Monitoring and Alerting
+The HMPPS Integration API utilises numerous tools to assist identification and resolution of issues that may arise. The 
+purpose of these documents is to provide instruction on the use of each tool, how to set up an account with them, and 
+examples of where each may be useful. This ensures contributors are well-equipped to debug issues.
+
+## Services
+- [Azure Application Insights](azure-application-insights.md): Access metrics
+- [Kubernetes](kubernetes.md): Pod specific application logs
+- [Kibana](kibana.md): Kubernetes application logs
+- [Sentry](sentry.md): Error logs
+- [Grafana](grafana.md): Performance metrics

--- a/docs/monitoring-and-alerting/azure-application-insights.md
+++ b/docs/monitoring-and-alerting/azure-application-insights.md
@@ -7,6 +7,8 @@ An HMPPS Azure account will be required to access application insights, please f
 During this process you will be required to add an entry to a configuration file, it's recommended that you use an entry
 from someone else on the HMPPS Integration API as a template for your own.
 
+[Here's](https://github.com/ministryofjustice/dso-infra-azure-ad/pull/1053) an example of a previous PR.
+
 ## Steps
 1. Log in to the [Application Insights dashboard](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents)
 2. Select an environment

--- a/docs/monitoring-and-alerting/azure-application-insights.md
+++ b/docs/monitoring-and-alerting/azure-application-insights.md
@@ -1,0 +1,24 @@
+# Azure Application Insights
+Data related to the quantities of requests made against our API as well as response times. These logs can also be used to
+identify bottlenecks in performance and to determine endpoint metric data such as the most commonly used endpoints.
+
+## Setup
+An HMPPS Azure account will be required to access application insights, please follow the [HMPPS documentation](https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/3897131056/DSO+Self-service+-+create+Azure+account).
+During this process you will be required to add an entry to a configuration file, it's recommended that you use an entry
+from someone else on the HMPPS Integration API as a template for your own.
+
+## Steps
+1. Log in to the [Application Insights dashboard](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/microsoft.insights%2Fcomponents)
+2. Select an environment
+    1. Development: `nomisapi-t3`
+    2. Pre-Production: `nomisapi-preprod`
+    3. Production: `nomisapi-prod`
+4. Select `Logs` within the window
+5. Either select a preset query, or close the window to write your own
+6. Filter the query on the following `| where cloud_RoleName = 'hmpps-integration-api`. This will restrict the query to
+   only display data for the HMPPS Integration API.
+
+## Example Use Case
+We'd like to check how a particular endpoint is performing. Using a query such as the `Operations Performance` query. 
+We can look at average response times for a given endpoint. This is beneficial as it removes any one user's networking
+as a factor and looks at the full data set of consumers.

--- a/docs/monitoring-and-alerting/grafana.md
+++ b/docs/monitoring-and-alerting/grafana.md
@@ -5,12 +5,15 @@ CPU usage, memory usage and networking details can be located in various graphs.
 dashboard can also be configured.
 
 ## Setup
-1. If you're a member of the Ministry of Justice Git Organisation you should be able to log in to [Grafana](https://grafana.live.cloud-platform.service.justice.gov.uk/?orgId=1).
+If you're a member of the Ministry of Justice GitHub Organisation you should be able to log in to [Grafana](https://grafana.live.cloud-platform.service.justice.gov.uk/?orgId=1).
 
 ## Steps
 1. Follow Cloud Platform's [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/prometheus.html#grafana)
 2. Access our [dashboard](https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=hmpps-integration-api-development&var-service=hmpps-integration-api)
 3. Change the environment using the namespace drop-down menu on the top left (if necessary)
+   - [Development](https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-service=hmpps-integration-api&var-namespace=hmpps-integration-api-development)
+   - [Pre-Production](https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-service=hmpps-integration-api&var-namespace=hmpps-integration-api-pre-production)
+   - [Production](https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-service=hmpps-integration-api&var-namespace=hmpps-integration-api-production)
 
 ## Example Use Case
 We've noticed that the API is responding slowly to specific requests. The Grafana metrics will allow us to check the

--- a/docs/monitoring-and-alerting/grafana.md
+++ b/docs/monitoring-and-alerting/grafana.md
@@ -1,0 +1,17 @@
+# Grafana
+Provides a graph-based dashboard view containing information on the performance of the service. The level at which this
+is provided is for the whole namespace (development, pre-production or production). Details such as quantities of requests
+CPU usage, memory usage and networking details can be located in various graphs. The period of data shown within the 
+dashboard can also be configured.
+
+## Setup
+1. If you're a member of the Ministry of Justice Git Organisation you should be able to log in to [Grafana](https://grafana.live.cloud-platform.service.justice.gov.uk/?orgId=1).
+
+## Steps
+1. Follow Cloud Platform's [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/prometheus.html#grafana)
+2. Access our [dashboard](https://grafana.live.cloud-platform.service.justice.gov.uk/d/golden-signals/golden-signals?orgId=1&var-namespace=hmpps-integration-api-development&var-service=hmpps-integration-api)
+3. Change the environment using the namespace drop-down menu on the top left (if necessary)
+
+## Example Use Case
+We've noticed that the API is responding slowly to specific requests. The Grafana metrics will allow us to check the
+resources on the pods to ensure we're not reaching hardware limits.

--- a/docs/monitoring-and-alerting/kibana.md
+++ b/docs/monitoring-and-alerting/kibana.md
@@ -11,7 +11,7 @@ pod.
 Follow Cloud Platform's [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/access-logs.html#accessing-application-log-data)
 
 ## Steps
-[hmpps-integration-api-dashboard](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/dashboards#/view/87dccad0-e503-11ed-a7a3-8d8f1c5a54a7?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-1h%2Cto%3Anow)) is a direct link to the dashboard which the steps below lead you to.
+[hmpps-integration-api-dashboard](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/goto/c78b76502b288a271254817cc39db78f) is a direct link to the dashboard which the steps below lead you to.
 1. Click the hamburger button on the top left
 2. Go to Dashboard
 3. Search for 'hmpps-integration-api-dashboard'

--- a/docs/monitoring-and-alerting/kibana.md
+++ b/docs/monitoring-and-alerting/kibana.md
@@ -1,0 +1,22 @@
+# Kibana
+Logs based on ElasticSearch are available through the tool Kibana. Usage of Kibana is recommended where you want to look 
+at logs for multiple pods and/or environments at once as the logs for any given environment includes all pod logs. 
+Using Kibana can alleviate the requirement of monitoring pod logs individually as is necessary with the
+[Kubernetes Logs](kubernetes.md). Kibana also allows time based filtering of logs.
+
+The information you'll find within the Kibana logs is any information that has been logged to the standard output of each
+pod.
+
+## Setup
+Follow Cloud Platform's [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/logging-an-app/access-logs.html#accessing-application-log-data)
+
+## Steps
+[hmpps-integration-api-dashboard](https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/dashboards#/view/87dccad0-e503-11ed-a7a3-8d8f1c5a54a7?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3Anow-1h%2Cto%3Anow)) is a direct link to the dashboard which the steps below lead you to.
+1. Click the hamburger button on the top left
+2. Go to Dashboard
+3. Search for 'hmpps-integration-api-dashboard'
+4. Select 'hmpps-integration-api-dashboard'
+
+## Example Use Case
+You've made a request on the API but aren't sure which pod you've been directed to as there are a number running. Using
+Kibana will allow you to see the logs regardless of the pod they're running on.

--- a/docs/monitoring-and-alerting/kubernetes.md
+++ b/docs/monitoring-and-alerting/kubernetes.md
@@ -1,0 +1,30 @@
+# Kubernetes Logs
+Each pod the service is runs on has its own logs. These logs contain information which pertains to the instance of the API
+running within the pod. The sort of information that can be obtained from the Kubernetes logs is as follows:
+- Application and server hosting information such as local ports, versions and active profiles.
+- Incoming requests (does not contain sensitive information) i.e. request type, request URL and request body.
+
+> Since traffic to the pods is load balanced, multiple logs may need to be checked for each pod the service runs on. For
+> this reason we'd recommend using [Kibana](kibana.md) when numerous pods are running.
+
+## Setup
+Ensure you are able to access Cloud Platform's Kubernetes cluster via the Kubernetes CLI. This can be done by running
+`kubectl get namespaces`. A successful call will return a list of all namespaces within the cluster.
+
+**If not** Follow Cloud Platform's [documentation](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html) on how to set this up.
+
+## Steps
+1. Get the unique names of the pods that are running.
+```
+kubectl get pods -n hmpps-integration-api-<environment>
+```
+2. Using the name of the pods, you can retrieve the logs via the following command:
+```
+kubectl logs -n hmpps-integration-api-<environment> <podname>
+```
+If successful, your terminal will display the logs for this pod.
+> You can optionally follow the logs in your terminal by appending the `-f` flag onto the end of the logs command.
+
+### Example Use Case
+A consumer is getting unexpected data from the API, in such a scenario we can obtain the request details from the log and
+reproduce it ourselves.

--- a/docs/monitoring-and-alerting/kubernetes.md
+++ b/docs/monitoring-and-alerting/kubernetes.md
@@ -1,5 +1,5 @@
 # Kubernetes Logs
-Each pod the service is runs on has its own logs. These logs contain information which pertains to the instance of the API
+Each pod the service runs on has its own logs. These logs contain information which pertains to the instance of the API
 running within the pod. The sort of information that can be obtained from the Kubernetes logs is as follows:
 - Application and server hosting information such as local ports, versions and active profiles.
 - Incoming requests (does not contain sensitive information) i.e. request type, request URL and request body.
@@ -28,3 +28,5 @@ If successful, your terminal will display the logs for this pod.
 ### Example Use Case
 A consumer is getting unexpected data from the API, in such a scenario we can obtain the request details from the log and
 reproduce it ourselves.
+
+> It may also be beneficial to visit our Kubernetes [Useful Commands](https://github.com/ministryofjustice/hmpps-integration-api/blob/main/docs/useful-commands.md#kubectl) page.

--- a/docs/monitoring-and-alerting/sentry.md
+++ b/docs/monitoring-and-alerting/sentry.md
@@ -1,0 +1,18 @@
+# Sentry
+Exceptions thrown by the API are picked by Sentry. Sentry keeps records of when an exception was thrown, how
+many times it's occurred as well as details about the request; A stack trace is also available to aid in
+debugging the issue.
+
+An integration with the Slack Justice Digital workspace ensures that exceptions are not missed by posting them to the 
+[hmpps-integration-api-alerts](https://mojdt.slack.com/archives/C052TUCR12L) channel.
+
+## Setup
+Access to Sentry is provided all members of the Ministry of Justice GitHub organization as outlined in their [documentation](https://operations-engineering.service.justice.gov.uk/documentation/services/sentry.html#sentry-io). 
+
+1. Once you have access, log in to the [Projects Dashboard](https://ministryofjustice.sentry.io/projects/)
+2. Click `Join a Team`
+3. Search for `hmpps-integration-api` 
+4. Join the team
+
+## Steps
+1. Select an environment from the [Projects Dashboard](https://ministryofjustice.sentry.io/projects/)


### PR DESCRIPTION
Documents on how contributors to our repository can get set up with the monitoring and alerting services. These also contain information on why someone might use one of the services.