### PR TITLE
Add test and fix where address type is an empty json

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Address.kt
@@ -28,12 +28,12 @@ data class Address(
     startDate = this.from,
     street = this.streetName,
     town = this.town,
-    types = listOf(Type(type.code, type.description).toAddressType()),
+    types = if (this.type == null || this.type.code == null) emptyList() else listOf(Type(type.code, type.description).toAddressType()),
     notes = this.notes,
   )
 
   data class Type(
-    val code: String,
+    val code: String?,
     val description: String?,
   ) {
     fun toAddressType() = IntegrationAPIAddress.Type(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -28,15 +28,16 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address as Integr
 class GetAddressesForPersonTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
   private val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
-) : DescribeSpec({
-  val probationOffenderSearchApiMockServer = ProbationOffenderSearchApiMockServer()
-  val pncId = "2002/1121M"
+) : DescribeSpec(
+  {
+    val probationOffenderSearchApiMockServer = ProbationOffenderSearchApiMockServer()
+    val pncId = "2002/1121M"
 
-  beforeEach {
-    probationOffenderSearchApiMockServer.start()
-    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      """
+    beforeEach {
+      probationOffenderSearchApiMockServer.start()
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        """
         [
           {
             "firstName": "English",
@@ -70,39 +71,39 @@ class GetAddressesForPersonTest(
           }
         ]
       """,
-    )
+      )
 
-    Mockito.reset(hmppsAuthGateway)
-    whenever(hmppsAuthGateway.getClientToken("Probation Offender Search")).thenReturn(
-      HmppsAuthMockServer.TOKEN,
-    )
-  }
+      Mockito.reset(hmppsAuthGateway)
+      whenever(hmppsAuthGateway.getClientToken("Probation Offender Search")).thenReturn(
+        HmppsAuthMockServer.TOKEN,
+      )
+    }
 
-  afterTest {
-    probationOffenderSearchApiMockServer.stop()
-  }
+    afterTest {
+      probationOffenderSearchApiMockServer.stop()
+    }
 
-  it("authenticates using HMPPS Auth with credentials") {
-    probationOffenderSearchGateway.getAddressesForPerson(pncId)
+    it("authenticates using HMPPS Auth with credentials") {
+      probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Probation Offender Search")
-  }
+      verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("Probation Offender Search")
+    }
 
-  it("returns addresses for a person with the matching ID") {
-    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+    it("returns addresses for a person with the matching ID") {
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldContain(
-      generateTestAddress(
-        country = null,
-        types = listOf(IntegrationAPIAddress.Type("A07", "Friends/Family")),
-      ),
-    )
-  }
+      response.data.shouldContain(
+        generateTestAddress(
+          country = null,
+          types = listOf(IntegrationAPIAddress.Type("A07", "Friends/Family")),
+        ),
+      )
+    }
 
-  it("returns an empty list when no addresses are found") {
-    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      """
+    it("returns an empty list when no addresses are found") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        """
         [
           {
             "firstName": "English",
@@ -113,28 +114,28 @@ class GetAddressesForPersonTest(
           }
         ]
         """,
-    )
+      )
 
-    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldBeEmpty()
-  }
+      response.data.shouldBeEmpty()
+    }
 
-  it("returns an error when no results are returned") {
-    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      "[]",
-    )
+    it("returns an error when no results are returned") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "[]",
+      )
 
-    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
-  }
+      response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
+    }
 
-  it("returns an empty list when there is no contactDetails field") {
-    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      """
+    it("returns an empty list when there is no contactDetails field") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        """
         [
           {
             "firstName": "English",
@@ -142,17 +143,17 @@ class GetAddressesForPersonTest(
           }
         ]
         """,
-    )
+      )
 
-    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldBeEmpty()
-  }
+      response.data.shouldBeEmpty()
+    }
 
-  it("returns an empty list when contactDetails field is null") {
-    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      """
+    it("returns an empty list when contactDetails field is null") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        """
         [
           {
             "firstName": "English",
@@ -161,17 +162,17 @@ class GetAddressesForPersonTest(
           }
         ]
         """,
-    )
+      )
 
-    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldBeEmpty()
-  }
+      response.data.shouldBeEmpty()
+    }
 
-  it("returns an empty list when contactDetails.addresses field is null") {
-    probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-      "{\"pncNumber\": \"$pncId\", \"valid\": true}",
-      """
+    it("returns an empty list when contactDetails.addresses field is null") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        """
         [
           {
             "firstName": "English",
@@ -182,10 +183,36 @@ class GetAddressesForPersonTest(
           }
         ]
         """,
-    )
+      )
 
-    val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
-    response.data.shouldBeEmpty()
-  }
-},)
+      response.data.shouldBeEmpty()
+    }
+
+    it("returns an empty list when the type is an empty object") {
+      probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        """
+        [
+          {
+            "firstName": "English",
+            "surname": "Breakfast",
+            "contactDetails": {
+               "addresses": [
+                {
+                    "type": {}
+                }
+              ]
+            }
+          }
+        ]
+        """,
+      )
+
+      val response = probationOffenderSearchGateway.getAddressesForPerson(pncId)
+
+      response.data.first().types.shouldBeEmpty()
+    }
+  },
+)


### PR DESCRIPTION
We spotted an error where Spring was failing to create the Probation address type model.

![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/109950424/1c35757e-e94e-43e0-9466-ef9a43ebb46f)

It turns out that the record in question had their address type as `"type": {}`. When the auto mapper actually parses this JSON into our address type object, it creates the object. However, our address type object had the `code` parameter as required. This meant that it couldn't create the object.

We had a look at ways to exclude empty json objects to prevent them from being converted into our models. But didn't have any luck (https://www.logicbig.com/tutorials/misc/jackson/json-include-non-default.html). 

For the time being we decided the best option was to just allow `code` to be null in the constructor and return an empty list to _our_ address model if it was.