### PR TITLE
Guard against nullable fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -67,8 +67,12 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
       )
     }
 
-    return if (offender.first().contactDetails.addresses.isNotEmpty()) {
-      Response(data = offender.first().contactDetails.addresses.map { it.toAddress() })
+    return if (offender.first().contactDetails == null) {
+      Response(data = emptyList())
+    } else if (offender.first().contactDetails!!.addresses == null) {
+      Response(data = emptyList())
+    } else if (offender.first().contactDetails!!.addresses!!.isNotEmpty()) {
+      Response(data = offender.first().contactDetails!!.addresses!!.map { it.toAddress() })
     } else {
       Response(data = emptyList())
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/ContactDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/ContactDetails.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
 data class ContactDetails(
-  val addresses: List<Address> = listOf(),
+  val addresses: List<Address>? = listOf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -10,7 +10,7 @@ data class Offender(
   val middleNames: List<String> = listOf(),
   val dateOfBirth: LocalDate? = null,
   val offenderAliases: List<OffenderAlias> = listOf(),
-  val contactDetails: ContactDetails = ContactDetails(),
+  val contactDetails: ContactDetails? = ContactDetails(),
   val otherIds: OtherIds = OtherIds(),
 ) {
   fun toPerson(): Person = Person(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -126,4 +126,62 @@ class GetAddressesForPersonTest(
 
     response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
   }
+
+  it("returns an empty list when there is no contactDetails field") {
+    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+      """
+        [
+          {
+            "firstName": "English",
+            "surname": "Breakfast"
+          }
+        ]
+        """,
+    )
+
+    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+
+    response.data.shouldBeEmpty()
+  }
+
+  it("returns an empty list when contactDetails field is null") {
+    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+      """
+        [
+          {
+            "firstName": "English",
+            "surname": "Breakfast",
+            "contactDetails": null
+          }
+        ]
+        """,
+    )
+
+    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+
+    response.data.shouldBeEmpty()
+  }
+
+  it("returns an empty list when contactDetails.addresses field is null") {
+    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+      """
+        [
+          {
+            "firstName": "English",
+            "surname": "Breakfast",
+            "contactDetails": {
+              "addresses": null
+            }
+          }
+        ]
+        """,
+    )
+
+    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+
+    response.data.shouldBeEmpty()
+  }
 },)


### PR DESCRIPTION
Nested ContactDetails and Addresses can be null, make sure we return empty list of addresses when this is the case.