### PR TITLE
Fix CVE vulnerabilities for guava and spring-boot-autoconfigure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,6 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - hmpps/gradle_owasp_dependency_check:
-          context:
-            - hmpps-common-vars
       - lint-code:
           context:
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
+      - hmpps/gradle_owasp_dependency_check:
+          context:
+            - hmpps-common-vars
       - lint-code:
           context:
             - hmpps-common-vars

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.2.0"
   kotlin("plugin.spring") version "1.8.21"
 }
 


### PR DESCRIPTION
Fixes our OWASP dependency checks. See commits for evidence of the update fixes the check, commits will be squashed.

![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/1e37d85a-3689-470f-a569-730f6aaade51)
