### PR TITLE
Return type of address for Probation Offender Search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -10,6 +10,7 @@ data class Address(
   val from: String?,
   val postcode: String?,
   val streetName: String?,
+  val status: Status,
   val to: String?,
   val town: String?,
 ) {
@@ -24,6 +25,16 @@ data class Address(
     startDate = this.from,
     street = this.streetName,
     town = this.town,
-    types = listOf(IntegrationAPIAddress.Type("REPLACEME", null)),
+    types = listOf(Status(status.code, status.description).toAddressType()),
   )
+
+  data class Status(
+    val code: String,
+    val description: String?,
+  ) {
+    fun toAddressType() = IntegrationAPIAddress.Type(
+      code = this.code,
+      description = this.description ?: this.code,
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -87,7 +87,7 @@ class GetAddressesForPersonTest(
   it("returns addresses for a person with the matching ID") {
     val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldContain(generateTestAddress(types = listOf(IntegrationAPIAddress.Type("REPLACEME", null))))
+    response.data.shouldContain(generateTestAddress(types = listOf(IntegrationAPIAddress.Type("P", "Previous"))))
   }
 
   it("returns an empty list when no addresses are found") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/AddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/AddressTest.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address.Type as IntegrationAPIAddressType
+
+class AddressTest : DescribeSpec(
+  {
+    describe("#toAddress") {
+      val someDescription = "some description"
+      val someCode = "some code"
+
+      it("maps one-to-one attributes to integration API attributes") {
+        val address = Address(
+          addressNumber = "addressNumber",
+          buildingName = "buildingName",
+          district = "district",
+          county = "county",
+          from = "from",
+          postcode = "postcode",
+          streetName = "streetName",
+          status = Address.Status(someCode, someDescription),
+          to = "to",
+          town = "town",
+        )
+
+        val integrationApiAddress = address.toAddress()
+
+        integrationApiAddress.country.shouldBe("England")
+        integrationApiAddress.county.shouldBe(address.county)
+        integrationApiAddress.endDate.shouldBe(address.to)
+        integrationApiAddress.number.shouldBe(address.addressNumber)
+        integrationApiAddress.locality.shouldBe(address.district)
+        integrationApiAddress.postcode.shouldBe(address.postcode)
+        integrationApiAddress.name.shouldBe(address.buildingName)
+        integrationApiAddress.startDate.shouldBe(address.from)
+        integrationApiAddress.types.shouldBe(listOf(IntegrationAPIAddressType(someCode, someDescription)))
+        integrationApiAddress.street.shouldBe(address.streetName)
+        integrationApiAddress.town.shouldBe(address.town)
+      }
+
+      it("uses the code as the description if the description is not present") {
+        val address = Address(
+          addressNumber = "addressType",
+          buildingName = "buildingName",
+          district = "country",
+          county = "county",
+          from = "endDate",
+          postcode = "flat",
+          streetName = "locality",
+          status = Address.Status(someCode, null),
+          to = "premise",
+          town = "town",
+        )
+
+        address.toAddress().types.shouldBe(listOf(IntegrationAPIAddressType(someCode, someCode)))
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -161,8 +161,8 @@ class PersonSmokeTest : DescribeSpec(
             "town": "string",
             "types": [
               {
-                "code": "REPLACEME",
-                "description": null
+                "code": "string",
+                "description": "string"
               }
             ]
           }


### PR DESCRIPTION
This type has a code and a description.
If the description is missing it will use the code.