### PR TITLE
Update pagination for searching for a person endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -30,18 +30,18 @@ paths:
           name: page
           schema:
             type: number
-            minimum: 0
-            default: 0
+            minimum: 1
+            default: 1
           required: false
-          description: Zero-based page index (0..N)
+          description: The page number (starting from 1)
         - in: query
-          name: size
+          name: per_page
           schema:
             type: number
             minimum: 1
             default: 10
           required: false
-          description: The size of the page to be returned
+          description: The maximum number of results for a page
       responses:
         "200":
           description: Successfully performed the query on upstream APIs. An empty list is returned when no results are found.
@@ -50,39 +50,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  content:
+                  data:
                     type: array
                     minItems: 0
                     items:
                       $ref: "#/components/schemas/Person"
-                  pageable:
-                    $ref: "#/components/schemas/Pageable"
-                  totalPages:
-                    type: integer
-                    example: 1
-                  totalElements:
-                    type: integer
-                    example: 1
-                  last:
-                    type: boolean
-                    example: true
-                  size:
-                    type: integer
-                    example: 10
-                  number:
-                    type: integer
-                    example: 0
-                  sort:
-                    $ref: "#/components/schemas/Sort"
-                  numberOfElements:
-                    type: integer
-                    example: 1
-                  first:
-                    type: boolean
-                    example: true
-                  empty:
-                    type: boolean
-                    example: false
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
         "400":
           description: There were no query parameters passed in. At least one must be specified.
           content:
@@ -413,26 +387,33 @@ components:
         type:
           type: string
           example: OFF_BKG
-    Pageable:
+    Pagination:
       type: object
       properties:
-        sort:
-          $ref: "#/components/schemas/Sort"
-        offset:
-          type: integer
-          example: 0
-        pageNumber:
-          type: integer
-          example: 0
-        pageSize:
-          type: integer
-          example: 10
-        paged:
+        isLastPage:
           type: boolean
           example: true
-        unpaged:
-          type: boolean
-          example: false
+          description: Is the current page the last one?
+        count:
+          type: integer
+          example: 1
+          description: The number of results in `data` for the current page
+        page:
+          type: integer
+          example: 1
+          description: The current page number
+        perPage:
+          type: integer
+          example: 10
+          description: The maximum number of results in `data` for a page
+        totalCount:
+          type: integer
+          example: 1
+          description: The total number of results in `data` across all pages
+        totalPages:
+          type: integer
+          example: 1
+          description: The total number of pages
     Person:
       type: object
       properties:
@@ -468,18 +449,6 @@ components:
           type: string
           example: 2008/0545166T
           description: An identifier from the Police National Computer (PNC)
-    Sort:
-      type: object
-      properties:
-        empty:
-          type: boolean
-          example: true
-        sorted:
-          type: boolean
-          example: false
-        unsorted:
-          type: boolean
-          example: true
   examples:
     PersonNotFoundError:
       value:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
@@ -2,9 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
 
 import jakarta.validation.ValidationException
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
-import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesFor
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonsService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.PaginatedResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.paginateWith
 
 @RestController
@@ -34,15 +32,16 @@ class PersonController(
   fun getPersons(
     @RequestParam(required = false, name = "first_name") firstName: String?,
     @RequestParam(required = false, name = "last_name") lastName: String?,
-    @PageableDefault paginationOptions: Pageable,
-  ): Page<Person?> {
+    @RequestParam(required = false, defaultValue = "1", name = "page") page: Int,
+    @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
+  ): PaginatedResponse<Person?> {
     if (firstName == null && lastName == null) {
       throw ValidationException("No query parameters specified.")
     }
 
-    val result = getPersonsService.execute(firstName, lastName)
+    val results = getPersonsService.execute(firstName, lastName)
 
-    return result.paginateWith(paginationOptions)
+    return results.paginateWith(page, perPage)
   }
 
   @GetMapping("{encodedPncId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/util/Paginate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/util/Paginate.kt
@@ -1,14 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.util
 
 import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.PageRequest
 
-infix fun <T> List<T>.paginateWith(paginationOptions: Pageable): PageImpl<T> {
+fun <T> List<T>.paginateWith(page: Int = 1, perPage: Int = 10): PaginatedResponse<T> {
+  val paginationOptions = PageRequest.of(page - 1, perPage)
   val start = paginationOptions.pageSize * paginationOptions.pageNumber
   val end = (start + paginationOptions.pageSize).coerceAtMost(this.size)
 
   if (start > end) {
-    return PageImpl(listOf<T>(), paginationOptions, this.size.toLong())
+    return PaginatedResponse(PageImpl(listOf<T>(), paginationOptions, this.size.toLong()))
   }
-  return PageImpl(this.subList(start, end), paginationOptions, this.count().toLong())
+
+  return PaginatedResponse(PageImpl(this.subList(start, end), paginationOptions, this.count().toLong()))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/util/PaginatedResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/util/PaginatedResponse.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.util
+
+import org.springframework.data.domain.Page
+
+class PaginatedResponse<T>(pageableResponse: Page<T>) {
+  val data: List<T> = pageableResponse.content
+  val pagination: Pagination = Pagination(pageableResponse)
+
+  inner class Pagination(pageableResponse: Page<T>) {
+    val isLastPage: Boolean = pageableResponse.isLast
+    val count: Int = pageableResponse.numberOfElements
+    val page: Int = pageableResponse.number + 1
+    val perPage: Int = pageableResponse.size
+    val totalCount: Long = pageableResponse.totalElements
+    val totalPages: Int = pageableResponse.totalPages
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -32,7 +32,7 @@ class PersonSmokeTest : DescribeSpec({
     )
 
     response.statusCode().shouldBe(HttpStatus.OK.value())
-    response.body().shouldContain("\"content\":[")
+    response.body().shouldContain("\"data\":[")
     response.body().shouldContain(
       """
         "firstName":"Robert",


### PR DESCRIPTION
## Context

We added pagination to our `/v1/persons` API endpoint in #144, however we were unsatisfied with the default response provided by the Spring Boot pageable package.

## Changes proposed in this PR

Update our pagination response like so:

![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/9f3abb8d-4983-4097-95a6-022fbd3fe486)

This improves pagination by removing unnecessary properties, duplicated values and adding more meaningful property names. It also updates our OpenAPI spec with these changes.

## Next steps

1. Make all API endpoints return a `data` property for consistency.
2. Have a lil think or looksies at how to test pagination across all endpoints.