### PR TITLE
Bump Gradle Spring Boot version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.2"
-  kotlin("plugin.spring") version "1.8.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
+  kotlin("plugin.spring") version "1.8.21"
 }
 
 configurations {


### PR DESCRIPTION
Our Owasp security scan is currently failing, bumping versions to address this.