### PR TITLE
Document image file type from prison API

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -143,6 +143,8 @@ paths:
       tags:
         - images
       summary: Returns an image in bytes.
+      produces:
+        - image/jpeg
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
According to the Prison API OpenAPI spec, images will always be in JPEG format. Document this so that consumers can build the images with the correct extension on their side.