### PR TITLE
Refactor: Wrap person response in Response object

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonController.kt
@@ -50,13 +50,16 @@ class PersonController(
   @GetMapping("{encodedPncId}")
   fun getPerson(@PathVariable encodedPncId: String): Map<String, Person?> {
     val pncId = encodedPncId.decodeUrlCharacters()
-    val result = getPersonService.execute(pncId)
+    val response = getPersonService.execute(pncId)
 
-    if (result.isNullOrEmpty()) {
+    if (
+      response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS) &&
+      response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH)
+    ) {
       throw EntityNotFoundException("Could not find person with id: $pncId")
     }
 
-    return result
+    return response.data
   }
 
   @GetMapping("{encodedPncId}/images")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -24,7 +22,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  fun getPerson(pncId: String): Response<Person?>? {
+  fun getPerson(pncId: String): Response<Person?> {
     return try {
       val offenders = webClient.requestList<Offender>(
         HttpMethod.POST,
@@ -47,8 +45,15 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
         Response(data = offenders.first().toPerson())
       }
     } catch (exception: WebClientResponseException.BadRequest) {
-      log.error("${exception.message} - ${Json.parseToJsonElement(exception.responseBodyAsString).jsonObject["developerMessage"]}")
-      null
+      Response(
+        data = null,
+        errors = listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+            type = UpstreamApiError.Type.BAD_REQUEST,
+          ),
+        ),
+      )
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -24,8 +24,8 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  fun getPerson(pncId: String): Response<Person?> {
-    try {
+  fun getPerson(pncId: String): Response<Person?>? {
+    return try {
       val offenders = webClient.requestList<Offender>(
         HttpMethod.POST,
         "/search",
@@ -33,7 +33,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
         mapOf("pncNumber" to pncId, "valid" to true),
       )
 
-      return if (offenders.isEmpty()) {
+      if (offenders.isEmpty()) {
         Response(
           data = null,
           errors = listOf(
@@ -48,15 +48,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
       }
     } catch (exception: WebClientResponseException.BadRequest) {
       log.error("${exception.message} - ${Json.parseToJsonElement(exception.responseBodyAsString).jsonObject["developerMessage"]}")
-      return Response(
-        data = null,
-        errors = listOf(
-          UpstreamApiError(
-            causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
-            type = UpstreamApiError.Type.BAD_REQUEST,
-          ),
-        ),
-      )
+      null
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class UpstreamApiError(val causedBy: UpstreamApi, val type: Type, val description: String? = null) {
   enum class Type {
-    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND
+    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND, BAD_REQUEST
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class UpstreamApiError(val causedBy: UpstreamApi, val type: Type, val description: String? = null) {
   enum class Type {
-    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND, BAD_REQUEST
+    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -19,7 +19,7 @@ class GetPersonService(
     return Response(
       data = mapOf(
         "prisonerOffenderSearch" to responseFromPrisonerOffenderSearch.data.firstOrNull(),
-        "probationOffenderSearch" to personFromProbationOffenderSearch.data,
+        "probationOffenderSearch" to personFromProbationOffenderSearch?.data,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -5,23 +5,22 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 
 @Service
 class GetPersonService(
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) {
-  fun execute(pncId: String): Map<String, Person?>? {
+  fun execute(pncId: String): Response<Map<String, Person?>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
     val personFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(pncId)
 
-    if (responseFromPrisonerOffenderSearch.data.isEmpty() && personFromProbationOffenderSearch == null) {
-      return null
-    }
-
-    return mapOf(
-      "prisonerOffenderSearch" to responseFromPrisonerOffenderSearch.data.firstOrNull(),
-      "probationOffenderSearch" to personFromProbationOffenderSearch,
+    return Response(
+      data = mapOf(
+        "prisonerOffenderSearch" to responseFromPrisonerOffenderSearch.data.firstOrNull(),
+        "probationOffenderSearch" to personFromProbationOffenderSearch.data,
+      ),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -197,7 +197,7 @@ internal class PersonControllerTest(
             Response(
               mapOf(
                 "prisonerOffenderSearch" to null,
-                "probationOffenderSearch" to null
+                "probationOffenderSearch" to null,
               ),
               errors = listOf(
                 UpstreamApiError(
@@ -223,7 +223,7 @@ internal class PersonControllerTest(
             Response(
               mapOf(
                 "probationOffenderSearch" to Person("someFirstName", "someLastName"),
-                "prisonerOffenderSearch" to null
+                "prisonerOffenderSearch" to null,
               ),
               errors = listOf(
                 UpstreamApiError(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
@@ -179,7 +180,7 @@ internal class PersonControllerTest(
 
       beforeTest {
         Mockito.reset(getPersonService)
-        whenever(getPersonService.execute(pncId)).thenReturn(person)
+        whenever(getPersonService.execute(pncId)).thenReturn(Response(data = person))
       }
 
       it("responds with a 200 OK status") {
@@ -188,14 +189,50 @@ internal class PersonControllerTest(
         result.response.status.shouldBe(HttpStatus.OK.value())
       }
 
-      it("responds with a 404 NOT FOUND status") {
+      describe("404 Not found") {
         val idThatDoesNotExist = "9999/11111Z"
-        whenever(getPersonService.execute(idThatDoesNotExist)).thenReturn(null)
 
-        val encodedIdThatDoesNotExist = URLEncoder.encode(idThatDoesNotExist, StandardCharsets.UTF_8)
-        val result = mockMvc.perform(get("$basePath/$encodedIdThatDoesNotExist")).andReturn()
+        it("responds with a 404 when a person cannot be found in both upstream APIs") {
+          whenever(getPersonService.execute(idThatDoesNotExist)).thenReturn(
+            Response(
+              mapOf("prisonerOffenderSearch" to null),
+              errors = listOf(
+                UpstreamApiError(
+                  causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
+                UpstreamApiError(
+                  causedBy = UpstreamApi.NOMIS,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
+              ),
+            ),
+          )
 
-        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+          val encodedIdThatDoesNotExist = URLEncoder.encode(idThatDoesNotExist, StandardCharsets.UTF_8)
+          val result = mockMvc.perform(get("$basePath/$encodedIdThatDoesNotExist")).andReturn()
+
+          result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+        }
+
+        it("does not respond with a 404 when a person was found in one upstream API") {
+          whenever(getPersonService.execute(idThatDoesNotExist)).thenReturn(
+            Response(
+              mapOf("prisonerOffenderSearch" to null),
+              errors = listOf(
+                UpstreamApiError(
+                  causedBy = UpstreamApi.NOMIS,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
+              ),
+            ),
+          )
+
+          val encodedIdThatDoesNotExist = URLEncoder.encode(idThatDoesNotExist, StandardCharsets.UTF_8)
+          val result = mockMvc.perform(get("$basePath/$encodedIdThatDoesNotExist")).andReturn()
+
+          result.response.status.shouldNotBe(HttpStatus.NOT_FOUND.value())
+        }
       }
 
       it("retrieves a person with the matching ID") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -195,7 +195,10 @@ internal class PersonControllerTest(
         it("responds with a 404 when a person cannot be found in both upstream APIs") {
           whenever(getPersonService.execute(idThatDoesNotExist)).thenReturn(
             Response(
-              mapOf("prisonerOffenderSearch" to null),
+              mapOf(
+                "prisonerOffenderSearch" to null,
+                "probationOffenderSearch" to null
+              ),
               errors = listOf(
                 UpstreamApiError(
                   causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
@@ -218,7 +221,10 @@ internal class PersonControllerTest(
         it("does not respond with a 404 when a person was found in one upstream API") {
           whenever(getPersonService.execute(idThatDoesNotExist)).thenReturn(
             Response(
-              mapOf("prisonerOffenderSearch" to null),
+              mapOf(
+                "probationOffenderSearch" to Person("someFirstName", "someLastName"),
+                "prisonerOffenderSearch" to null
+              ),
               errors = listOf(
                 UpstreamApiError(
                   causedBy = UpstreamApi.NOMIS,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -165,14 +165,14 @@ class ProbationOffenderSearchGatewayTest(
     it("returns a person with the matching ID") {
       val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      response.data?.firstName.shouldBe("Jonathan")
-      response.data?.middleName.shouldBe("Echo Fred")
-      response.data?.lastName.shouldBe("Bravo")
-      response.data?.dateOfBirth.shouldBe(LocalDate.parse("1970-02-07"))
-      response.data?.aliases?.first()?.firstName.shouldBe("John")
-      response.data?.aliases?.first()?.middleName.shouldBe("Tom")
-      response.data?.aliases?.first()?.lastName.shouldBe("Wick")
-      response.data?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("2000-02-07"))
+      response?.data?.firstName.shouldBe("Jonathan")
+      response?.data?.middleName.shouldBe("Echo Fred")
+      response?.data?.lastName.shouldBe("Bravo")
+      response?.data?.dateOfBirth.shouldBe(LocalDate.parse("1970-02-07"))
+      response?.data?.aliases?.first()?.firstName.shouldBe("John")
+      response?.data?.aliases?.first()?.middleName.shouldBe("Tom")
+      response?.data?.aliases?.first()?.lastName.shouldBe("Wick")
+      response?.data?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("2000-02-07"))
     }
 
     it("returns a person without aliases when no aliases are found") {
@@ -192,7 +192,7 @@ class ProbationOffenderSearchGatewayTest(
 
       val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      response.data?.aliases.shouldBeEmpty()
+      response?.data?.aliases.shouldBeEmpty()
     }
 
     it("returns null when 400 Bad Request is returned") {
@@ -207,7 +207,7 @@ class ProbationOffenderSearchGatewayTest(
       )
 
       val response = probationOffenderSearchGateway.getPerson(pncId)
-      response.data.shouldBeNull()
+      response?.data.shouldBeNull()
     }
 
     it("returns null when no offenders are returned") {
@@ -218,7 +218,7 @@ class ProbationOffenderSearchGatewayTest(
 
       val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      response.data.shouldBeNull()
+      response?.data.shouldBeNull()
     }
   }
 },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -163,16 +163,16 @@ class ProbationOffenderSearchGatewayTest(
     }
 
     it("returns a person with the matching ID") {
-      val person = probationOffenderSearchGateway.getPerson(pncId)
+      val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      person?.firstName.shouldBe("Jonathan")
-      person?.middleName.shouldBe("Echo Fred")
-      person?.lastName.shouldBe("Bravo")
-      person?.dateOfBirth.shouldBe(LocalDate.parse("1970-02-07"))
-      person?.aliases?.first()?.firstName.shouldBe("John")
-      person?.aliases?.first()?.middleName.shouldBe("Tom")
-      person?.aliases?.first()?.lastName.shouldBe("Wick")
-      person?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("2000-02-07"))
+      response.data?.firstName.shouldBe("Jonathan")
+      response.data?.middleName.shouldBe("Echo Fred")
+      response.data?.lastName.shouldBe("Bravo")
+      response.data?.dateOfBirth.shouldBe(LocalDate.parse("1970-02-07"))
+      response.data?.aliases?.first()?.firstName.shouldBe("John")
+      response.data?.aliases?.first()?.middleName.shouldBe("Tom")
+      response.data?.aliases?.first()?.lastName.shouldBe("Wick")
+      response.data?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("2000-02-07"))
     }
 
     it("returns a person without aliases when no aliases are found") {
@@ -190,9 +190,9 @@ class ProbationOffenderSearchGatewayTest(
         """,
       )
 
-      val person = probationOffenderSearchGateway.getPerson(pncId)
+      val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      person?.aliases.shouldBeEmpty()
+      response.data?.aliases.shouldBeEmpty()
     }
 
     it("returns null when 400 Bad Request is returned") {
@@ -206,9 +206,8 @@ class ProbationOffenderSearchGatewayTest(
         HttpStatus.BAD_REQUEST,
       )
 
-      val person = probationOffenderSearchGateway.getPerson(pncId)
-
-      person?.shouldBeNull()
+      val response = probationOffenderSearchGateway.getPerson(pncId)
+      response.data.shouldBeNull()
     }
 
     it("returns null when no offenders are returned") {
@@ -217,9 +216,9 @@ class ProbationOffenderSearchGatewayTest(
         "[]",
       )
 
-      val person = probationOffenderSearchGateway.getPerson(pncId)
+      val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      person?.shouldBeNull()
+      response.data.shouldBeNull()
     }
   }
 },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -18,6 +18,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGatewa
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ProbationOffenderSearchApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.io.File
 import java.time.LocalDate
 
@@ -165,14 +167,14 @@ class ProbationOffenderSearchGatewayTest(
     it("returns a person with the matching ID") {
       val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      response?.data?.firstName.shouldBe("Jonathan")
-      response?.data?.middleName.shouldBe("Echo Fred")
-      response?.data?.lastName.shouldBe("Bravo")
-      response?.data?.dateOfBirth.shouldBe(LocalDate.parse("1970-02-07"))
-      response?.data?.aliases?.first()?.firstName.shouldBe("John")
-      response?.data?.aliases?.first()?.middleName.shouldBe("Tom")
-      response?.data?.aliases?.first()?.lastName.shouldBe("Wick")
-      response?.data?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("2000-02-07"))
+      response.data?.firstName.shouldBe("Jonathan")
+      response.data?.middleName.shouldBe("Echo Fred")
+      response.data?.lastName.shouldBe("Bravo")
+      response.data?.dateOfBirth.shouldBe(LocalDate.parse("1970-02-07"))
+      response.data?.aliases?.first()?.firstName.shouldBe("John")
+      response.data?.aliases?.first()?.middleName.shouldBe("Tom")
+      response.data?.aliases?.first()?.lastName.shouldBe("Wick")
+      response.data?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("2000-02-07"))
     }
 
     it("returns a person without aliases when no aliases are found") {
@@ -192,7 +194,7 @@ class ProbationOffenderSearchGatewayTest(
 
       val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      response?.data?.aliases.shouldBeEmpty()
+      response.data?.aliases.shouldBeEmpty()
     }
 
     it("returns null when 400 Bad Request is returned") {
@@ -207,7 +209,15 @@ class ProbationOffenderSearchGatewayTest(
       )
 
       val response = probationOffenderSearchGateway.getPerson(pncId)
-      response?.data.shouldBeNull()
+      response.data.shouldBeNull()
+      response.errors.shouldBe(
+        listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+            type = UpstreamApiError.Type.BAD_REQUEST,
+          ),
+        ),
+      )
     }
 
     it("returns null when no offenders are returned") {
@@ -218,7 +228,7 @@ class ProbationOffenderSearchGatewayTest(
 
       val response = probationOffenderSearchGateway.getPerson(pncId)
 
-      response?.data.shouldBeNull()
+      response.data.shouldBeNull()
     }
   }
 },)


### PR DESCRIPTION
Defer the decision to throw a 404 or return an empty list / null. The Response domain object is predictable and easier to manage than custom responses from our gateways.