### PR TITLE
Refactor get image metadata for a person to use response wrapper class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -5,13 +5,14 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 
 @Service
 class GetImageMetadataForPersonService(
   @Autowired val nomisGateway: NomisGateway,
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
 ) {
-  fun execute(pncId: String): List<ImageMetadata> {
+  fun execute(pncId: String): Response<List<ImageMetadata>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
 
     return nomisGateway.getImageMetadataForPerson(responseFromPrisonerOffenderSearch.data.first().prisonerId!!)


### PR DESCRIPTION
## Context

In #160, we introduced a wrapper class to be used for returning data from gateways and services.

## Changes proposed in this PR

- Refactor get an image to use the wrapper class for consistency.
- Move throwing `EntityNotFoundException` at the controller level instead.