### PR TITLE
Refactor get an image to use response wrapper class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ImageController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ImageController.kt
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageService
 
 @RestController
@@ -15,10 +17,14 @@ class ImageController(
 ) {
   @GetMapping("{id}")
   fun getImage(@PathVariable id: Int): ResponseEntity<ByteArray> {
-    val image = getImageService.execute(id)
+    val response = getImageService.execute(id)
+
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not find image with id: $id")
+    }
 
     return ResponseEntity.ok()
       .header("content-type", "image/jpeg")
-      .body(image)
+      .body(response.data)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -48,11 +48,19 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
     }
   }
 
-  fun getImageData(id: Int): ByteArray {
+  fun getImageData(id: Int): Response<ByteArray> {
     return try {
-      webClient.request<ByteArray>(HttpMethod.GET, "/api/images/$id/data", authenticationHeader())
+      Response(data = webClient.request(HttpMethod.GET, "/api/images/$id/data", authenticationHeader()))
     } catch (exception: WebClientResponseException.NotFound) {
-      throw EntityNotFoundException("Could not find image with id: $id")
+      Response(
+        data = byteArrayOf(),
+        errors = listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.NOMIS,
+            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+          ),
+        ),
+      )
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageService.kt
@@ -3,8 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 
 @Service
 class GetImageService(@Autowired val nomisGateway: NomisGateway) {
-  fun execute(id: Int): ByteArray = nomisGateway.getImageData(id)
+  fun execute(id: Int): Response<ByteArray> = nomisGateway.getImageData(id)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ImageControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ImageControllerTest.kt
@@ -12,39 +12,62 @@ import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageService
 
 @WebMvcTest(controllers = [ImageController::class])
 internal class ImageControllerTest(
   @Autowired val mockMvc: MockMvc,
   @MockBean val getImageService: GetImageService,
-) : DescribeSpec({
-  val id = 2461788
-  val image = byteArrayOf(0x48, 101, 108, 108, 111)
-  val basePath = "/v1/images"
+) : DescribeSpec(
+  {
+    val id = 2461788
+    val image = byteArrayOf(0x48, 101, 108, 108, 111)
+    val basePath = "/v1/images"
 
-  describe("GET $basePath/{id}") {
-    beforeTest {
-      Mockito.reset(getImageService)
-      whenever(getImageService.execute(id)).thenReturn(image)
+    describe("GET $basePath/{id}") {
+      beforeTest {
+        Mockito.reset(getImageService)
+        whenever(getImageService.execute(id)).thenReturn(Response(data = image))
+      }
+
+      it("responds with a 200 OK status") {
+        val result = mockMvc.perform(get("$basePath/$id")).andReturn()
+
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+
+      it("retrieves a image with the matching ID") {
+        mockMvc.perform(get("$basePath/$id")).andReturn()
+
+        verify(getImageService, VerificationModeFactory.times(1)).execute(id)
+      }
+
+      it("returns an image with the matching ID") {
+        val result = mockMvc.perform(get("$basePath/$id")).andReturn()
+
+        result.response.contentAsByteArray.shouldBe(image)
+      }
+
+      it("responds with a 404 NOT FOUND status") {
+        whenever(getImageService.execute(id)).thenReturn(
+          Response(
+            data = byteArrayOf(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+          ),
+        )
+
+        val result = mockMvc.perform(get("$basePath/$id")).andReturn()
+
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
     }
-
-    it("responds with a 200 OK status") {
-      val result = mockMvc.perform(get("$basePath/$id")).andReturn()
-
-      result.response.status.shouldBe(HttpStatus.OK.value())
-    }
-
-    it("retrieves a image with the matching ID") {
-      mockMvc.perform(get("$basePath/$id")).andReturn()
-
-      verify(getImageService, VerificationModeFactory.times(1)).execute(id)
-    }
-
-    it("returns an image with the matching ID") {
-      val result = mockMvc.perform(get("$basePath/$id")).andReturn()
-
-      result.response.contentAsByteArray.shouldBe(image)
-    }
-  }
-},)
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
@@ -10,6 +11,9 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
@@ -18,26 +22,48 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 internal class GetImageServiceTest(
   @MockBean val nomisGateway: NomisGateway,
   private val getImageService: GetImageService,
-) : DescribeSpec({
-  val id = 12345
+) : DescribeSpec(
+  {
+    val id = 12345
 
-  beforeEach {
-    Mockito.reset(nomisGateway)
-  }
+    beforeEach {
+      Mockito.reset(nomisGateway)
+    }
 
-  it("retrieves an image from NOMIS") {
-    getImageService.execute(id)
+    it("retrieves an image from NOMIS") {
+      getImageService.execute(id)
 
-    verify(nomisGateway, VerificationModeFactory.times(1)).getImageData(id)
-  }
+      verify(nomisGateway, VerificationModeFactory.times(1)).getImageData(id)
+    }
 
-  it("returns an image") {
-    val image = byteArrayOf(1, 2, 3, 4)
+    it("returns an image") {
+      val image = byteArrayOf(1, 2, 3, 4)
 
-    whenever(nomisGateway.getImageData(id)).thenReturn(image)
+      whenever(nomisGateway.getImageData(id)).thenReturn(Response(data = image))
 
-    val result = getImageService.execute(id)
+      val response = getImageService.execute(id)
 
-    result.shouldBe(image)
-  }
-},)
+      response.data.shouldBe(image)
+    }
+
+    it("returns the error from NOMIS when an error occurs") {
+      whenever(nomisGateway.getImageData(id)).thenReturn(
+        Response(
+          data = byteArrayOf(),
+          errors = listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NOMIS,
+              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+            ),
+          ),
+        ),
+      )
+
+      val response = getImageService.execute(id)
+
+      response.errors.shouldHaveSize(1)
+      response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
+      response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
+    }
+  },
+)


### PR DESCRIPTION
## Context

In #160, we introduced a wrapper class to be used for returning data from gateways and services.

## Changes proposed in this PR

- Refactor get an image to use the wrapper class for consistency.
- Move throwing `EntityNotFoundException` at the controller level instead.