### PR TITLE
Update Slack notification for pipeline failures to improve clarity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,21 +21,38 @@ slack-fail-post-step: &slack-fail-post-step
         channel: << pipeline.parameters.alerts-slack-channel >>
         custom: |
           {
-            "text": "",
             "blocks": [
               {
-                "type": "section",
+                "type": "header",
                 "text": {
-                  "type": "mrkdwn",
-                  "text": "❌ *Failure* `${CIRCLE_PROJECT_REPONAME}` - `${CIRCLE_JOB}` (Build: #${CIRCLE_BUILD_NUM}) on `${CIRCLE_BRANCH}`"
+                  "type": "plain_text",
+                  "text": ":this-is-fine-fire: ${CIRCLE_JOB} job has failed",
+                  "emoji": true
                 }
+              },
+              {
+                "type": "context",
+                "elements": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "Project: *${CIRCLE_PROJECT_REPONAME}*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "Branch: *${CIRCLE_BRANCH}*"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "Build: *#${CIRCLE_BUILD_NUM}*"
+                  }
+                ]
               },
               {
                 "type": "actions",
                 "elements": [
                   {
                     "type": "button",
-                    "text": { "type": "plain_text", "text": "View Job" },
+                    "text": { "type": "plain_text", "text": "View job" },
                     "url": "${CIRCLE_BUILD_URL}"
                   }
                 ]


### PR DESCRIPTION
## Context

Atm, our Slack notification for pipeline failures are a bit difficult to read with the important information (what job failed) not  prominent enough and the code blocks surrounding information making all the words look the same in the one sentence.

## Changes proposed in this PR

- Update the Slack notification to highlight the failing job as a header and move other information about the failure into a context component. 

Before | After
-- | --
![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/7ddb1740-b628-4d76-9c6e-27020ff034cb) | ![image](https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/520224a7-e96b-4eb2-8647-91119bf41bbe)

