### PR TITLE
Update get person addresses condition when not found is returned

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
@@ -12,7 +12,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlChar
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError.Type.ENTITY_NOT_FOUND
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetImageMetadataForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
@@ -75,7 +76,10 @@ class PersonController(
     val pncId = encodedPncId.decodeUrlCharacters()
     val response = getAddressesForPersonService.execute(pncId)
 
-    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+    if (
+      response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS) &&
+      response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH)
+    ) {
       throw EntityNotFoundException("Could not find person with id: $pncId")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Response.kt
@@ -2,8 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class Response<T>(val data: T, val errors: List<UpstreamApiError> = emptyList(), val description: String? = null) {
   companion object {
-    fun <T> merge(responses: List<Response<List<T>>>): Response<List<T>> = Response(data = responses.flatMap { it.data }, errors = responses.flatMap { it.errors })
+    fun <T> merge(responses: List<Response<List<T>>>): Response<List<T>> =
+      Response(data = responses.flatMap { it.data }, errors = responses.flatMap { it.errors })
   }
 
   fun hasError(type: UpstreamApiError.Type): Boolean = this.errors.any { it.type == type }
+
+  fun hasErrorCausedBy(type: UpstreamApiError.Type, causedBy: UpstreamApi): Boolean =
+    this.errors.any { it.type == type && it.causedBy == causedBy }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -341,13 +341,17 @@ internal class PersonControllerTest(
         )
       }
 
-      it("responds with a 404 NOT FOUND status when person isn't found") {
+      it("responds with a 404 NOT FOUND status when person isn't found in all upstream APIs") {
         whenever(getAddressesForPersonService.execute(pncId)).thenReturn(
           Response(
             data = emptyList(),
             errors = listOf(
               UpstreamApiError(
                 causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+              UpstreamApiError(
+                causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
                 type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
               ),
             ),
@@ -358,6 +362,24 @@ internal class PersonControllerTest(
 
         result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
       }
+    }
+
+    it("responds with a 200 OK status when person is found in one upstream API but not another") {
+      whenever(getAddressesForPersonService.execute(pncId)).thenReturn(
+        Response(
+          data = emptyList(),
+          errors = listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NOMIS,
+              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+            ),
+          ),
+        ),
+      )
+
+      val result = mockMvc.perform(get("$basePath/$encodedPncId/addresses")).andReturn()
+
+      result.response.status.shouldBe(HttpStatus.OK.value())
     }
   },
 )


### PR DESCRIPTION
## Context

In #160, we "refactored" get addresses to remove nullable type but I just realised that we changed the behaviour. We are returning 404 when there is an error in one upstream API. Instead we should only do this if this occurs in both upstream APIs used like before.

## Changes proposed in this PR 

Only return 404 NOT FOUND when service returns errors for both upstream APIs as it might be that addresses is found in one API but not another. This is still valid.