### PR TITLE
Fix empty string for middle names of offenders in Probation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -18,7 +18,7 @@ data class Offender(
   fun toPerson(): Person = Person(
     firstName = this.firstName,
     lastName = this.surname,
-    middleName = this.middleNames.joinToString(" "),
+    middleName = this.middleNames.joinToString(" ").ifEmpty { null },
     dateOfBirth = this.dateOfBirth,
     gender = this.gender,
     ethnicity = this.offenderProfile.ethnicity,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAlias.kt
@@ -13,7 +13,7 @@ data class OffenderAlias(
   fun toAlias(): Alias = Alias(
     firstName = this.firstName,
     lastName = this.surname,
-    middleName = this.middleNames.joinToString(" "),
+    middleName = this.middleNames.joinToString(" ").ifEmpty { null },
     dateOfBirth = this.dateOfBirth,
     gender = this.gender,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAliasTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderAliasTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
 
@@ -23,6 +24,18 @@ class OffenderAliasTest : DescribeSpec(
         alias.middleName.shouldBe("Alias Middle Names")
         alias.dateOfBirth.shouldBe(offenderAlias.dateOfBirth)
         alias.gender.shouldBe(offenderAlias.gender)
+      }
+
+      it("returns null when no middle names") {
+        val offenderAlias = OffenderAlias(
+          firstName = "First Name",
+          surname = "Surname",
+          middleNames = listOf(),
+        )
+
+        val alias = offenderAlias.toAlias()
+
+        alias.middleName.shouldBeNull()
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationoffendersearch
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Alias
@@ -41,6 +42,18 @@ class OffenderTest : DescribeSpec(
         person.identifiers.croNumber.shouldBe(prisoner.otherIds.croNumber)
         person.identifiers.deliusCrn.shouldBe(prisoner.otherIds.crn)
         person.pncId.shouldBe(prisoner.otherIds.pncNumber)
+      }
+
+      it("returns null when no middle names") {
+        val prisoner = Offender(
+          firstName = "First Name",
+          surname = "Surname",
+          middleNames = listOf(),
+        )
+
+        val person = prisoner.toPerson()
+
+        person.middleName.shouldBeNull()
       }
     }
   },


### PR DESCRIPTION
When an offender from Probation Offender Search had no middle names, our API would return `""` i.e. an empty string. This fixes this to return null instead.