### PR TITLE
Update offences models to include nullable fields

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
@@ -4,9 +4,9 @@ import java.time.LocalDate
 
 data class Offence(
   val cjsCode: String,
-  val courtDate: LocalDate,
+  val courtDate: LocalDate?,
   val description: String,
-  val endDate: LocalDate,
+  val endDate: LocalDate?,
   val startDate: LocalDate,
   val statuteCode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetail.kt
@@ -4,11 +4,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
 import java.time.LocalDate
 
 data class OffenceHistoryDetail(
-  val courtDate: LocalDate,
+  val courtDate: LocalDate?,
   val offenceCode: String,
   val offenceDate: LocalDate,
   val offenceDescription: String,
-  val offenceRangeDate: LocalDate,
+  val offenceRangeDate: LocalDate?,
   val statuteCode: String,
 ) {
   fun toOffence(): Offence = Offence(


### PR DESCRIPTION
Some fields in Prison API's offender offence history detail model are nullable, which was not previously reflected in our models.