### PR TITLE
Implement basic offence information endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -144,36 +144,6 @@ paths:
                 PersonNotFoundError:
                   $ref: "#/components/examples/PersonNotFoundError"
 
-  /v1/persons/{encodedPncId}/addresses:
-    get:
-      tags:
-        - persons
-      summary: Returns addresses associated with a person.
-      parameters:
-        - $ref: "#/components/parameters/EncodedPncId"
-      responses:
-        "200":
-          description: Successfully found a person with the provided PNC ID.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: array
-                    minItems: 0
-                    items:
-                      $ref: "#/components/schemas/Address"
-        "404":
-          description: Failed to find a person with the provided PNC ID.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-              examples:
-                PersonNotFoundError:
-                  $ref: "#/components/examples/PersonNotFoundError"
-
   /v1/images/{id}:
     get:
       tags:
@@ -202,6 +172,102 @@ paths:
               examples:
                 ImageNotFoundError:
                   $ref: "#/components/examples/ImageNotFoundError"
+
+  /v1/persons/{encodedPncId}/addresses:
+    get:
+      tags:
+        - persons
+      summary: Returns addresses associated with a person.
+      parameters:
+        - $ref: "#/components/parameters/EncodedPncId"
+        - in: query
+          name: page
+          schema:
+            type: number
+            minimum: 0
+            default: 1
+          required: false
+          description: The page number (starting from 1)
+        - in: query
+          name: per_page
+          schema:
+            type: number
+            minimum: 1
+            default: 10
+          required: false
+          description: The maximum number of results for a page
+      responses:
+        "200":
+          description: Successfully found a person with the provided PNC ID.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    minItems: 0
+                    items:
+                      $ref: "#/components/schemas/Address"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "404":
+          description: Failed to find a person with the provided PNC ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                PersonNotFoundError:
+                  $ref: "#/components/examples/PersonNotFoundError"
+
+  /v1/persons/{encodedPncId}/offences:
+    get:
+      tags:
+        - persons
+      summary: Returns offences associated with a person.
+      parameters:
+        - $ref: "#/components/parameters/EncodedPncId"
+        - in: query
+          name: page
+          schema:
+            type: number
+            minimum: 0
+            default: 1
+          required: false
+          description: The page number (starting from 1)
+        - in: query
+          name: per_page
+          schema:
+            type: number
+            minimum: 1
+            default: 10
+          required: false
+          description: The maximum number of results for a page
+      responses:
+        "200":
+          description: Successfully found a person with the provided PNC ID.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    minItems: 0
+                    items:
+                      $ref: "#/components/schemas/Offence"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "404":
+          description: Failed to find a person with the provided PNC ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                PersonNotFoundError:
+                  $ref: "#/components/examples/PersonNotFoundError"
 
   /{TBC}/v1/persons/{Id}/accommodations:
     get:
@@ -242,15 +308,6 @@ paths:
   /{TBC}/v1/persons/{Id}/licenses:
     get:
       summary: FUTURE ENDPOINT - Returns license conditions associated with a person.
-      parameters:
-        - $ref: "#/components/parameters/Id"
-      responses:
-        "200":
-          description: Success.
-
-  /{TBC}/v1/persons/{Id}/offences:
-    get:
-      summary: FUTURE ENDPOINT -  Returns offences associated with a person.
       parameters:
         - $ref: "#/components/parameters/Id"
       responses:
@@ -475,6 +532,22 @@ components:
           type: string
           example: OFF_BKG
           description: The type describes the contextual foci, context or scenario within which the image was taken. It could be for a particular purpose or capturing the results of a particular type of incident.
+    Offence:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date
+          example: 1965-12-01
+          description: Date the offence took place or start date if the offence occurred over a period of time
+        code:
+          type: string
+          example: RR84070
+          description: CJS offence code
+        description:
+          type: string
+          example: Commit an act / series of acts with intent to pervert the course of public justice
+          description: Description associated with the CJS offence code
     Pagination:
       type: object
       properties:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
@@ -1,7 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
 
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
@@ -26,12 +30,10 @@ class OffencesController(
     val pncId = encodedPncId.decodeUrlCharacters()
     val response = getOffencesForPersonService.execute(pncId)
 
-    if (
-      response!!.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS)
-    ) { // REMOVE !! above
+    if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS)) {
       throw EntityNotFoundException("Could not find person with id: $pncId")
     }
 
-    return response!!.data.paginateWith(page, perPage) // remove the !!
+    return response.data.paginateWith(page, perPage)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetOffencesForPersonService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.PaginatedResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.paginateWith
+
+@RestController
+@RequestMapping("/v1/persons")
+class OffencesController(
+  @Autowired val getOffencesForPersonService: GetOffencesForPersonService,
+) {
+
+  @GetMapping("{encodedPncId}/offences")
+  fun getPersonOffences(
+    @PathVariable encodedPncId: String,
+    @RequestParam(required = false, defaultValue = "1", name = "page") page: Int,
+    @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
+  ): PaginatedResponse<Offence> {
+    val pncId = encodedPncId.decodeUrlCharacters()
+    val response = getOffencesForPersonService.execute(pncId)
+
+    if (
+      response!!.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS)
+    ) { // REMOVE !! above
+      throw EntityNotFoundException("Could not find person with id: $pncId")
+    }
+
+    return response!!.data.paginateWith(page, perPage) // remove the !!
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
 
 import jakarta.validation.ValidationException
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -9,7 +9,13 @@ import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.ImageDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Offender
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Address as AddressFromNomis

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -9,12 +9,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Address
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.*
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.ImageDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Offender
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Address as AddressFromNomis
@@ -93,6 +88,10 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
         ),
       )
     }
+  }
+
+  fun getOffencesForPerson(id: String): Response<List<Offence>> {
+    return Response(data = emptyList())
   }
 
   private fun authenticationHeader(): Map<String, String> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+import java.time.LocalDate
+
+data class Offence(
+  val date: LocalDate?,
+  val code: String?,
+  val description: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 import java.time.LocalDate
 
 data class Offence(
-  val date: LocalDate?,
-  val code: String?,
-  val description: String?,
+  val date: LocalDate,
+  val code: String,
+  val description: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetail.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import java.time.LocalDate
+
+data class OffenceHistoryDetail(
+  val offenceDate: LocalDate,
+  val offenceCode: String,
+  val offenceDescription: String,
+) {
+  fun toOffence(): Offence = Offence(
+    date = offenceDate,
+    code = offenceCode,
+    description = offenceDescription,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+
+@Service
+class GetOffencesForPersonService(
+  @Autowired val nomisGateway: NomisGateway,
+) {
+  fun execute(pncId: String): Response<List<Offence>>? { // TAKE OFF THE NULLABLE ?
+    return null
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -3,14 +3,18 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 
 @Service
 class GetOffencesForPersonService(
   @Autowired val nomisGateway: NomisGateway,
+  @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
 ) {
-  fun execute(pncId: String): Response<List<Offence>>? { // TAKE OFF THE NULLABLE ?
-    return null
+  fun execute(pncId: String): Response<List<Offence>> {
+    val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
+
+    return nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().prisonerId!!)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
+
+import io.kotest.assertions.json.shouldContainJsonKeyValue
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetOffencesForPersonService
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+
+@WebMvcTest(controllers = [OffencesController::class])
+internal class OffencesControllerTest(
+  @Autowired val mockMvc: MockMvc,
+  @MockBean val getOffencesForPersonService: GetOffencesForPersonService,
+) : DescribeSpec(
+  {
+    val pncId = "9999/11111A"
+    val encodedPncId = URLEncoder.encode(pncId, StandardCharsets.UTF_8)
+    val path = "/v1/persons/$encodedPncId/offences"
+
+    describe("GET $path") {
+      beforeTest {
+        Mockito.reset(getOffencesForPersonService)
+        whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
+          Response(
+            data = listOf(
+              Offence(
+                date = LocalDate.parse("9999-01-01"),
+                code = "RR99999",
+                description = "This is a description of an offence.",
+              ),
+            ),
+          ),
+        )
+      }
+
+      it("responds with a 200 OK status") {
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+
+      it("retrieves the offences for a person with the matching ID") {
+        mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+
+        verify(getOffencesForPersonService, VerificationModeFactory.times(1)).execute(pncId)
+      }
+
+      it("returns the offences for a person with the matching ID") {
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+
+        result.response.contentAsString.shouldBe(
+          """
+        {
+          "data": [
+            {
+              "date": "9999-01-01",
+              "code": "RR99999",
+              "description": "This is a description of an offence."
+            }
+          ]
+        }
+        """.removeWhitespaceAndNewlines(),
+        )
+      }
+
+      it("returns an empty list embedded in a JSON object when no offences are found") {
+        val pncIdForPersonWithNoOffences = "0000/11111A"
+        val encodedPncIdForPersonWithNoOffences =
+          URLEncoder.encode(pncIdForPersonWithNoOffences, StandardCharsets.UTF_8)
+        val path = "/v1/persons/$encodedPncIdForPersonWithNoOffences/offences"
+
+        whenever(getOffencesForPersonService.execute(pncIdForPersonWithNoOffences)).thenReturn(
+          Response(
+            data = emptyList(),
+          ),
+        )
+
+        val result =
+          mockMvc.perform(MockMvcRequestBuilders.get("$path"))
+            .andReturn()
+
+        result.response.contentAsString.shouldContain("\"data\":[]".removeWhitespaceAndNewlines())
+      }
+
+      it("responds with a 404 NOT FOUND status when person isn't found in the upstream API") {
+        whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
+          Response(
+            data = emptyList(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+          ),
+        )
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
+
+      it("returns paginated results") {
+        whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
+          Response(
+            data =
+            List(20) { i ->
+              Offence(
+                date = LocalDate.parse("9999-01-01"),
+                code = "RR99999",
+                description = "This is a description of an offence.",
+              )
+            },
+          ),
+        )
+
+        val result =
+          mockMvc.perform(MockMvcRequestBuilders.get("$path&page=3&perPage=5"))
+            .andReturn()
+
+        result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.page", 3)
+        result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.totalPages", 4)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -15,7 +15,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetOffencesForPersonService
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -62,9 +62,8 @@ internal class OffencesControllerTest(
       it("returns the offences for a person with the matching ID") {
         val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
 
-        result.response.contentAsString.shouldBe(
+        result.response.contentAsString.shouldContain(
           """
-        {
           "data": [
             {
               "date": "9999-01-01",
@@ -72,7 +71,6 @@ internal class OffencesControllerTest(
               "description": "This is a description of an offence."
             }
           ]
-        }
         """.removeWhitespaceAndNewlines(),
         )
       }
@@ -118,7 +116,7 @@ internal class OffencesControllerTest(
         whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
           Response(
             data =
-            List(20) { i ->
+            List(20) {
               Offence(
                 date = LocalDate.parse("9999-01-01"),
                 code = "RR99999",
@@ -129,11 +127,11 @@ internal class OffencesControllerTest(
         )
 
         val result =
-          mockMvc.perform(MockMvcRequestBuilders.get("$path&page=3&perPage=5"))
+          mockMvc.perform(MockMvcRequestBuilders.get("$path?page=1&perPage=10"))
             .andReturn()
 
-        result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.page", 3)
-        result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.totalPages", 4)
+        result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.page", 1)
+        result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.totalPages", 2)
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
 
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.core.spec.style.DescribeSpec

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetOffencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetOffencesForPersonTest.kt
@@ -71,36 +71,34 @@ class GetOffencesForPersonTest(
         nomisApiMockServer.stop()
       }
 
-      describe("#getOffences") {
-        it("authenticates using HMPPS Auth with credentials") {
-          nomisGateway.getOffencesForPerson(offenderNo)
+      it("authenticates using HMPPS Auth with credentials") {
+        nomisGateway.getOffencesForPerson(offenderNo)
 
-          verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
-        }
+        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+      }
 
-        it("returns offence history for the matching person ID") {
-          val response = nomisGateway.getOffencesForPerson(offenderNo)
+      it("returns offence history for the matching person ID") {
+        val response = nomisGateway.getOffencesForPerson(offenderNo)
 
-          response.data.count().shouldBeGreaterThan(0)
-        }
+        response.data.count().shouldBeGreaterThan(0)
+      }
 
-        it("returns a person with an empty list of offences when no offences are found") {
-          nomisApiMockServer.stubGetOffencesForPerson(offenderNo, "[]")
+      it("returns a person with an empty list of offences when no offences are found") {
+        nomisApiMockServer.stubGetOffencesForPerson(offenderNo, "[]")
 
-          val response = nomisGateway.getOffencesForPerson(offenderNo)
+        val response = nomisGateway.getOffencesForPerson(offenderNo)
 
-          response.data.shouldBeEmpty()
-        }
+        response.data.shouldBeEmpty()
+      }
 
-        it("returns an error when 404 Not Found is returned because no person is found") {
-          nomisApiMockServer.stubGetOffencesForPerson(offenderNo, "", HttpStatus.NOT_FOUND)
+      it("returns an error when 404 Not Found is returned because no person is found") {
+        nomisApiMockServer.stubGetOffencesForPerson(offenderNo, "", HttpStatus.NOT_FOUND)
 
-          val response = nomisGateway.getOffencesForPerson(offenderNo)
+        val response = nomisGateway.getOffencesForPerson(offenderNo)
 
-          response.errors.shouldHaveSize(1)
-          response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
-          response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
-        }
+        response.errors.shouldHaveSize(1)
+        response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
+        response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetOffencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetOffencesForPersonTest.kt
@@ -1,0 +1,211 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.nomis
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import java.io.File
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [NomisGateway::class],
+)
+class GetOffencesForPersonTest(
+  @MockBean val hmppsAuthGateway: HmppsAuthGateway,
+  val nomisGateway: NomisGateway,
+) :
+  DescribeSpec({
+    val nomisApiMockServer = NomisApiMockServer()
+    val offenderNo = "zyx987"
+
+    beforeEach {
+      nomisApiMockServer.start()
+      nomisApiMockServer.stubGetOffences(
+        offenderNo,
+        // INSERT BODY
+      )
+
+      Mockito.reset(hmppsAuthGateway)
+      whenever(hmppsAuthGateway.getClientToken("NOMIS")).thenReturn(HmppsAuthMockServer.TOKEN)
+    }
+
+    afterTest {
+      nomisApiMockServer.stop()
+    }
+
+    describe("#getOffences") {
+      it("authenticates using HMPPS Auth with credentials") {
+        nomisGateway.getOffences(offenderNo)
+
+        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+      }
+
+      it("returns a person with the matching ID") {
+        val person = nomisGateway.getPerson(offenderNo)
+
+        person?.firstName.shouldBe("John")
+        person?.middleName.shouldBe("Muriel")
+        person?.lastName.shouldBe("Smith")
+        person?.dateOfBirth.shouldBe(LocalDate.parse("1970-03-15"))
+        person?.aliases?.first()?.firstName.shouldBe("Joey")
+        person?.aliases?.first()?.middleName.shouldBe("Martin")
+        person?.aliases?.first()?.lastName.shouldBe("Smiles")
+        person?.aliases?.first()?.dateOfBirth.shouldBe(LocalDate.parse("1975-10-12"))
+      }
+
+      it("returns a person without aliases when no aliases are found") {
+        nomisApiMockServer.stubGetOffender(
+          offenderNo,
+          """
+          {
+            "offenderNo": "$offenderNo",
+            "firstName": "John",
+            "lastName": "Smith",
+            "aliases": []
+          }
+          """,
+        )
+
+        val person = nomisGateway.getPerson(offenderNo)
+
+        person?.aliases.shouldBeEmpty()
+      }
+
+      it("returns null when 400 Bad Request is returned") {
+        nomisApiMockServer.stubGetOffender(
+          offenderNo,
+          """
+          {
+            "developerMessage": "reason for bad request"
+          }
+          """,
+          HttpStatus.BAD_REQUEST,
+        )
+
+        val person = nomisGateway.getPerson(offenderNo)
+
+        person?.shouldBeNull()
+      }
+
+      it("returns null when 404 Not Found is returned") {
+        nomisApiMockServer.stubGetOffender(
+          offenderNo,
+          """
+          {
+            "developerMessage": "cannot find person"
+          }
+          """,
+          HttpStatus.NOT_FOUND,
+        )
+
+        val person = nomisGateway.getPerson(offenderNo)
+
+        person?.shouldBeNull()
+      }
+    }
+
+    describe("#getPersonImageMetadata") {
+      beforeTest {
+        nomisApiMockServer.stubGetOffenderImageDetails(
+          offenderNo,
+          """
+          [
+            {
+              "imageId": 24213,
+              "active": true,
+              "captureDateTime": "2008-08-27T16:35:00",
+              "imageView": "FACE",
+              "imageOrientation": "FRONT",
+              "imageType": "OFF_BKG"
+            }
+          ]
+        """,
+        )
+      }
+
+      it("authenticates using HMPPS Auth with credentials") {
+        nomisGateway.getImageMetadataForPerson(offenderNo)
+
+        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+      }
+
+      it("returns image metadata for the matching person ID") {
+        val response = nomisGateway.getImageMetadataForPerson(offenderNo)
+
+        response.data.first().active.shouldBe(true)
+        response.data.first().captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
+        response.data.first().view.shouldBe("FACE")
+        response.data.first().orientation.shouldBe("FRONT")
+        response.data.first().type.shouldBe("OFF_BKG")
+      }
+
+      it("returns a person without image metadata when no images are found") {
+        nomisApiMockServer.stubGetOffenderImageDetails(offenderNo, "[]")
+
+        val response = nomisGateway.getImageMetadataForPerson(offenderNo)
+
+        response.data.shouldBeEmpty()
+      }
+
+      it("returns an error when 404 Not Found is returned") {
+        nomisApiMockServer.stubGetOffenderImageDetails(offenderNo, "", HttpStatus.NOT_FOUND)
+
+        val response = nomisGateway.getImageMetadataForPerson(offenderNo)
+
+        response.errors.shouldHaveSize(1)
+        response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
+        response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
+      }
+    }
+
+    describe("#getImageData") {
+      val imageId = 5678
+
+      beforeTest {
+        nomisApiMockServer.stubGetImageData(imageId)
+      }
+
+      it("authenticates using HMPPS Auth with credentials") {
+        nomisGateway.getImageData(imageId)
+
+        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+      }
+
+      it("returns an image with the matching ID") {
+        val expectedImage = File("src/test/resources/__files/example.jpg").readBytes()
+
+        val response = nomisGateway.getImageData(imageId)
+
+        response.data.shouldBe(expectedImage)
+      }
+
+      it("returns an error when 404 Not Found is returned") {
+        nomisApiMockServer.stubGetImageData(imageId, HttpStatus.NOT_FOUND)
+
+        val response = nomisGateway.getImageData(imageId)
+
+        response.errors.shouldHaveSize(1)
+        response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
+        response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
+      }
+    }
+  },)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -70,4 +70,19 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
         ),
     )
   }
+
+  fun stubGetOffencesForPerson(offenderNo: String, body: String, status: HttpStatus = HttpStatus.OK) {
+    stubFor(
+      get("/api/bookings/offenderNo/$offenderNo/offenceHistory")
+        .withHeader(
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
+        ).willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+            .withBody(body.trimIndent()),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetailTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 
-class OffenceTest : DescribeSpec(
+class OffenceHistoryDetailTest : DescribeSpec(
   {
     describe("#toOffence") {
       it("maps one-to-one attributes to integration API attributes") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceTest.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+
+class OffenceTest : DescribeSpec(
+  {
+    describe("#toOffence") {
+      it("maps one-to-one attributes to integration API attributes") {
+        val offenceHistoryDetail = OffenceHistoryDetail(
+          offenceDate = LocalDate.parse("1995-04-06"),
+          offenceCode = "RR84555",
+          offenceDescription = "A test offence description for model testing",
+        )
+
+        val integrationApiOffence = offenceHistoryDetail.toOffence()
+
+        integrationApiOffence.date.shouldBe(offenceHistoryDetail.offenceDate)
+        integrationApiOffence.code.shouldBe(offenceHistoryDetail.offenceCode)
+        integrationApiOffence.description.shouldBe(offenceHistoryDetail.offenceDescription)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
@@ -1,0 +1,88 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import java.time.LocalDate
+
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [GetOffencesForPersonService::class],
+)
+internal class GetOffencesForPersonServiceTest(
+  @MockBean val nomisGateway: NomisGateway,
+  @MockBean val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
+  private val getOffencesForPersonService: GetOffencesForPersonService,
+) : DescribeSpec(
+  {
+    val pncId = "1234/56789B"
+    val prisonerNumber = "Z99999ZZ"
+
+    beforeEach {
+      Mockito.reset(nomisGateway)
+
+      whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
+        Response(data = listOf(Person(firstName = "Chandler", lastName = "Bing", prisonerId = prisonerNumber))),
+      )
+
+      whenever(nomisGateway.getOffencesForPerson(prisonerNumber)).thenReturn(
+        Response(
+          data = listOf(
+            Offence(code = "RR12345", description = "First Offence", date = LocalDate.parse("2020-02-03")),
+            Offence(code = "RR54321", description = "Second Offence", date = LocalDate.parse("2021-03-04")),
+            Offence(code = "RR24680", description = "Third Offence", date = LocalDate.parse("2022-04-05")),
+          ),
+        ),
+      )
+    }
+
+    it("retrieves prisoner ID from Prisoner Offender Search using a PNC ID") {
+      getOffencesForPersonService.execute(pncId)
+
+      verify(prisonerOffenderSearchGateway, VerificationModeFactory.times(1)).getPersons(pncId = pncId)
+    }
+
+    it("retrieves offences for a person from NOMIS using prisoner number") {
+      getOffencesForPersonService.execute(pncId)
+
+      verify(nomisGateway, VerificationModeFactory.times(1)).getOffencesForPerson(prisonerNumber)
+    }
+
+    it("returns all offences for a person") {
+      val response = getOffencesForPersonService.execute(pncId)
+
+      response.data.shouldHaveSize(3)
+    }
+
+    it("returns an error when person cannot be found in NOMIS") {
+      whenever(nomisGateway.getOffencesForPerson(prisonerNumber)).thenReturn(
+        Response(
+          data = emptyList(),
+          errors = listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NOMIS,
+              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+            ),
+          ),
+        ),
+      )
+
+      val response = getOffencesForPersonService.execute(pncId)
+
+      response.errors.shouldHaveSize(1)
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
@@ -32,16 +32,24 @@ class OffencesSmokeTest : DescribeSpec(
       response.statusCode().shouldBe(HttpStatus.OK.value())
       response.body().shouldEqualJson(
         """
-      {
-        "data": [
-          {
-            "date": "2018-02-10",
-            "code": "RR84070",
-            "description": "Commit an act / series of acts with intent to pervert the course of public justice",
+        {
+          "data": [
+            {
+              "date": "2018-02-10",
+              "code": "RR84070",
+              "description": "Commit an act / series of acts with intent to pervert the course of public justice"
+            }
+          ],
+          "pagination": {
+            "isLastPage": true,
+            "count": 1,
+            "page": 1,
+            "perPage": 10,
+            "totalCount": 1,
+            "totalPages": 1
           }
-        ]
-      }
-      """.removeWhitespaceAndNewlines(),
+        }
+        """.removeWhitespaceAndNewlines(),
       )
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke.person
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+
+class OffencesSmokeTest : DescribeSpec(
+  {
+    val pncId = "2004/13116M"
+    val encodedPncId = URLEncoder.encode(pncId, StandardCharsets.UTF_8)
+
+    val baseUrl = "http://localhost:8080"
+    val basePath = "v1/persons/$encodedPncId/offences"
+
+    val httpClient = HttpClient.newBuilder().build()
+    val httpRequest = HttpRequest.newBuilder()
+
+    it("returns offences for a person") {
+      val response = httpClient.send(
+        httpRequest.uri(URI.create("$baseUrl/$basePath")).build(),
+        HttpResponse.BodyHandlers.ofString(),
+      )
+
+      response.statusCode().shouldBe(HttpStatus.OK.value())
+      response.body().shouldEqualJson(
+        """
+      {
+        "data": [
+          {
+            "date": "2018-02-10",
+            "code": "RR84070",
+            "description": "Commit an act / series of acts with intent to pervert the course of public justice",
+          }
+        ]
+      }
+      """.removeWhitespaceAndNewlines(),
+      )
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke.person
 
 import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.DescribeSpec


### PR DESCRIPTION
Added an initial offences endpoint. Notably:
- Offence histories only currently come from Prison API.
- We've exposed 3 fields only: date, offence code, and description. These will be expanded in line with requirements.