### PR TITLE
Rename prisonerId to nomisNumber

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -624,7 +624,7 @@ components:
           items:
             $ref: "#/components/schemas/Alias"
           description: list of aliases
-        prisonerId:
+        nomisNumber:
           type: string
           example: A1234AA
           description: A prisoner identifier from Prison API (NOMIS)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Person.kt
@@ -14,6 +14,6 @@ data class Person(
   val ethnicity: String? = null,
   @JsonAlias("offenderAliases")
   val aliases: List<Alias> = listOf(),
-  val prisonerId: String? = null,
+  val nomisNumber: String? = null,
   val pncId: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/Prisoner.kt
@@ -22,7 +22,7 @@ data class Prisoner(
     gender = this.gender,
     ethnicity = this.ethnicity,
     aliases = this.aliases.map { it.toAlias() },
-    prisonerId = this.prisonerNumber,
+    nomisNumber = this.prisonerNumber,
     pncId = this.pncNumber,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonService.kt
@@ -17,7 +17,7 @@ class GetAddressesForPersonService(
   fun execute(pncId: String): Response<List<Address>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
 
-    val responseFromNomis = nomisGateway.getAddressesForPerson(responseFromPrisonerOffenderSearch.data.first().prisonerId!!)
+    val responseFromNomis = nomisGateway.getAddressesForPerson(responseFromPrisonerOffenderSearch.data.first().nomisNumber!!)
     val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getAddressesForPerson(pncId)
 
     return Response.merge(listOf(responseFromNomis, responseFromProbationOffenderSearch))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -15,6 +15,6 @@ class GetImageMetadataForPersonService(
   fun execute(pncId: String): Response<List<ImageMetadata>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
 
-    return nomisGateway.getImageMetadataForPerson(responseFromPrisonerOffenderSearch.data.first().prisonerId!!)
+    return nomisGateway.getImageMetadataForPerson(responseFromPrisonerOffenderSearch.data.first().nomisNumber!!)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -15,6 +15,6 @@ class GetOffencesForPersonService(
   fun execute(pncId: String): Response<List<Offence>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
 
-    return nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().prisonerId!!)
+    return nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().nomisNumber!!)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -115,7 +115,7 @@ internal class PersonControllerTest(
               "gender": null,
               "ethnicity": null,
               "aliases":[],
-              "prisonerId": null,
+              "nomisNumber": null,
               "pncId": null
             },
             {
@@ -126,7 +126,7 @@ internal class PersonControllerTest(
               "gender": null,
               "ethnicity": null,
               "aliases":[],
-              "prisonerId": null,
+              "nomisNumber": null,
               "pncId": null
             }
           ]
@@ -265,7 +265,7 @@ internal class PersonControllerTest(
             "gender": null,
             "ethnicity": null,
             "aliases": [],
-            "prisonerId": null,
+            "nomisNumber": null,
             "pncId": null
           },
           "probationOffenderSearch": {
@@ -276,7 +276,7 @@ internal class PersonControllerTest(
             "gender": null,
             "ethnicity": null,
             "aliases": [],
-            "prisonerId": null,
+            "nomisNumber": null,
             "pncId": null
           }
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -76,10 +76,10 @@ class PrisonerOffenderSearchGatewayTest(
         it.firstName.shouldBe(firstName)
         it.lastName.shouldBe(lastName)
       }
-      response.data[0].prisonerId.shouldBe("A7796DY")
-      response.data[1].prisonerId.shouldBe("G9347GV")
-      response.data[2].prisonerId.shouldBe("A5043DY")
-      response.data[3].prisonerId.shouldBe("A5083DY")
+      response.data[0].nomisNumber.shouldBe("A7796DY")
+      response.data[1].nomisNumber.shouldBe("G9347GV")
+      response.data[2].nomisNumber.shouldBe("A5043DY")
+      response.data[3].nomisNumber.shouldBe("A5083DY")
 
       response.data[0].pncId.shouldBeNull()
       response.data[1].pncId.shouldBe("95/289622B")
@@ -140,7 +140,7 @@ class PrisonerOffenderSearchGatewayTest(
       response.data.count().shouldBe(1)
       response.data.first().firstName.shouldBe("Obi-Wan")
       response.data.first().lastName.shouldBe("Kenobi")
-      response.data.first().prisonerId.shouldBe("A1234AA")
+      response.data.first().nomisNumber.shouldBe("A1234AA")
     }
 
     it("returns person(s) when searching on last name only") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonerOffenderSearchApiMockServer.kt
@@ -13,9 +13,9 @@ class PrisonerOffenderSearchApiMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 4001
   }
 
-  fun stubGetPrisoner(prisonerId: String, responseBody: String, status: HttpStatus = HttpStatus.OK) {
+  fun stubGetPrisoner(nomisNumber: String, responseBody: String, status: HttpStatus = HttpStatus.OK) {
     stubFor(
-      get("/prisoner/$prisonerId")
+      get("/prisoner/$nomisNumber")
         .withHeader("Authorization", matching("Bearer ${HmppsAuthMockServer.TOKEN}"))
         .willReturn(
           aResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
@@ -33,7 +33,7 @@ class PrisonerTest : DescribeSpec(
         person.gender.shouldBe(prisoner.gender)
         person.ethnicity.shouldBe(prisoner.ethnicity)
         person.aliases.first().shouldBeTypeOf<Alias>()
-        person.prisonerId.shouldBe(prisoner.prisonerNumber)
+        person.nomisNumber.shouldBe(prisoner.prisonerNumber)
         person.pncId.shouldBe(prisoner.pncNumber)
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAddressesForPersonServiceTest.kt
@@ -39,7 +39,7 @@ internal class GetAddressesForPersonServiceTest(
       Mockito.reset(nomisGateway)
 
       whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
-        Response(data = listOf(Person(firstName = "Qui-gon", lastName = "Jin", prisonerId = prisonerNumber))),
+        Response(data = listOf(Person(firstName = "Qui-gon", lastName = "Jin", nomisNumber = prisonerNumber))),
       )
       whenever(probationOffenderSearchGateway.getAddressesForPerson(pncId)).thenReturn(Response(data = emptyList()))
       whenever(nomisGateway.getAddressesForPerson(prisonerNumber)).thenReturn(Response(data = emptyList()))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
@@ -35,7 +35,7 @@ internal class GetImageMetadataForPersonServiceTest(
     Mockito.reset(nomisGateway)
 
     whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
-      Response(data = listOf(Person(firstName = "Joey", lastName = "Tribbiani", prisonerId = prisonerNumber))),
+      Response(data = listOf(Person(firstName = "Joey", lastName = "Tribbiani", nomisNumber = prisonerNumber))),
     )
     whenever(nomisGateway.getImageMetadataForPerson(prisonerNumber)).thenReturn(Response(data = emptyList()))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
@@ -35,7 +35,7 @@ internal class GetOffencesForPersonServiceTest(
       Mockito.reset(nomisGateway)
 
       whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
-        Response(data = listOf(Person(firstName = "Chandler", lastName = "Bing", prisonerId = prisonerNumber))),
+        Response(data = listOf(Person(firstName = "Chandler", lastName = "Bing", nomisNumber = prisonerNumber))),
       )
 
       whenever(nomisGateway.getOffencesForPerson(prisonerNumber)).thenReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -30,10 +30,10 @@ internal class GetPersonServiceTest(
     Mockito.reset(probationOffenderSearchGateway)
 
     whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
-      Response(data = listOf(Person(firstName = "Qui-gon", lastName = "Jin", prisonerId = "A1234AA"))),
+      Response(data = listOf(Person(firstName = "Qui-gon", lastName = "Jin", nomisNumber = "A1234AA"))),
     )
     whenever(probationOffenderSearchGateway.getPerson(pncId = pncId)).thenReturn(
-      Response(data = Person(firstName = "Qui-gon", lastName = "Jin", prisonerId = "A1234AA")),
+      Response(data = Person(firstName = "Qui-gon", lastName = "Jin", nomisNumber = "A1234AA")),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
@@ -75,7 +75,7 @@ class PersonSmokeTest : DescribeSpec(
                   "ethnicity": "White : Irish"
                 }
               ],
-              "prisonerId": "A1234AA",
+              "nomisNumber": "A1234AA",
               "pncId": "12/394773H"
             },
             "probationOffenderSearch": {
@@ -95,7 +95,7 @@ class PersonSmokeTest : DescribeSpec(
                   "ethnicity": null
                 }
               ],
-              "prisonerId": null,
+              "nomisNumber": null,
               "pncId": "string"
             }
           }


### PR DESCRIPTION
This is to make the naming of other identifiers used for a person consistent.