### PR TITLE
Add documentation to monitor all pod logs at once

### DIFF
--- a/docs/useful-commands.md
+++ b/docs/useful-commands.md
@@ -49,6 +49,12 @@ To view logs of a pod:
 kubectl logs <pod-name> -n <namespace>
 ```
 
+To monitor all pod logs in a namespace at once
+```bash
+kubectl get pods --show-labels -n <namespace>
+kubectl logs -n <namespace> -l pod-template-hash=<hash> -f 
+````
+
 To perform a command within a pod:
 
 ```bash

--- a/docs/useful-commands.md
+++ b/docs/useful-commands.md
@@ -62,6 +62,11 @@ kubectl exec <pod-name> -c <container-name> -n <namespace> <command>
 # E.g. kubectl exec hmpps-integration-api-5b8f4f9699-wbwgf -c hmpps-integration-api -n hmpps-integration-api-dev -- curl http://localhost:8080/
 ```
 
+Open a shell into a pod:
+```bash
+kubectl exec --stdin -n <namespace> --tty <podname> -- /bin/bash
+```
+
 To delete all ingress, services, pods and deployments:
 
 ```bash

--- a/docs/useful-commands.md
+++ b/docs/useful-commands.md
@@ -52,7 +52,8 @@ kubectl logs <pod-name> -n <namespace>
 To monitor all pod logs in a namespace at once
 ```bash
 kubectl get pods --show-labels -n <namespace>
-kubectl logs -n <namespace> -l pod-template-hash=<hash> -f 
+# We need the pod-template-hash from the the first command
+kubectl logs -n <namespace> -l pod-template-hash=<pod-template-hash> -f 
 ````
 
 To perform a command within a pod:


### PR DESCRIPTION
Since our pods are load balanced, it's useful to be able to monitor multiple pod's logs at once.

Credit to @emileswarts for sussing out that we can do this via labels.