### PR TITLE
Update sentences smoke test to expect full response

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
@@ -23,7 +23,7 @@ class SentencesSmokeTest : DescribeSpec(
     val httpClient = HttpClient.newBuilder().build()
     val httpRequest = HttpRequest.newBuilder()
 
-    xit("returns sentences for a person") {
+    it("returns sentences for a person") {
       val response = httpClient.send(
         httpRequest.uri(URI.create("$baseUrl/$basePath")).build(),
         HttpResponse.BodyHandlers.ofString(),
@@ -34,10 +34,18 @@ class SentencesSmokeTest : DescribeSpec(
         """
         {
           "data": [
-          {
-            "startDate": "2018-12-31"
-          }
-        ],
+            {
+              "startDate": "2018-12-31",
+              "length": {
+                "days": 4,
+                "weeks": 3,
+                "months": 2,
+                "years": 1
+              },
+              "fineAmount": -1.7976931348623157E308,
+              "isLifeSentence": true
+            }
+          ],
           "pagination": {
             "isLastPage": true,
             "count": 1,


### PR DESCRIPTION
- Enable the smoke test even though we expect this to change soon.
- We've added examples to Prison API for the sentence terms endpoint so we can assert on better example values for length.
- Fine amount is still a dodgy value but fine for now as we're unsure about whether we'll be able to return it. We can always update it later.