### PR TITLE
Don't hardcode "England" as country for probation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -15,7 +15,7 @@ data class Address(
   val town: String?,
 ) {
   fun toAddress() = IntegrationAPIAddress(
-    country = "England",
+    country = null,
     county = this.county,
     endDate = this.to,
     locality = this.district,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -87,7 +87,12 @@ class GetAddressesForPersonTest(
   it("returns addresses for a person with the matching ID") {
     val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldContain(generateTestAddress(types = listOf(IntegrationAPIAddress.Type("P", "Previous"))))
+    response.data.shouldContain(
+      generateTestAddress(
+        country = null,
+        types = listOf(IntegrationAPIAddress.Type("P", "Previous")),
+      ),
+    )
   }
 
   it("returns an empty list when no addresses are found") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/AddressHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/AddressHelper.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
 
 fun generateTestAddress(
   postcode: String = "SE1 1TZ",
-  country: String = "England",
+  country: String? = "England",
   county: String = "Greater London",
   endDate: String = "20 May 2023",
   startDate: String = "10 May 2021",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/AddressTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/AddressTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address.Type as IntegrationAPIAddressType
 
@@ -26,7 +27,7 @@ class AddressTest : DescribeSpec(
 
         val integrationApiAddress = address.toAddress()
 
-        integrationApiAddress.country.shouldBe("England")
+        integrationApiAddress.country.shouldBeNull()
         integrationApiAddress.county.shouldBe(address.county)
         integrationApiAddress.endDate.shouldBe(address.to)
         integrationApiAddress.number.shouldBe(address.addressNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -149,7 +149,7 @@ class PersonSmokeTest : DescribeSpec(
             ]
           },
           {
-            "country": "England",
+            "country": null,
             "county": "string",
             "endDate": "2019-08-24",
             "locality": "string",


### PR DESCRIPTION
This field isn't present in the upstream API, leave it as null