### PR TITLE
Update addresses and images endpoints to use data key

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -111,7 +111,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  images:
+                  data:
                     type: array
                     minItems: 0
                     items:
@@ -141,7 +141,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  addresses:
+                  data:
                     type: array
                     minItems: 0
                     items:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
@@ -61,7 +61,7 @@ class PersonController(
     val pncId = encodedPncId.decodeUrlCharacters()
     val images = getImageMetadataForPersonService.execute(pncId)
 
-    return mapOf("images" to images)
+    return mapOf("data" to images)
   }
 
   @GetMapping("{encodedPncId}/addresses")
@@ -70,6 +70,6 @@ class PersonController(
     val addresses = getAddressesForPersonService.execute(pncId)
       ?: throw EntityNotFoundException("Could not find person with id: $pncId")
 
-    return mapOf("addresses" to addresses)
+    return mapOf("data" to addresses)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -83,11 +83,7 @@ internal class PersonControllerTest(
           mockMvc.perform(get("$basePath?first_name=$firstNameThatDoesNotExist&last_name=$lastNameThatDoesNotExist"))
             .andReturn()
 
-        result.response.contentAsString.shouldContain(
-          """
-          "data":[]
-        """.removeWhitespaceAndNewlines(),
-        )
+        result.response.contentAsString.shouldContain("\"data\":[]".removeWhitespaceAndNewlines())
       }
 
       it("retrieves a person with matching search criteria") {
@@ -101,29 +97,27 @@ internal class PersonControllerTest(
 
         result.response.contentAsString.shouldContain(
           """
-          {
-            "data":
-            [
-              {
-                "firstName":"Barry",
-                "lastName":"Allen",
-                "middleName":"Jonas",
-                "dateOfBirth":"2023-03-01",
-                "aliases":[],
-                "prisonerId": null,
-                "pncId": null
-               },
-               {
-                 "firstName":"Barry",
-                 "lastName":"Allen",
-                 "middleName":"Rock",
-                 "dateOfBirth":"2022-07-22",
-                 "aliases":[],
-                 "prisonerId": null,
-                 "pncId": null
-               }
-             ]
-        """.removeWhitespaceAndNewlines(),
+          "data": [
+            {
+              "firstName":"Barry",
+              "lastName":"Allen",
+              "middleName":"Jonas",
+              "dateOfBirth":"2023-03-01",
+              "aliases":[],
+              "prisonerId": null,
+              "pncId": null
+            },
+            {
+               "firstName":"Barry",
+               "lastName":"Allen",
+               "middleName":"Rock",
+               "dateOfBirth":"2022-07-22",
+               "aliases":[],
+               "prisonerId": null,
+               "pncId": null
+            }
+          ]
+          """.removeWhitespaceAndNewlines(),
         )
       }
 
@@ -245,7 +239,7 @@ internal class PersonControllerTest(
         result.response.contentAsString.shouldBe(
           """
         {
-          "images": [
+          "data": [
             {
               "id" : 2461788,
               "active" : true,
@@ -289,7 +283,7 @@ internal class PersonControllerTest(
         result.response.contentAsString.shouldBe(
           """
         {
-          "addresses": [
+          "data": [
             {
               "postcode": "SE1 1TE"
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -102,7 +102,7 @@ class PersonSmokeTest : DescribeSpec({
     response.body().shouldBe(
       """
     {
-      "images": [
+      "data": [
         {
           "id":2461788,
           "active":false,
@@ -127,7 +127,7 @@ class PersonSmokeTest : DescribeSpec({
     response.body().shouldBe(
       """
     {
-      "addresses": [
+      "data": [
         {
           "postcode": "string"
         },


### PR DESCRIPTION
This is to make all API endpoints consistent inline with the recent pagination changes.