### PR TITLE
Add gender and ethnicity for get a person and person search endpoints

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -419,6 +419,14 @@ components:
           format: date
           example: 1965-12-01
           description: date of birth
+        gender:
+          type: string
+          example: Male
+          description: gender
+        ethnicity:
+          type: string
+          example: Prefer not to say
+          description: ethnicity
     Error:
       type: object
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -515,6 +515,14 @@ components:
           format: date
           example: 1965-12-01
           description: date of birth
+        gender:
+          type: string
+          example: Male
+          description: gender
+        ethnicity:
+          type: string
+          example: "White: Eng./Welsh/Scot./N.Irish/British"
+          description: ethnicity
         aliases:
           type: array
           minItems: 0

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Alias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Alias.kt
@@ -11,4 +11,6 @@ data class Alias(
   val middleName: String? = null,
   @JsonAlias("dob")
   var dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
+  val ethnicity: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -10,6 +10,8 @@ data class Person(
   @JsonAlias("middleNames")
   val middleName: String? = null,
   val dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
+  val ethnicity: String? = null,
   @JsonAlias("offenderAliases")
   val aliases: List<Alias> = listOf(),
   val prisonerId: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import java.time.LocalDate
 
@@ -22,14 +21,7 @@ data class Prisoner(
     dateOfBirth = this.dateOfBirth,
     gender = this.gender,
     ethnicity = this.ethnicity,
-    aliases = this.aliases.map {
-      Alias(
-        it.firstName,
-        it.lastName,
-        it.middleNames,
-        it.dateOfBirth,
-      )
-    },
+    aliases = this.aliases.map { it.toAlias() },
     prisonerId = this.prisonerNumber,
     pncId = this.pncNumber,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
@@ -9,6 +9,8 @@ data class Prisoner(
   val lastName: String,
   val middleNames: String? = null,
   val dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
+  val ethnicity: String? = null,
   val aliases: List<PrisonerAlias> = listOf(),
   val prisonerNumber: String? = null,
   val pncNumber: String? = null,
@@ -18,6 +20,8 @@ data class Prisoner(
     lastName = this.lastName,
     middleName = this.middleNames,
     dateOfBirth = this.dateOfBirth,
+    gender = this.gender,
+    ethnicity = this.ethnicity,
     aliases = this.aliases.map {
       Alias(
         it.firstName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAlias.kt
@@ -8,11 +8,15 @@ data class PrisonerAlias(
   val lastName: String,
   val middleNames: String? = null,
   var dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
+  val ethnicity: String? = null,
 ) {
   fun toAlias(): Alias = Alias(
     firstName = this.firstName,
     lastName = this.lastName,
     middleName = this.middleNames,
     dateOfBirth = this.dateOfBirth,
+    gender = this.gender,
+    ethnicity = this.ethnicity,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAlias.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch
 
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import java.time.LocalDate
 
 data class PrisonerAlias(
@@ -7,4 +8,11 @@ data class PrisonerAlias(
   val lastName: String,
   val middleNames: String? = null,
   var dateOfBirth: LocalDate? = null,
-)
+) {
+  fun toAlias(): Alias = Alias(
+    firstName = this.firstName,
+    lastName = this.lastName,
+    middleName = this.middleNames,
+    dateOfBirth = this.dateOfBirth,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -10,6 +10,7 @@ data class Offender(
   val middleNames: List<String> = listOf(),
   val dateOfBirth: LocalDate? = null,
   val gender: String? = null,
+  val offenderProfile: OffenderProfile = OffenderProfile(),
   val offenderAliases: List<OffenderAlias> = listOf(),
   val contactDetails: ContactDetails? = ContactDetails(),
   val otherIds: OtherIds = OtherIds(),
@@ -20,6 +21,7 @@ data class Offender(
     middleName = this.middleNames.joinToString(" "),
     dateOfBirth = this.dateOfBirth,
     gender = this.gender,
+    ethnicity = this.offenderProfile.ethnicity,
     aliases = this.offenderAliases.map {
       Alias(
         it.firstName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -9,6 +9,7 @@ data class Offender(
   val surname: String,
   val middleNames: List<String> = listOf(),
   val dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
   val offenderAliases: List<OffenderAlias> = listOf(),
   val contactDetails: ContactDetails? = ContactDetails(),
   val otherIds: OtherIds = OtherIds(),
@@ -18,6 +19,7 @@ data class Offender(
     lastName = this.surname,
     middleName = this.middleNames.joinToString(" "),
     dateOfBirth = this.dateOfBirth,
+    gender = this.gender,
     aliases = this.offenderAliases.map {
       Alias(
         it.firstName,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import java.time.LocalDate
 
@@ -22,14 +21,7 @@ data class Offender(
     dateOfBirth = this.dateOfBirth,
     gender = this.gender,
     ethnicity = this.offenderProfile.ethnicity,
-    aliases = this.offenderAliases.map {
-      Alias(
-        it.firstName,
-        it.surname,
-        it.middleNames.joinToString(" "),
-        it.dateOfBirth,
-      )
-    },
+    aliases = this.offenderAliases.map { it.toAlias() },
     pncId = otherIds.pncNumber,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import java.time.LocalDate
 
 data class OffenderAlias(
@@ -7,4 +8,11 @@ data class OffenderAlias(
   val surname: String,
   val middleNames: List<String> = listOf(),
   var dateOfBirth: LocalDate? = null,
-)
+) {
+  fun toAlias(): Alias = Alias(
+    firstName = this.firstName,
+    lastName = this.surname,
+    middleName = this.middleNames.joinToString(" "),
+    dateOfBirth = this.dateOfBirth,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
@@ -8,11 +8,13 @@ data class OffenderAlias(
   val surname: String,
   val middleNames: List<String> = listOf(),
   var dateOfBirth: LocalDate? = null,
+  val gender: String? = null,
 ) {
   fun toAlias(): Alias = Alias(
     firstName = this.firstName,
     lastName = this.surname,
     middleName = this.middleNames.joinToString(" "),
     dateOfBirth = this.dateOfBirth,
+    gender = this.gender,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderProfile.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderProfile.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+data class OffenderProfile(
+  val ethnicity: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -19,7 +19,7 @@ class GetPersonService(
     return Response(
       data = mapOf(
         "prisonerOffenderSearch" to responseFromPrisonerOffenderSearch.data.firstOrNull(),
-        "probationOffenderSearch" to personFromProbationOffenderSearch?.data,
+        "probationOffenderSearch" to personFromProbationOffenderSearch.data,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PersonControllerTest.kt
@@ -112,18 +112,22 @@ internal class PersonControllerTest(
               "lastName":"Allen",
               "middleName":"Jonas",
               "dateOfBirth":"2023-03-01",
+              "gender": null,
+              "ethnicity": null,
               "aliases":[],
               "prisonerId": null,
               "pncId": null
             },
             {
-               "firstName":"Barry",
-               "lastName":"Allen",
-               "middleName":"Rock",
-               "dateOfBirth":"2022-07-22",
-               "aliases":[],
-               "prisonerId": null,
-               "pncId": null
+              "firstName":"Barry",
+              "lastName":"Allen",
+              "middleName":"Rock",
+              "dateOfBirth":"2022-07-22",
+              "gender": null,
+              "ethnicity": null,
+              "aliases":[],
+              "prisonerId": null,
+              "pncId": null
             }
           ]
           """.removeWhitespaceAndNewlines(),
@@ -258,6 +262,8 @@ internal class PersonControllerTest(
             "lastName": "Sob",
             "middleName": null,
             "dateOfBirth": null,
+            "gender": null,
+            "ethnicity": null,
             "aliases": [],
             "prisonerId": null,
             "pncId": null
@@ -267,6 +273,8 @@ internal class PersonControllerTest(
             "lastName": "Sobbers",
             "middleName": null,
             "dateOfBirth": null,
+            "gender": null,
+            "ethnicity": null,
             "aliases": [],
             "prisonerId": null,
             "pncId": null
@@ -442,24 +450,24 @@ internal class PersonControllerTest(
 
         result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
       }
-    }
 
-    it("responds with a 200 OK status when person is found in one upstream API but not another") {
-      whenever(getAddressesForPersonService.execute(pncId)).thenReturn(
-        Response(
-          data = emptyList(),
-          errors = listOf(
-            UpstreamApiError(
-              causedBy = UpstreamApi.NOMIS,
-              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+      it("responds with a 200 OK status when person is found in one upstream API but not another") {
+        whenever(getAddressesForPersonService.execute(pncId)).thenReturn(
+          Response(
+            data = emptyList(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
             ),
           ),
-        ),
-      )
+        )
 
-      val result = mockMvc.perform(get("$basePath/$encodedPncId/addresses")).andReturn()
+        val result = mockMvc.perform(get("$basePath/$encodedPncId/addresses")).andReturn()
 
-      result.response.status.shouldBe(HttpStatus.OK.value())
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
     }
   },
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAliasTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAliasTest.kt
@@ -13,6 +13,8 @@ class PrisonerAliasTest : DescribeSpec(
           lastName = "Alias Last Name",
           middleNames = "Alias Middle Names",
           dateOfBirth = LocalDate.parse("2023-01-01"),
+          gender = "Gender",
+          ethnicity = "Ethnicity",
         )
 
         val alias = prisonerAlias.toAlias()
@@ -21,6 +23,8 @@ class PrisonerAliasTest : DescribeSpec(
         alias.lastName.shouldBe(prisonerAlias.lastName)
         alias.middleName.shouldBe(prisonerAlias.middleNames)
         alias.dateOfBirth.shouldBe(prisonerAlias.dateOfBirth)
+        alias.gender.shouldBe(prisonerAlias.gender)
+        alias.ethnicity.shouldBe(prisonerAlias.ethnicity)
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAliasTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerAliasTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class PrisonerAliasTest : DescribeSpec(
+  {
+    describe("#toAlias") {
+      it("maps one-to-one attributes to alias attributes") {
+        val prisonerAlias = PrisonerAlias(
+          firstName = "Alias First Name",
+          lastName = "Alias Last Name",
+          middleNames = "Alias Middle Names",
+          dateOfBirth = LocalDate.parse("2023-01-01"),
+        )
+
+        val alias = prisonerAlias.toAlias()
+
+        alias.firstName.shouldBe(prisonerAlias.firstName)
+        alias.lastName.shouldBe(prisonerAlias.lastName)
+        alias.middleName.shouldBe(prisonerAlias.middleNames)
+        alias.dateOfBirth.shouldBe(prisonerAlias.dateOfBirth)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class PrisonerTest : DescribeSpec(
+  {
+    describe("#toPerson") {
+      it("maps one-to-one attributes to person attributes") {
+        val prisoner = Prisoner(
+          firstName = "First Name",
+          lastName = "Last Name",
+          middleNames = "Middle Name",
+          dateOfBirth = LocalDate.parse("2023-03-01"),
+          prisonerNumber = "prisonerNumber",
+          pncNumber = "pncNumber",
+          aliases = listOf(
+            PrisonerAlias(
+              firstName = "Alias First Name",
+              lastName = "Alias Last Name",
+              middleNames = "Alias Middle Names",
+              dateOfBirth = LocalDate.parse("2023-01-01"),
+            ),
+          ),
+        )
+
+        val person = prisoner.toPerson()
+
+        person.firstName.shouldBe(prisoner.firstName)
+        person.lastName.shouldBe(prisoner.lastName)
+        person.middleName.shouldBe(prisoner.middleNames)
+        person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
+        person.aliases.first().firstName.shouldBe("Alias First Name")
+        person.aliases.first().lastName.shouldBe("Alias Last Name")
+        person.aliases.first().middleName.shouldBe("Alias Middle Names")
+        person.aliases.first().dateOfBirth.shouldBe(LocalDate.parse("2023-01-01"))
+        person.prisonerId.shouldBe(prisoner.prisonerNumber)
+        person.pncId.shouldBe(prisoner.pncNumber)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
@@ -13,6 +13,8 @@ class PrisonerTest : DescribeSpec(
           lastName = "Last Name",
           middleNames = "Middle Name",
           dateOfBirth = LocalDate.parse("2023-03-01"),
+          gender = "Gender",
+          ethnicity = "Ethnicity",
           prisonerNumber = "prisonerNumber",
           pncNumber = "pncNumber",
           aliases = listOf(
@@ -31,6 +33,8 @@ class PrisonerTest : DescribeSpec(
         person.lastName.shouldBe(prisoner.lastName)
         person.middleName.shouldBe(prisoner.middleNames)
         person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
+        person.gender.shouldBe(prisoner.gender)
+        person.ethnicity.shouldBe(prisoner.ethnicity)
         person.aliases.first().firstName.shouldBe("Alias First Name")
         person.aliases.first().lastName.shouldBe("Alias Last Name")
         person.aliases.first().middleName.shouldBe("Alias Middle Names")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffender
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import java.time.LocalDate
 
 class PrisonerTest : DescribeSpec(
@@ -18,12 +20,7 @@ class PrisonerTest : DescribeSpec(
           prisonerNumber = "prisonerNumber",
           pncNumber = "pncNumber",
           aliases = listOf(
-            PrisonerAlias(
-              firstName = "Alias First Name",
-              lastName = "Alias Last Name",
-              middleNames = "Alias Middle Names",
-              dateOfBirth = LocalDate.parse("2023-01-01"),
-            ),
+            PrisonerAlias(firstName = "Alias First Name", lastName = "Alias Last Name"),
           ),
         )
 
@@ -35,10 +32,7 @@ class PrisonerTest : DescribeSpec(
         person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
         person.gender.shouldBe(prisoner.gender)
         person.ethnicity.shouldBe(prisoner.ethnicity)
-        person.aliases.first().firstName.shouldBe("Alias First Name")
-        person.aliases.first().lastName.shouldBe("Alias Last Name")
-        person.aliases.first().middleName.shouldBe("Alias Middle Names")
-        person.aliases.first().dateOfBirth.shouldBe(LocalDate.parse("2023-01-01"))
+        person.aliases.first().shouldBeTypeOf<Alias>()
         person.prisonerId.shouldBe(prisoner.prisonerNumber)
         person.pncId.shouldBe(prisoner.pncNumber)
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAliasTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAliasTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class OffenderAliasTest : DescribeSpec(
+  {
+    describe("#toAlias") {
+      it("maps one-to-one attributes to alias attributes") {
+        val offenderAlias = OffenderAlias(
+          firstName = "Alias First Name",
+          surname = "Alias Last Name",
+          middleNames = listOf("Alias", "Middle", "Names"),
+          dateOfBirth = LocalDate.parse("2023-01-01"),
+        )
+
+        val alias = offenderAlias.toAlias()
+
+        alias.firstName.shouldBe(offenderAlias.firstName)
+        alias.lastName.shouldBe(offenderAlias.surname)
+        alias.middleName.shouldBe("Alias Middle Names")
+        alias.dateOfBirth.shouldBe(offenderAlias.dateOfBirth)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAliasTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAliasTest.kt
@@ -13,6 +13,7 @@ class OffenderAliasTest : DescribeSpec(
           surname = "Alias Last Name",
           middleNames = listOf("Alias", "Middle", "Names"),
           dateOfBirth = LocalDate.parse("2023-01-01"),
+          gender = "Gender",
         )
 
         val alias = offenderAlias.toAlias()
@@ -21,6 +22,7 @@ class OffenderAliasTest : DescribeSpec(
         alias.lastName.shouldBe(offenderAlias.surname)
         alias.middleName.shouldBe("Alias Middle Names")
         alias.dateOfBirth.shouldBe(offenderAlias.dateOfBirth)
+        alias.gender.shouldBe(offenderAlias.gender)
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffende
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
 import java.time.LocalDate
 
 class OffenderTest : DescribeSpec(
@@ -16,12 +18,7 @@ class OffenderTest : DescribeSpec(
           gender = "Gender",
           offenderProfile = OffenderProfile(ethnicity = "Ethnicity"),
           offenderAliases = listOf(
-            OffenderAlias(
-              firstName = "Alias First Name",
-              surname = "Alias Surname",
-              middleNames = listOf("Alias Middle Name"),
-              dateOfBirth = LocalDate.parse("2023-03-01"),
-            ),
+            OffenderAlias(firstName = "Alias First Name", surname = "Alias Surname"),
           ),
           otherIds = OtherIds(pncNumber = "pncNumber"),
         )
@@ -34,10 +31,7 @@ class OffenderTest : DescribeSpec(
         person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
         person.gender.shouldBe(prisoner.gender)
         person.ethnicity.shouldBe(prisoner.offenderProfile.ethnicity)
-        person.aliases.first().firstName.shouldBe("Alias First Name")
-        person.aliases.first().lastName.shouldBe("Alias Surname")
-        person.aliases.first().middleName.shouldBe("Alias Middle Name")
-        person.aliases.first().dateOfBirth.shouldBe(LocalDate.parse("2023-03-01"))
+        person.aliases.first().shouldBeTypeOf<Alias>()
         person.pncId.shouldBe(prisoner.otherIds.pncNumber)
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
@@ -14,6 +14,7 @@ class OffenderTest : DescribeSpec(
           middleNames = listOf("Middle Name"),
           dateOfBirth = LocalDate.parse("2023-03-01"),
           gender = "Gender",
+          offenderProfile = OffenderProfile(ethnicity = "Ethnicity"),
           offenderAliases = listOf(
             OffenderAlias(
               firstName = "Alias First Name",
@@ -32,6 +33,7 @@ class OffenderTest : DescribeSpec(
         person.middleName.shouldBe("Middle Name")
         person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
         person.gender.shouldBe(prisoner.gender)
+        person.ethnicity.shouldBe(prisoner.offenderProfile.ethnicity)
         person.aliases.first().firstName.shouldBe("Alias First Name")
         person.aliases.first().lastName.shouldBe("Alias Surname")
         person.aliases.first().middleName.shouldBe("Alias Middle Name")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
@@ -1,0 +1,41 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class OffenderTest : DescribeSpec(
+  {
+    describe("#toPerson") {
+      it("maps one-to-one attributes to person attributes") {
+        val prisoner = Offender(
+          firstName = "First Name",
+          surname = "Surname",
+          middleNames = listOf("Middle Name"),
+          dateOfBirth = LocalDate.parse("2023-03-01"),
+          offenderAliases = listOf(
+            OffenderAlias(
+              firstName = "Alias First Name",
+              surname = "Alias Surname",
+              middleNames = listOf("Alias Middle Name"),
+              dateOfBirth = LocalDate.parse("2023-03-01"),
+            ),
+          ),
+          otherIds = OtherIds(pncNumber = "pncNumber"),
+        )
+
+        val person = prisoner.toPerson()
+
+        person.firstName.shouldBe(prisoner.firstName)
+        person.lastName.shouldBe(prisoner.surname)
+        person.middleName.shouldBe("Middle Name")
+        person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
+        person.aliases.first().firstName.shouldBe("Alias First Name")
+        person.aliases.first().lastName.shouldBe("Alias Surname")
+        person.aliases.first().middleName.shouldBe("Alias Middle Name")
+        person.aliases.first().dateOfBirth.shouldBe(LocalDate.parse("2023-03-01"))
+        person.pncId.shouldBe(prisoner.otherIds.pncNumber)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
@@ -13,6 +13,7 @@ class OffenderTest : DescribeSpec(
           surname = "Surname",
           middleNames = listOf("Middle Name"),
           dateOfBirth = LocalDate.parse("2023-03-01"),
+          gender = "Gender",
           offenderAliases = listOf(
             OffenderAlias(
               firstName = "Alias First Name",
@@ -30,6 +31,7 @@ class OffenderTest : DescribeSpec(
         person.lastName.shouldBe(prisoner.surname)
         person.middleName.shouldBe("Middle Name")
         person.dateOfBirth.shouldBe(prisoner.dateOfBirth)
+        person.gender.shouldBe(prisoner.gender)
         person.aliases.first().firstName.shouldBe("Alias First Name")
         person.aliases.first().lastName.shouldBe("Alias Surname")
         person.aliases.first().middleName.shouldBe("Alias Middle Name")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -63,6 +63,8 @@ class PersonSmokeTest : DescribeSpec(
               "lastName": "Larsen",
               "middleName": "John James",
               "dateOfBirth": "1975-04-02",
+              "gender": "Female",
+              "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
               "aliases": [
                 {
                   "firstName": "Robert",
@@ -79,6 +81,8 @@ class PersonSmokeTest : DescribeSpec(
               "lastName": "string",
               "middleName": "string",
               "dateOfBirth": "2019-08-24",
+              "gender": "string",
+              "ethnicity": "string",
               "aliases": [
                 {
                   "firstName": "string",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PersonSmokeTest.kt
@@ -49,7 +49,7 @@ class PersonSmokeTest : DescribeSpec(
       )
     }
 
-    it("returns a person from NOMIS, Prisoner Offender Search and Probation Offender Search") {
+    it("returns a person from Prisoner Offender Search and Probation Offender Search") {
       val response = httpClient.send(
         httpRequest.uri(URI.create("$baseUrl/$basePath/$encodedPncId")).build(),
         HttpResponse.BodyHandlers.ofString(),
@@ -70,7 +70,9 @@ class PersonSmokeTest : DescribeSpec(
                   "firstName": "Robert",
                   "lastName": "Lorsen",
                   "middleName": "Trevor",
-                  "dateOfBirth": "1975-04-02"
+                  "dateOfBirth": "1975-04-02",
+                  "gender": "Male",
+                  "ethnicity": "White : Irish"
                 }
               ],
               "prisonerId": "A1234AA",
@@ -88,7 +90,9 @@ class PersonSmokeTest : DescribeSpec(
                   "firstName": "string",
                   "lastName": "string",
                   "middleName": "string",
-                  "dateOfBirth": "2019-08-24"
+                  "dateOfBirth": "2019-08-24",
+                  "gender": "string",
+                  "ethnicity": null
                 }
               ],
               "prisonerId": null,


### PR DESCRIPTION
## Context

We're not returning all the attributes available for an alias in our `GET /v1/persons/{pncId}` and `GET /v1/persons` API endpoints.

## Changes proposed in this PR

- Add `gender` and `ethnicity` to our person and alias models and the ones for Prisoner Offender Search and Probation Offender Search (the two upstream APIs we use for endpoints).
- Add tests for alias models and refactor so `PrisonerAlias` and `OffenderAlias` has a `toAlias` method so this logic is tested separately (follows how we do addresses).
- Update our OpenAPI spec with these additions.

## Next steps

- Add a query parameter to allow a consumer to decide whether we should search within aliases too. 