### PR TITLE
Add ability to search within aliases for person search endpoint

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -21,6 +21,13 @@ paths:
           required: false
           description: The first name of the person
         - in: query
+          name: search_within_aliases
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: Whether to return results that match the search criteria within the aliases of a person
+        - in: query
           name: last_name
           schema:
             type: string

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -35,6 +35,7 @@ class PersonController(
   fun getPersons(
     @RequestParam(required = false, name = "first_name") firstName: String?,
     @RequestParam(required = false, name = "last_name") lastName: String?,
+    @RequestParam(required = false, defaultValue = "false", name = "search_within_aliases") searchWithinAliases: Boolean,
     @RequestParam(required = false, defaultValue = "1", name = "page") page: Int,
     @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
   ): PaginatedResponse<Person?> {
@@ -42,7 +43,7 @@ class PersonController(
       throw ValidationException("No query parameters specified.")
     }
 
-    val response = getPersonsService.execute(firstName, lastName)
+    val response = getPersonsService.execute(firstName, lastName, searchWithinAliases)
 
     return response.data.paginateWith(page, perPage)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -33,9 +33,9 @@ class PrisonerOffenderSearchGateway(@Value("\${services.prisoner-offender-search
     }
   }
 
-  fun getPersons(firstName: String? = null, lastName: String? = null, pncId: String? = null): Response<List<Person>> {
+  fun getPersons(firstName: String? = null, lastName: String? = null, pncId: String? = null, searchWithinAliases: Boolean = false): Response<List<Person>> {
     val requestBody =
-      mapOf("firstName" to firstName, "lastName" to lastName, "includeAliases" to true, "prisonerIdentifier" to pncId)
+      mapOf("firstName" to firstName, "lastName" to lastName, "includeAliases" to searchWithinAliases, "prisonerIdentifier" to pncId)
         .filterValues { it != null }
 
     return Response(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpMethod
@@ -17,7 +16,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffender
 @Component
 class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-search.base-url}") baseUrl: String) {
   private val webClient = WebClientWrapper(baseUrl)
-  private val log = LoggerFactory.getLogger(this::class.java)
 
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
@@ -57,8 +55,8 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
     }
   }
 
-  fun getPersons(firstName: String?, surname: String?): Response<List<Person>> {
-    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "valid" to true)
+  fun getPersons(firstName: String?, surname: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
+    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "includeAliases" to searchWithinAliases, "valid" to true)
       .filterValues { it != null }
 
     return Response(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
@@ -13,9 +13,9 @@ class GetPersonsService(
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) {
 
-  fun execute(firstName: String?, lastName: String?): Response<List<Person>> {
-    val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(firstName, lastName)
-    val personsFromProbationOffenderSearch = probationOffenderSearchGateway.getPersons(firstName, lastName)
+  fun execute(firstName: String?, lastName: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
+    val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = searchWithinAliases)
+    val personsFromProbationOffenderSearch = probationOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = searchWithinAliases)
 
     return Response(data = responseFromPrisonerOffenderSearch.data + personsFromProbationOffenderSearch.data)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -72,33 +72,34 @@ internal class PersonControllerTest(
         )
       }
 
-      it("responds with a 200 OK status") {
-        val result = mockMvc.perform(get("$basePath?first_name=$firstName&last_name=$lastName")).andReturn()
-
-        result.response.status.shouldBe(HttpStatus.OK.value())
-      }
-
-      it("returns an empty list embedded in a JSON object when no matching people") {
-        val firstNameThatDoesNotExist = "Bob21345"
-        val lastNameThatDoesNotExist = "Gun36773"
-
-        whenever(getPersonsService.execute(firstNameThatDoesNotExist, lastNameThatDoesNotExist)).thenReturn(
-          Response(
-            data = emptyList(),
-          ),
-        )
-
-        val result =
-          mockMvc.perform(get("$basePath?first_name=$firstNameThatDoesNotExist&last_name=$lastNameThatDoesNotExist"))
-            .andReturn()
-
-        result.response.contentAsString.shouldContain("\"data\":[]".removeWhitespaceAndNewlines())
-      }
-
       it("retrieves a person with matching search criteria") {
         mockMvc.perform(get("$basePath?first_name=$firstName&last_name=$lastName")).andReturn()
 
         verify(getPersonsService, times(1)).execute(firstName, lastName)
+      }
+
+      it("retrieves a person with matching first name") {
+        mockMvc.perform(get("$basePath?first_name=$firstName")).andReturn()
+
+        verify(getPersonsService, times(1)).execute(firstName, null)
+      }
+
+      it("retrieves a person with matching last name") {
+        mockMvc.perform(get("$basePath?last_name=$lastName")).andReturn()
+
+        verify(getPersonsService, times(1)).execute(null, lastName)
+      }
+
+      it("retrieves a person with matching alias") {
+        mockMvc.perform(get("$basePath?first_name=$firstName&search_within_aliases=true")).andReturn()
+
+        verify(getPersonsService, times(1)).execute(firstName, null, searchWithinAliases = true)
+      }
+
+      it("defaults to not searching within aliases") {
+        mockMvc.perform(get("$basePath?first_name=$firstName")).andReturn()
+
+        verify(getPersonsService, times(1)).execute(firstName, null, searchWithinAliases = false)
       }
 
       it("returns a person with matching first and last name") {
@@ -164,16 +165,27 @@ internal class PersonControllerTest(
         result.response.contentAsString.shouldContainJsonKeyValue("$.pagination.totalPages", 4)
       }
 
-      it("retrieves a person with matching first name") {
-        mockMvc.perform(get("$basePath?first_name=$firstName")).andReturn()
+      it("returns an empty list embedded in a JSON object when no matching people") {
+        val firstNameThatDoesNotExist = "Bob21345"
+        val lastNameThatDoesNotExist = "Gun36773"
 
-        verify(getPersonsService, times(1)).execute(firstName, null)
+        whenever(getPersonsService.execute(firstNameThatDoesNotExist, lastNameThatDoesNotExist)).thenReturn(
+          Response(
+            data = emptyList(),
+          ),
+        )
+
+        val result =
+          mockMvc.perform(get("$basePath?first_name=$firstNameThatDoesNotExist&last_name=$lastNameThatDoesNotExist"))
+            .andReturn()
+
+        result.response.contentAsString.shouldContain("\"data\":[]".removeWhitespaceAndNewlines())
       }
 
-      it("retrieves a person with matching last name") {
-        mockMvc.perform(get("$basePath?last_name=$lastName")).andReturn()
+      it("responds with a 200 OK status") {
+        val result = mockMvc.perform(get("$basePath?first_name=$firstName&last_name=$lastName")).andReturn()
 
-        verify(getPersonsService, times(1)).execute(null, lastName)
+        result.response.status.shouldBe(HttpStatus.OK.value())
       }
 
       it("responds with a 400 BAD REQUEST status when no search criteria provided") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
-import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.internal.verification.VerificationModeFactory.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
@@ -34,16 +34,33 @@ internal class GetPersonsServiceTest(
     whenever(probationOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(Response(data = emptyList()))
   }
 
-  it("returns person(s) from Prisoner Offender Search") {
+  it("retrieves person(s) from Prisoner Offender Search") {
     getPersonsService.execute(firstName, lastName)
 
-    verify(prisonerOffenderSearchGateway, VerificationModeFactory.times(1)).getPersons(firstName, lastName)
+    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName)
   }
 
-  it("returns person(s) from Probation Offender Search") {
+  it("retrieves person(s) from Probation Offender Search") {
     getPersonsService.execute(firstName, lastName)
 
-    verify(probationOffenderSearchGateway, VerificationModeFactory.times(1)).getPersons(firstName, lastName)
+    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName)
+  }
+
+  it("defaults to not searching within aliases") {
+    getPersonsService.execute(firstName, lastName)
+
+    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = false)
+    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = false)
+  }
+
+  it("allows searching within aliases") {
+    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = true)).thenReturn(Response(data = emptyList()))
+    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = true)).thenReturn(Response(data = emptyList()))
+
+    getPersonsService.execute(firstName, lastName, searchWithinAliases = true)
+
+    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = true)
+    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = true)
   }
 
   it("returns person(s)") {


### PR DESCRIPTION
This adds a new query parameter `search_within_aliases` to our `GET /v1/persons` endpoint that allows a consumer to decide whether to matching their search criteria within the aliases of a person.