### PR TITLE
Refactor get addresses to remove nullable return types 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlChar
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
@@ -72,9 +73,12 @@ class PersonController(
   @GetMapping("{encodedPncId}/addresses")
   fun getPersonAddresses(@PathVariable encodedPncId: String): Map<String, List<Address>> {
     val pncId = encodedPncId.decodeUrlCharacters()
-    val addresses = getAddressesForPersonService.execute(pncId)
-      ?: throw EntityNotFoundException("Could not find person with id: $pncId")
+    val response = getAddressesForPersonService.execute(pncId)
 
-    return mapOf("data" to addresses)
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not find person with id: $pncId")
+    }
+
+    return mapOf("data" to response.data)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -13,6 +13,9 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrap
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.ImageDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Offender
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Address as AddressFromNomis
@@ -53,12 +56,25 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
     }
   }
 
-  fun getAddressesForPerson(id: String): List<Address>? {
+  fun getAddressesForPerson(id: String): Response<List<Address>> {
     return try {
-      webClient.requestList<AddressFromNomis>(HttpMethod.GET, "/api/offenders/$id/addresses", authenticationHeader())
-        .map { it.toAddress() }
+      Response(
+        data = webClient.requestList<AddressFromNomis>(
+          HttpMethod.GET,
+          "/api/offenders/$id/addresses",
+          authenticationHeader(),
+        ).map { it.toAddress() },
+      )
     } catch (exception: WebClientResponseException.NotFound) {
-      null
+      Response(
+        data = emptyList(),
+        errors = listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.NOMIS,
+            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+          ),
+        ),
+      )
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Response.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class Response<T>(val data: T, val errors: List<UpstreamApiError> = emptyList(), val description: String? = null) {
+  companion object {
+    fun <T> merge(responses: List<Response<List<T>>>): Response<List<T>> = Response(data = responses.flatMap { it.data }, errors = responses.flatMap { it.errors })
+  }
+
+  fun hasError(type: UpstreamApiError.Type): Boolean = this.errors.any { it.type == type }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApi.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+enum class UpstreamApi {
+  NOMIS, PRISONER_OFFENDER_SEARCH, PROBATION_OFFENDER_SEARCH
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class UpstreamApiError(val causedBy: UpstreamApi, val type: Type, val description: String? = null) {
+  enum class Type {
+    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 
 @Service
 class GetAddressesForPersonService(
@@ -13,16 +14,12 @@ class GetAddressesForPersonService(
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @Autowired val nomisGateway: NomisGateway,
 ) {
-  fun execute(pncId: String): List<Address>? {
+  fun execute(pncId: String): Response<List<Address>> {
     val personFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
 
-    val addressesFromNomis = nomisGateway.getAddressesForPerson(personFromPrisonerOffenderSearch.first().prisonerId!!)
-    val addressesFromProbationOffenderSearch = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+    val responseFromNomis = nomisGateway.getAddressesForPerson(personFromPrisonerOffenderSearch.first().prisonerId!!)
+    val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    if (addressesFromNomis == null && addressesFromProbationOffenderSearch == null) {
-      return null
-    }
-
-    return addressesFromProbationOffenderSearch?.plus(addressesFromNomis.orEmpty())
+    return Response.merge(listOf(responseFromNomis, responseFromProbationOffenderSearch))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -18,6 +18,9 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitesp
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
@@ -294,9 +297,7 @@ internal class PersonControllerTest(
       beforeTest {
         Mockito.reset(getAddressesForPersonService)
         whenever(getAddressesForPersonService.execute(pncId)).thenReturn(
-          listOf(
-            Address(postcode = "SE1 1TE"),
-          ),
+          Response(data = listOf(Address(postcode = "SE1 1TE"))),
         )
       }
 
@@ -329,7 +330,17 @@ internal class PersonControllerTest(
       }
 
       it("responds with a 404 NOT FOUND status when person isn't found") {
-        whenever(getAddressesForPersonService.execute(pncId)).thenReturn(null)
+        whenever(getAddressesForPersonService.execute(pncId)).thenReturn(
+          Response(
+            data = emptyList(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+          ),
+        )
 
         val result = mockMvc.perform(get("$basePath/$encodedPncId/addresses")).andReturn()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.probationoffendersearch
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.nulls.shouldBeNull
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffend
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ProbationOffenderSearchApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 
 @ActiveProfiles("test")
 @ContextConfiguration(
@@ -68,9 +69,9 @@ class GetAddressesForPersonTest(
   }
 
   it("returns addresses for a person with the matching ID") {
-    val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    addresses?.shouldContain(Address(postcode = "M3 2JA"))
+    response.data.shouldContain(Address(postcode = "M3 2JA"))
   }
 
   it("returns an empty list when no addresses are found") {
@@ -89,19 +90,19 @@ class GetAddressesForPersonTest(
         """,
     )
 
-    val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    addresses.shouldBeEmpty()
+    response.data.shouldBeEmpty()
   }
 
-  it("returns null when no results are returned") {
+  it("returns an error when no results are returned") {
     probationOffenderSearchApiMockServer.stubPostOffenderSearch(
       "{\"pncNumber\": \"$pncId\", \"valid\": true}",
       "[]",
     )
 
-    val addresses = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    addresses.shouldBeNull()
+    response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
   }
 },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke
 
+import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -120,19 +121,19 @@ class PersonSmokeTest : DescribeSpec({
     )
 
     response.statusCode().shouldBe(HttpStatus.OK.value())
-    response.body().shouldBe(
+    response.body().shouldEqualJson(
       """
-    {
-      "data": [
-        {
-          "postcode": "string"
-        },
-        {
-          "postcode": "LI1 5TH"
-        }
-      ]
-    }
-    """.removeWhitespaceAndNewlines(),
+      {
+        "data": [
+          {
+            "postcode": "LI1 5TH"
+          },
+          {
+            "postcode": "string"
+          }
+        ]
+      }
+      """,
     )
   }
 },)


### PR DESCRIPTION
## Context

We've not be happy with the use of nullable return types in our codebase as the meaning of them aren't clear i.e. person couldn't be found. As a result, we've looked for an approach to tackle this.

## Changes proposed in this PR

Introduce a class to wrap the data and errors returned by gateways and use cases. This means that errors aren't lost and each layer can decide what to do with the information they have. As part of this we decided we'll only throw exceptions in the controller level.

Before | After
-- | --
![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/d3e87d90-6af0-4b57-afc8-c9f2a1f04947) | ![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/0b6e5d72-7338-4b17-9e80-bf9ee11ecc08)

## Next steps

Jira tickets will be created to refactor the remaining endpoints to ensure our whole codebase is consistent with this approach.