### PR TITLE
Update heartbeat to retry 5 times in 10 secs intervals before failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ workflows:
 
       - heartbeat:
           <<: *slack-fail-post-step
-          name: heartbeat-dev
+          name: post-deploy-check-heartbeat-for-dev
           context:
             - hmpps-common-vars
             - hmpps-integration-api-heartbeat-dev
@@ -188,7 +188,7 @@ workflows:
             - hmpps-common-vars
             - hmpps-integration-api-preprod
           requires:
-            - heartbeat-dev
+            - post-deploy-check-heartbeat-for-dev
           filters:
             branches:
               only:
@@ -211,7 +211,7 @@ workflows:
           slack_notification: false
       - heartbeat:
           <<: *slack-fail-post-step
-          name: heartbeat-preprod
+          name: post-deploy-check-heartbeat-for-preprod
           context:
             - hmpps-common-vars
             - hmpps-integration-api-heartbeat-preprod
@@ -225,7 +225,7 @@ workflows:
             - hmpps-integration-api-prod
             - hmpps-common-vars
           requires:
-            - heartbeat-preprod
+            - post-deploy-check-heartbeat-for-preprod
           filters:
             branches:
               only:
@@ -248,7 +248,7 @@ workflows:
           slack_notification: false
       - heartbeat:
           <<: *slack-fail-post-step
-          name: heartbeat-prod
+          name: post-deploy-check-heartbeat-for-prod
           context:
             - hmpps-common-vars
             - hmpps-integration-api-heartbeat-prod
@@ -297,19 +297,19 @@ workflows:
     jobs:
       - heartbeat:
           <<: *slack-fail-post-step
-          name: heartbeat-development
+          name: check-heartbeat-for-dev
           context:
             - hmpps-common-vars
             - hmpps-integration-api-heartbeat-dev
       - heartbeat:
           <<: *slack-fail-post-step
-          name: heartbeat-preprod
+          name: check-heartbeat-for-preprod
           context:
             - hmpps-common-vars
             - hmpps-integration-api-heartbeat-preprod
       - heartbeat:
           <<: *slack-fail-post-step
-          name: heartbeat-prod
+          name: check-heartbeat-for-prod
           context:
             - hmpps-common-vars
             - hmpps-integration-api-heartbeat-prod

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -11,7 +11,7 @@ for str in "${requiredVars[@]}"; do
   fi
 done
 
-if [ $fail = 1 ]; then
+if [[ $fail == 1 ]]; then
   echo "**FAIL** Missing CircleCI context variable(s)"
   exit 1
 fi

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -6,22 +6,28 @@ retry_attempts=5
 retry_after_seconds=10
 requiredVars=("MTLS_KEY" "MTLS_CERT" "SERVICE_URL" "API_KEY")
 
+echo "Heartbeat Checker"
+echo -e "=================\n"
+
+echo "[Config] Maximum retry attempts: $retry_attempts"
+echo "[Config] Retry after: $retry_after_seconds seconds"
+
 for str in "${requiredVars[@]}"; do
   if [[ -z "${!str}" ]]; then
-    echo "CircleCI context variable was undefined: $str"
+    echo "[Config] CircleCI context variable was undefined: $str"
     fail=1
   fi
 done
 
 if [[ $fail == 1 ]]; then
-  echo "**FAIL** Missing CircleCI context variable(s)"
+  echo "[Config] 💔️️ Failed! Missing CircleCI context variable(s)"
   exit 1
 fi
 
-echo "Retrieving certificates from context";
+echo -e "\n[Setup] Retrieving certificates from context";
 echo -n "${MTLS_CERT}" | base64 --decode > /tmp/client.pem
 echo -n "${MTLS_KEY}" | base64 --decode > /tmp/client.key
-echo "Certificates retrieved";
+echo -e "[Setup] Certificates retrieved\n";
 
 for (( attempts=1;attempts<=retry_attempts;attempts++ ))
 do

--- a/scripts/heartbeat.sh
+++ b/scripts/heartbeat.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+retry_attempts=5
+retry_after_seconds=10
 requiredVars=("MTLS_KEY" "MTLS_CERT" "SERVICE_URL" "API_KEY")
 
 for str in "${requiredVars[@]}"; do
@@ -21,12 +23,23 @@ echo -n "${MTLS_CERT}" | base64 --decode > /tmp/client.pem
 echo -n "${MTLS_KEY}" | base64 --decode > /tmp/client.key
 echo "Certificates retrieved";
 
-curl --silent "${SERVICE_URL}" -H "x-api-key: ${API_KEY}" --cert /tmp/client.pem --key /tmp/client.key | grep firstName > /dev/null
+for (( attempts=1;attempts<=retry_attempts;attempts++ ))
+do
+  echo "[Attempt ${attempts}] 🧑‍⚕️ Checking for a heartbeat..."
+  curl --silent "${SERVICE_URL}" -H "x-api-key: ${API_KEY}" --cert /tmp/client.pem --key /tmp/client.key | grep firstName > /dev/null
 
-if [ $? -eq 0 ]; then
-  echo "**SUCCESS** Located firstName in response"
-  exit 0
-else
-  echo "**FAIL** Failed to locate firstName in response"
-  exit 1
-fi
+  if [[ $? == 0 ]]; then
+    echo "[Attempt ${attempts}] ✅ Success! Located firstName in response"
+    exit 0
+  else
+    echo -e "[Attempt ${attempts}] 💔️ Failed! Unable to locate firstName in response"
+
+    if [[ $attempts != "$retry_attempts" ]]; then
+      sleep $retry_after_seconds
+      echo -e "[Attempt ${attempts}] 🔁 Retrying..."
+    fi
+    echo
+  fi
+done
+
+exit 1


### PR DESCRIPTION
## Context

We noticed that when our heartbeat script runs after deployment, there's a possibility that it could poke the previous version of the API i.e. not the latest deployment version as the Kubernetes pods gets switched over.

## Changes proposed in this PR

- Update heartbeat to retries multiple times before declaring a failure. Atm, it's configured to retry 5 times and wait 10 seconds after the next retry.
- Fix `./scripts/heartbeat.sh: line 14: [: =: unary operator expected` error.
- Add clearer logging i.e. add new lines, prefix logs, add emojis (fite me on dis).
- Update heartbeat job names in our pipeline as they previously were the same in the deployment pipeline and the continuous job - now a job in a deployment pipeline is named like `post-deploy-check-heartbeat-for-dev` and the continuous job is `check-heartbeat-for-dev`.

## Screenshots

Before | After
-- | --
![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/3499bea5-2c8a-4458-8261-9f25d9bbe165)  |  ![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/603c38cc-93b1-421d-8af8-6cc4feb443d2)
![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/576af440-d720-4c16-b38c-58bf0bad307c) | ![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/bf1f7493-f9c4-48fd-8e8e-382968a854c2)

## Next steps

- Output error from curl command so we know what caused a failure.
- Add time to logs.