### PR TITLE
Update Image Metadata to expose active and captureDateTime

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -374,9 +374,12 @@ components:
           minimum: 1
           format: int64
           example: 2461788
-        captureDate:
+        active:
+          type: boolean
+          example: true
+        captureDateTime:
           type: string
-          format: date
+          format: datetime
           example: 2015-05-27
         view:
           type: string

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ImageMetadata.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ImageMetadata.kt
@@ -1,10 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
-import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class ImageMetadata(
   val id: Long,
-  val captureDate: LocalDate,
+  val active: Boolean,
+  val captureDateTime: LocalDateTime,
   val view: String,
   val orientation: String,
   val type: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/ImageDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/ImageDetail.kt
@@ -2,17 +2,20 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class ImageDetail(
   val imageId: Long,
-  val captureDate: LocalDate,
+  val active: Boolean,
+  val captureDateTime: LocalDateTime,
   val imageView: String,
   val imageOrientation: String,
   val imageType: String,
 ) {
   fun toImageMetadata(): ImageMetadata = ImageMetadata(
     id = this.imageId,
-    captureDate = this.captureDate,
+    active = this.active,
+    captureDateTime = this.captureDateTime,
     view = this.imageView,
     orientation = this.imageOrientation,
     type = this.imageType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/ImageDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/ImageDetail.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 class ImageDetail(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonsServi
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @WebMvcTest(controllers = [PersonController::class])
 internal class PersonControllerTest(
@@ -209,19 +210,20 @@ internal class PersonControllerTest(
       }
     }
 
-    describe("GET $basePath/$encodedPncId/images") {
+  describe("GET $basePath/$encodedPncId/images") {
       beforeTest {
         Mockito.reset(getImageMetadataForPersonService)
         whenever(getImageMetadataForPersonService.execute(pncId)).thenReturn(
           listOf(
             ImageMetadata(
               id = 2461788,
-              captureDate = LocalDate.parse("2023-03-01"),
+              active = true,
+              captureDateTime = LocalDateTime.parse("2023-03-01T13:20:00"),
               view = "FACE",
               orientation = "FRONT",
               type = "OFF_BKG",
             ),
-          ),
+          )
         )
       }
 
@@ -246,7 +248,8 @@ internal class PersonControllerTest(
           "images": [
             {
               "id" : 2461788,
-              "captureDate": "2023-03-01",
+              "active" : true,
+              "captureDateTime": "2023-03-01T13:20:00",
               "view": "FACE",
               "orientation": "FRONT",
               "type": "OFF_BKG"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -210,7 +210,7 @@ internal class PersonControllerTest(
       }
     }
 
-  describe("GET $basePath/$encodedPncId/images") {
+    describe("GET $basePath/$encodedPncId/images") {
       beforeTest {
         Mockito.reset(getImageMetadataForPersonService)
         whenever(getImageMetadataForPersonService.execute(pncId)).thenReturn(
@@ -223,7 +223,7 @@ internal class PersonControllerTest(
               orientation = "FRONT",
               type = "OFF_BKG",
             ),
-          )
+          ),
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/NomisGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/NomisGatewayTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMoc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
 import java.io.File
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @ActiveProfiles("test")
 @ContextConfiguration(
@@ -145,7 +146,8 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
           [
             {
               "imageId": 24213,
-              "captureDate": "2008-08-27",
+              "active": true,
+              "captureDateTime": "2008-08-27T16:35:00",
               "imageView": "FACE",
               "imageOrientation": "FRONT",
               "imageType": "OFF_BKG"
@@ -164,7 +166,8 @@ class NomisGatewayTest(@MockBean val hmppsAuthGateway: HmppsAuthGateway, private
       it("returns image metadata for the matching person ID") {
         val imageMetadata = nomisGateway.getImageMetadataForPerson(offenderNo)
 
-        imageMetadata.first().captureDate.shouldBe(LocalDate.parse("2008-08-27"))
+        imageMetadata.first().active.shouldBe(true)
+        imageMetadata.first().captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
         imageMetadata.first().view.shouldBe("FACE")
         imageMetadata.first().orientation.shouldBe("FRONT")
         imageMetadata.first().type.shouldBe("OFF_BKG")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @ContextConfiguration(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffende
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
@@ -57,7 +58,8 @@ internal class GetImageMetadataForPersonServiceTest(
     val imageMetadataFromNomis = listOf(
       ImageMetadata(
         id = 2461788,
-        captureDate = LocalDate.parse("2023-03-01"),
+        active = false,
+        captureDateTime = LocalDateTime.parse("2023-03-01T08:30:45"),
         view = "FACE",
         orientation = "FRONT",
         type = "OFF_BKG",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -106,7 +106,7 @@ class PersonSmokeTest : DescribeSpec({
         {
           "id":2461788,
           "active":false,
-          "captureDateTime":"2021-07-05T10:35:17"
+          "captureDateTime":"2021-07-05T10:35:17",
           "view":"OIC",
           "orientation":"NECK",
           "type":"OFF_IDM"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -105,8 +105,10 @@ class PersonSmokeTest : DescribeSpec({
       "images": [
         {
           "id":2461788,
-          "captureDate":"2008-08-27",
-          "view":"OIC","orientation":"NECK",
+          "active":false,
+          "captureDateTime":"2021-07-05T10:35:17"
+          "view":"OIC",
+          "orientation":"NECK",
           "type":"OFF_IDM"
         }
       ]


### PR DESCRIPTION
~This will fail until prison api have merged the changes we requested on their end. As the schema won't contain the fields we're asserting on.~

The change in Prison API has now been completed!