### PR TITLE
Fix OpenAPI spec for get an image endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -142,9 +142,7 @@ paths:
     get:
       tags:
         - images
-      summary: Returns an image in bytes.
-      produces:
-        - image/jpeg
+      summary: Returns an image in bytes as a JPEG.
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
`produces` is not a valid attribute for OpenAPI version 3, it was for version 2.

We do document the return type as `image/jpeg` in the 200 response for this endpoint but it's just not displayed when rendered in our API docs. Therefore, it's been added in the description to be clear which is rendered.

![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/7b8517c1-7e59-41aa-8743-5567a8a025e4)

https://swagger.io/docs/specification/2-0/describing-responses/

![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/7ebc9f8f-b302-4312-b0a8-a9160269bc8e)

