### PR TITLE
Fix get persons endpoint not returning all Prisoner Offender Search results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -34,12 +34,13 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
   }
 
   fun getPersons(firstName: String? = null, lastName: String? = null, pncId: String? = null): Response<List<Person>> {
+    val maxNumberOfResults = 9999
     val requestBody =
       mapOf("firstName" to firstName, "lastName" to lastName, "includeAliases" to true, "prisonerIdentifier" to pncId)
         .filterValues { it != null }
 
     return Response(
-      data = webClient.request<GlobalSearch>(HttpMethod.POST, "/global-search", authenticationHeader(), requestBody)
+      data = webClient.request<GlobalSearch>(HttpMethod.POST, "/global-search?size=$maxNumberOfResults", authenticationHeader(), requestBody)
         .content.map { it.toPerson() },
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
@@ -28,7 +28,7 @@ class PrisonerOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubPostPrisonerSearch(requestBody: String, responseBody: String, status: HttpStatus = HttpStatus.OK) {
     stubFor(
-      post("/global-search")
+      post("/global-search?size=9999")
         .withHeader("Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}"))
         .withRequestBody(WireMock.equalToJson(requestBody))
         .willReturn(


### PR DESCRIPTION
Prisoner Offender Search's /global-search API endpoint returns a paginated response however we didn't have any logic to handle that. As a result, if the results from it was more than the default page size (10 in this case), then our API never returned them and incorrectly returned the total count between all upstream APIs used for this endpoint.

This fix is a temporary which attempts to get all the results from Prisoner Offender Search by providing a page size of 9999 (an arbitrary number). We have a ticket in the backlog to find a long term solution to dealing with pagination from upstream APIs.