### PR TITLE
Remove valid from Probation Offender Search requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -26,7 +26,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
         HttpMethod.POST,
         "/search",
         authenticationHeader(),
-        mapOf("pncNumber" to pncId, "valid" to true),
+        mapOf("pncNumber" to pncId),
       )
 
       if (offenders.isEmpty()) {
@@ -56,7 +56,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   }
 
   fun getPersons(firstName: String?, surname: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
-    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "includeAliases" to searchWithinAliases, "valid" to true)
+    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "includeAliases" to searchWithinAliases)
       .filterValues { it != null }
 
     return Response(
@@ -66,7 +66,7 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
   }
 
   fun getAddressesForPerson(pncId: String): Response<List<Address>> {
-    val requestBody = mapOf("pncNumber" to pncId, "valid" to true)
+    val requestBody = mapOf("pncNumber" to pncId)
 
     val offender = webClient.requestList<Offender>(HttpMethod.POST, "/search", authenticationHeader(), requestBody)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/GetAddressesForPersonTest.kt
@@ -36,7 +36,7 @@ class GetAddressesForPersonTest(
     beforeEach {
       probationOffenderSearchApiMockServer.start()
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
           {
@@ -104,7 +104,7 @@ class GetAddressesForPersonTest(
 
     it("returns an empty list when no addresses are found") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
           {
@@ -125,7 +125,7 @@ class GetAddressesForPersonTest(
 
     it("returns an error when no results are returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         "[]",
       )
 
@@ -136,7 +136,7 @@ class GetAddressesForPersonTest(
 
     it("returns an empty list when there is no contactDetails field") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
           {
@@ -154,7 +154,7 @@ class GetAddressesForPersonTest(
 
     it("returns an empty list when contactDetails field is null") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
           {
@@ -173,7 +173,7 @@ class GetAddressesForPersonTest(
 
     it("returns an empty list when contactDetails.addresses field is null") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
           {
@@ -194,7 +194,7 @@ class GetAddressesForPersonTest(
 
     it("returns an empty list when the type is an empty object") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
           {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -55,8 +55,7 @@ class ProbationOffenderSearchGatewayTest(
             {
               "firstName": "$firstName",
               "surname": "$surname",
-              "includeAliases": false,
-              "valid": true
+              "includeAliases": false
             }
           """.removeWhitespaceAndNewlines(),
         File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json").readText(),
@@ -82,8 +81,7 @@ class ProbationOffenderSearchGatewayTest(
         """
         {
           "firstName": "Ahsoka",
-          "includeAliases": false,
-          "valid": true
+          "includeAliases": false
         }
         """.removeWhitespaceAndNewlines(),
         """
@@ -108,8 +106,7 @@ class ProbationOffenderSearchGatewayTest(
         """
         {
           "surname": "Tano",
-          "includeAliases": false,
-          "valid":true
+          "includeAliases": false
         }
         """.removeWhitespaceAndNewlines(),
         """
@@ -133,8 +130,7 @@ class ProbationOffenderSearchGatewayTest(
         """
         {
           "firstName": "Fulcrum",
-          "includeAliases": true,
-          "valid": true
+          "includeAliases": true
         }
         """.removeWhitespaceAndNewlines(),
         """
@@ -166,7 +162,7 @@ class ProbationOffenderSearchGatewayTest(
 
     beforeEach {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
         [
            {
@@ -214,7 +210,7 @@ class ProbationOffenderSearchGatewayTest(
 
     it("returns a person without aliases when no aliases are found") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
           [
            {
@@ -234,7 +230,7 @@ class ProbationOffenderSearchGatewayTest(
 
     it("returns null when 400 Bad Request is returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         """
           {
             "developerMessage": "reason for bad request"
@@ -257,7 +253,7 @@ class ProbationOffenderSearchGatewayTest(
 
     it("returns null when no offenders are returned") {
       probationOffenderSearchApiMockServer.stubPostOffenderSearch(
-        "{\"pncNumber\": \"$pncId\", \"valid\": true}",
+        "{\"pncNumber\": \"$pncId\"}",
         "[]",
       )
 


### PR DESCRIPTION
According to the documentation of Probation Offender Search, this was a required property in requests. However, we've discovered this isn't true so we can remove it.