### PR TITLE
Offence information from nDelius

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
@@ -31,7 +31,11 @@ class OffencesController(
     val response = getOffencesForPersonService.execute(pncId)
 
     if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS)) {
-      throw EntityNotFoundException("Could not find person with id: $pncId")
+      throw EntityNotFoundException("Could not find person with id: $pncId in NOMIS")
+    }
+
+    if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NDELIUS)) {
+      throw EntityNotFoundException("Could not find person with id: $pncId in nDelius")
     }
 
     return response.data.paginateWith(page, perPage)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetOffencesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.PaginatedResponse
@@ -30,12 +29,8 @@ class OffencesController(
     val pncId = encodedPncId.decodeUrlCharacters()
     val response = getOffencesForPersonService.execute(pncId)
 
-    if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS)) {
-      throw EntityNotFoundException("Could not find person with id: $pncId in NOMIS")
-    }
-
-    if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NDELIUS)) {
-      throw EntityNotFoundException("Could not find person with id: $pncId in nDelius")
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not find person with id: $pncId")
     }
 
     return response.data.paginateWith(page, perPage)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpMethod
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.Supervisions
+
+@Component
+class NDeliusGateway(@Value("\${services.ndelius.base-url}") baseUrl: String) {
+  private val webClient = WebClientWrapper(baseUrl)
+
+  @Autowired
+  lateinit var hmppsAuthGateway: HmppsAuthGateway
+
+  fun getOffencesForPerson(id: String): Response<List<Offence>> {
+    return try {
+      Response(
+        data = webClient.request<Supervisions>(
+          HttpMethod.GET,
+          "/case/$id/supervisions",
+          authenticationHeader(),
+        ).supervisions.map { it.toOffence() },
+      )
+    } catch (exception: WebClientResponseException.NotFound) {
+      Response(
+        data = emptyList(),
+        errors = listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.NDELIUS,
+            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+          ),
+        ),
+      )
+    }
+  }
+
+  private fun authenticationHeader(): Map<String, String> {
+    val token = hmppsAuthGateway.getClientToken("nDelius")
+
+    return mapOf(
+      "Authorization" to "Bearer $token",
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 import java.time.LocalDate
 
 data class Offence(
-  val cjsCode: String,
-  val courtDate: LocalDate?,
-  val description: String,
-  val endDate: LocalDate?,
-  val startDate: LocalDate?,
-  val statuteCode: String,
+  val cjsCode: String? = null,
+  val courtDate: LocalDate? = null,
+  val description: String? = null,
+  val endDate: LocalDate? = null,
+  val startDate: LocalDate? = null,
+  val statuteCode: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApi.kt
@@ -1,5 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 enum class UpstreamApi {
-  NOMIS, PRISONER_OFFENDER_SEARCH, PROBATION_OFFENDER_SEARCH
+  NOMIS, PRISONER_OFFENDER_SEARCH, PROBATION_OFFENDER_SEARCH, NDELIUS
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/MainOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/MainOffence.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
+
+data class MainOffence(val description: String? = null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervision.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+
+data class Supervision(
+  val mainOffence: MainOffence = MainOffence(),
+) {
+  fun toOffence(): Offence = Offence(
+    cjsCode = null,
+    courtDate = null,
+    endDate = null,
+    startDate = null,
+    statuteCode = null,
+    description = this.mainOffence?.description,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervisions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervisions.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
+
+data class Supervisions(
+  val supervisions: List<Supervision>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 
@@ -11,10 +13,24 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 class GetOffencesForPersonService(
   @Autowired val nomisGateway: NomisGateway,
   @Autowired val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
+  @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
+  @Autowired val nDeliusGateway: NDeliusGateway,
 ) {
   fun execute(pncId: String): Response<List<Offence>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
+    val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(pncId = pncId)
 
-    return nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().identifiers.nomisNumber!!)
+    val nomisOffences = nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().identifiers.nomisNumber!!)
+    val nDeliusOffences = nDeliusGateway.getOffencesForPerson(responseFromProbationOffenderSearch.data?.identifiers?.deliusCrn!!)
+
+    if (nomisOffences.errors.isNotEmpty()) {
+      return Response(emptyList(), nomisOffences.errors)
+    }
+
+    if (nDeliusOffences.errors.isNotEmpty()) {
+      return Response(emptyList(), nDeliusOffences.errors)
+    }
+
+    return Response(data = nomisOffences.data + nDeliusOffences.data)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -20,6 +20,14 @@ class GetOffencesForPersonService(
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
     val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(pncId = pncId)
 
+    if (responseFromPrisonerOffenderSearch.errors.isNotEmpty()) {
+      return Response(emptyList(), responseFromPrisonerOffenderSearch.errors)
+    }
+
+    if (responseFromProbationOffenderSearch.errors.isNotEmpty()) {
+      return Response(emptyList(), responseFromProbationOffenderSearch.errors)
+    }
+
     val nomisOffences = nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().identifiers.nomisNumber!!)
     val nDeliusOffences = nDeliusGateway.getOffencesForPerson(responseFromProbationOffenderSearch.data?.identifiers?.deliusCrn!!)
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,8 @@ services:
     base-url: https://prisoner-offender-search-dev.prison.service.justice.gov.uk
   probation-offender-search:
     base-url: https://probation-offender-search-dev.hmpps.service.justice.gov.uk
+  ndelius:
+    base-url: https://external-api-and-delius-dev.hmpps.service.justice.gov.uk
   hmpps-auth:
     base-url: https://sign-in-dev.hmpps.service.justice.gov.uk
     username: ${CLIENT_ID}

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -5,5 +5,7 @@ services:
     base-url: http://prisoner-offender-search:4010
   prison-api:
     base-url: http://prison-api:4010
+  ndelius:
+    base-url: https://ndelius:4010
   hmpps-auth:
     base-url: http://hmpps-auth:8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,5 +5,7 @@ services:
     base-url: http://localhost:4010
   prison-api:
     base-url: http://localhost:4030
+  ndelius:
+    base-url: https://localhost:4040
   hmpps-auth:
     base-url: http://localhost:9090

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -5,6 +5,8 @@ services:
     base-url: https://prisoner-offender-search-preprod.prison.service.justice.gov.uk
   probation-offender-search:
     base-url: https://probation-offender-search-preprod.hmpps.service.justice.gov.uk
+  ndelius:
+    base-url: https://external-api-and-delius-preprod.hmpps.service.justice.gov.uk
   hmpps-auth:
     base-url: https://sign-in-preprod.hmpps.service.justice.gov.uk
     username: ${CLIENT_ID}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,6 +5,8 @@ services:
     base-url: https://prisoner-offender-search.prison.service.justice.gov.uk
   probation-offender-search:
     base-url: https://probation-offender-search.hmpps.service.justice.gov.uk
+  ndelius:
+    base-url: https://external-api-and-delius.hmpps.service.justice.gov.uk
   hmpps-auth:
     base-url: https://sign-in.hmpps.service.justice.gov.uk
     username: ${CLIENT_ID}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,3 +16,5 @@ services:
     base-url: http://localhost:4001
   probation-offender-search:
     base-url: http://localhost:4002
+  ndelius:
+    base-url: http://localhost:4003

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,8 @@ services:
     base-url: "TestURL"
   prisoner-offender-search:
     base-url: "TestURL"
+  ndelius:
+    base-url: "TestURL"
   hmpps-auth:
     base-url: "OtherTestURL"
     username: hmpps-integration-api-client

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -43,18 +43,10 @@ internal class OffencesControllerTest(
               Offence(
                 cjsCode = "RR99999",
                 courtDate = LocalDate.parse("2023-03-03"),
-                description = "Some Prison offence",
+                description = "This is a description of an offence.",
                 endDate = LocalDate.parse("2023-02-01"),
                 startDate = LocalDate.parse("2023-01-01"),
                 statuteCode = "RR99",
-              ),
-              Offence(
-                cjsCode = null,
-                courtDate = null,
-                description = "Some Probation offence",
-                endDate = null,
-                startDate = null,
-                statuteCode = null,
               ),
             ),
           ),
@@ -82,18 +74,10 @@ internal class OffencesControllerTest(
             {
               "cjsCode": "RR99999",
               "courtDate":"2023-03-03",
-              "description": "Some Prison offence",
+              "description": "This is a description of an offence.",
               "endDate":"2023-02-01",
               "startDate": "2023-01-01",
               "statuteCode":"RR99"
-            },
-            {
-              "cjsCode": null,
-              "courtDate": null,
-              "description": "Some Probation offence",
-              "endDate": null,
-              "startDate": null,
-              "statuteCode": null
             }
           ]
         """.removeWhitespaceAndNewlines(),
@@ -119,31 +103,13 @@ internal class OffencesControllerTest(
         result.response.contentAsString.shouldContain("\"data\":[]".removeWhitespaceAndNewlines())
       }
 
-      it("responds with a 404 NOT FOUND status when person isn't found in NOMIS") {
+      it("responds with a 404 NOT FOUND status when person isn't found in the upstream API") {
         whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
           Response(
             data = emptyList(),
             errors = listOf(
               UpstreamApiError(
                 causedBy = UpstreamApi.NOMIS,
-                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-              ),
-            ),
-          ),
-        )
-
-        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
-
-        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-      }
-
-      it("responds with a 404 NOT FOUND status when person isn't found in nDelius") {
-        whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
-          Response(
-            data = emptyList(),
-            errors = listOf(
-              UpstreamApiError(
-                causedBy = UpstreamApi.NDELIUS,
                 type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -43,10 +43,18 @@ internal class OffencesControllerTest(
               Offence(
                 cjsCode = "RR99999",
                 courtDate = LocalDate.parse("2023-03-03"),
-                description = "This is a description of an offence.",
+                description = "Some Prison offence",
                 endDate = LocalDate.parse("2023-02-01"),
                 startDate = LocalDate.parse("2023-01-01"),
                 statuteCode = "RR99",
+              ),
+              Offence(
+                cjsCode = null,
+                courtDate = null,
+                description = "Some Probation offence",
+                endDate = null,
+                startDate = null,
+                statuteCode = null,
               ),
             ),
           ),
@@ -74,10 +82,18 @@ internal class OffencesControllerTest(
             {
               "cjsCode": "RR99999",
               "courtDate":"2023-03-03",
-              "description": "This is a description of an offence.",
+              "description": "Some Prison offence",
               "endDate":"2023-02-01",
               "startDate": "2023-01-01",
               "statuteCode":"RR99"
+            },
+            {
+              "cjsCode": null,
+              "courtDate": null,
+              "description": "Some Probation offence",
+              "endDate": null,
+              "startDate": null,
+              "statuteCode": null
             }
           ]
         """.removeWhitespaceAndNewlines(),
@@ -103,13 +119,31 @@ internal class OffencesControllerTest(
         result.response.contentAsString.shouldContain("\"data\":[]".removeWhitespaceAndNewlines())
       }
 
-      it("responds with a 404 NOT FOUND status when person isn't found in the upstream API") {
+      it("responds with a 404 NOT FOUND status when person isn't found in NOMIS") {
         whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
           Response(
             data = emptyList(),
             errors = listOf(
               UpstreamApiError(
                 causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+          ),
+        )
+
+        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
+
+      it("responds with a 404 NOT FOUND status when person isn't found in nDelius") {
+        whenever(getOffencesForPersonService.execute(pncId)).thenReturn(
+          Response(
+            data = emptyList(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NDELIUS,
                 type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetOffencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetOffencesForPersonTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ndelius
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NDeliusApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import java.io.File
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [NDeliusGateway::class],
+)
+class GetOffencesForPersonTest(
+  @MockBean val hmppsAuthGateway: HmppsAuthGateway,
+  val nDeliusGateway: NDeliusGateway,
+) :
+  DescribeSpec(
+    {
+      val nDeliusApiMockServer = NDeliusApiMockServer()
+      val crn = "X777776"
+
+      beforeEach {
+        nDeliusApiMockServer.start()
+        nDeliusApiMockServer.stubGetOffencesForPerson(
+          crn,
+          File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/fixtures/GetOffencesResponse.json").readText(),
+        )
+
+        Mockito.reset(hmppsAuthGateway)
+        whenever(hmppsAuthGateway.getClientToken("nDelius")).thenReturn(HmppsAuthMockServer.TOKEN)
+      }
+
+      afterTest {
+        nDeliusApiMockServer.stop()
+      }
+
+      it("authenticates using HMPPS Auth with credentials") {
+        nDeliusGateway.getOffencesForPerson(crn)
+
+        verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("nDelius")
+      }
+
+      it("returns offences for the matching CRN") {
+        val response = nDeliusGateway.getOffencesForPerson(crn)
+
+        response.data[0].description.shouldBe("Common assault and battery - 10501")
+        response.data[1].description.shouldBe("Threatening behaviour, fear or provocation of violence (Public Order Act 1986) - 12511")
+      }
+
+      it("returns an empty list if no offences are found") {
+        nDeliusApiMockServer.stubGetOffencesForPerson(
+          crn,
+          """
+          { "supervisions": [] }
+          """,
+        )
+
+        val response = nDeliusGateway.getOffencesForPerson(crn)
+
+        response.data.shouldBeEmpty()
+      }
+
+      it("returns an error when 404 Not Found is returned because no person is found") {
+        nDeliusApiMockServer.stubGetOffencesForPerson(crn, "", HttpStatus.NOT_FOUND)
+
+        val response = nDeliusGateway.getOffencesForPerson(crn)
+
+        response.errors.shouldHaveSize(1)
+        response.errors.first().causedBy.shouldBe(UpstreamApi.NDELIUS)
+        response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
+      }
+    },
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/fixtures/GetOffencesResponse.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/fixtures/GetOffencesResponse.json
@@ -1,0 +1,126 @@
+{
+  "supervisions": [
+    {
+      "number": 1,
+      "active": false,
+      "sentence": {
+        "description": "CJA - Community Order",
+        "date": "2009-07-07",
+        "length": 12,
+        "lengthUnits": "Months"
+      },
+      "mainOffence": {
+        "date": "2009-03-31",
+        "count": 1,
+        "code": "10501",
+        "description": "Common assault and battery - 10501",
+        "mainCategory": {
+          "code": "105",
+          "description": "Common and other types of assault"
+        },
+        "subCategory": {
+          "code": "01",
+          "description": "Common assault and battery"
+        }
+      },
+      "additionalOffences": [
+        {
+          "date": "2009-03-31",
+          "count": 1,
+          "code": "05800",
+          "description": "Other Criminal Damage (including causing explosion)  - 05800",
+          "mainCategory": {
+            "code": "058",
+            "description": "Other Criminal damage"
+          },
+          "subCategory": {
+            "code": "00",
+            "description": "Other Criminal damage"
+          }
+        }
+      ],
+      "courtAppearances": [
+        {
+          "type": "Trial/Adjournment",
+          "date": "2009-07-07T00:00:00+01:00",
+          "court": "Llandudno Magistrates Court",
+          "plea": "Guilty"
+        },
+        {
+          "type": "Sentence",
+          "date": "2009-07-07T00:00:00+01:00",
+          "court": "Llandudno Magistrates Court",
+          "plea": "Guilty"
+        }
+      ]
+    },
+    {
+      "number": 2,
+      "active": false,
+      "sentence": {
+        "description": "CJA - Suspended Sentence Order",
+        "date": "2009-09-01",
+        "length": 12,
+        "lengthUnits": "Months"
+      },
+      "mainOffence": {
+        "date": "2009-07-31",
+        "count": 1,
+        "code": "12511",
+        "description": "Threatening behaviour, fear or provocation of violence (Public Order Act 1986) - 12511",
+        "mainCategory": {
+          "code": "125",
+          "description": "Offences against Public Order (Summary)"
+        },
+        "subCategory": {
+          "code": "11",
+          "description": "Threatening behaviour, fear or provocation of violence (Public Order Act 1986)"
+        }
+      },
+      "additionalOffences": [
+        {
+          "date": "2009-08-14",
+          "count": 1,
+          "code": "03900",
+          "description": "Stealing from the person of another - 03900",
+          "mainCategory": {
+            "code": "039",
+            "description": "Stealing from the person of another"
+          },
+          "subCategory": {
+            "code": "00",
+            "description": "Stealing from the person of another"
+          }
+        },
+        {
+          "date": "1900-01-01",
+          "count": 1,
+          "code": "99902",
+          "description": "Migrated Breach Offences",
+          "mainCategory": {
+            "code": "MIG",
+            "description": "Other offence (non-indictable)"
+          },
+          "subCategory": {
+            "code": "01",
+            "description": "Other offence (non-indictable)"
+          }
+        }
+      ],
+      "courtAppearances": [
+        {
+          "type": "Sentence",
+          "date": "2009-09-01T00:00:00+01:00",
+          "court": "Rhuddlan Magistrates Court",
+          "plea": "Guilty"
+        },
+        {
+          "type": "Trial/Adjournment",
+          "date": "2009-08-11T00:00:00+01:00",
+          "court": "Rhuddlan Magistrates Court",
+          "plea": "Guilty"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/OffenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/OffenceHelper.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import java.time.LocalDate
+
+fun generateTestOffence(
+  cjsCode: String? = "RR12345",
+  description: String? = "Some description",
+  startDate: LocalDate? = LocalDate.parse("2020-02-03"),
+  endDate: LocalDate? = LocalDate.parse("2020-03-03"),
+  courtDate: LocalDate? = LocalDate.parse("2020-04-03"),
+  statuteCode: String? = "RR12",
+): Offence = Offence(
+  cjsCode = cjsCode,
+  description = description,
+  startDate = startDate,
+  endDate = endDate,
+  courtDate = courtDate,
+  statuteCode = statuteCode,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NDeliusApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NDeliusApiMockServer.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import org.springframework.http.HttpStatus
+
+class NDeliusApiMockServer : WireMockServer(WIREMOCK_PORT) {
+  companion object {
+    private const val WIREMOCK_PORT = 4003
+  }
+
+  fun stubGetOffencesForPerson(crn: String, body: String, status: HttpStatus = HttpStatus.OK) {
+    stubFor(
+      get("/case/$crn/supervisions")
+        .withHeader(
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
+        ).willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+            .withBody(body.trimIndent()),
+        ),
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+
+class SupervisionsTest : DescribeSpec(
+  {
+    describe("#toOffence") {
+      it("maps one-to-one attributes to integration API attributes") {
+        val supervisions = Supervisions(
+          supervisions = listOf(
+            Supervision(mainOffence = MainOffence(description = "foobar")),
+            Supervision(mainOffence = MainOffence(description = "barbaz")),
+          ),
+        )
+
+        val integrationApiOffences = supervisions.supervisions.map { it.toOffence() }
+
+        integrationApiOffences.shouldBe(
+          listOf(
+            Offence(description = "foobar"),
+            Offence(description = "barbaz"),
+          ),
+        )
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
@@ -9,8 +10,10 @@ import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Identifiers
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
@@ -26,25 +29,51 @@ import java.time.LocalDate
 internal class GetOffencesForPersonServiceTest(
   @MockBean val nomisGateway: NomisGateway,
   @MockBean val prisonerOffenderSearchGateway: PrisonerOffenderSearchGateway,
+  @MockBean val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
+  @MockBean val nDeliusGateway: NDeliusGateway,
   private val getOffencesForPersonService: GetOffencesForPersonService,
 ) : DescribeSpec(
   {
     val pncId = "1234/56789B"
     val prisonerNumber = "Z99999ZZ"
+    val nDeliusCRN = "X123456"
+    val prisonOffence1 = Offence(cjsCode = "RR12345", description = "Prision Offence 1", startDate = LocalDate.parse("2020-02-03"), endDate = LocalDate.parse("2020-03-03"), courtDate = LocalDate.parse("2020-04-03"), statuteCode = "RR12")
+    val prisonOffence2 = Offence(cjsCode = "RR54321", description = "Prision Offence 2", startDate = LocalDate.parse("2021-03-04"), endDate = LocalDate.parse("2021-04-04"), courtDate = LocalDate.parse("2021-05-04"), statuteCode = "RR54")
+    val prisonOffence3 = Offence(cjsCode = "RR24680", description = "Prision Offence 3", startDate = LocalDate.parse("2022-04-05"), endDate = LocalDate.parse("2022-05-05"), courtDate = LocalDate.parse("2022-06-05"), statuteCode = "RR24")
+    val probationOffence1 = Offence(cjsCode = null, description = "Probation Offence 1", startDate = null, endDate = null, courtDate = null, statuteCode = null)
+    val probationOffence2 = Offence(cjsCode = null, description = "Probation Offence 2", startDate = null, endDate = null, courtDate = null, statuteCode = null)
+    val probationOffence3 = Offence(cjsCode = null, description = "Probation Offence 3", startDate = null, endDate = null, courtDate = null, statuteCode = null)
 
     beforeEach {
       Mockito.reset(nomisGateway)
+      Mockito.reset(nDeliusGateway)
+      Mockito.reset(probationOffenderSearchGateway)
+      Mockito.reset(prisonerOffenderSearchGateway)
 
       whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
         Response(data = listOf(Person(firstName = "Chandler", lastName = "Bing", identifiers = Identifiers(nomisNumber = prisonerNumber)))),
       )
 
+      whenever(probationOffenderSearchGateway.getPerson(pncId = pncId)).thenReturn(
+        Response(data = Person(firstName = "Chandler", lastName = "ProbationBing", identifiers = Identifiers(deliusCrn = nDeliusCRN))),
+      )
+
       whenever(nomisGateway.getOffencesForPerson(prisonerNumber)).thenReturn(
         Response(
           data = listOf(
-            Offence(cjsCode = "RR12345", description = "First Offence", startDate = LocalDate.parse("2020-02-03"), endDate = LocalDate.parse("2020-03-03"), courtDate = LocalDate.parse("2020-04-03"), statuteCode = "RR12"),
-            Offence(cjsCode = "RR54321", description = "Second Offence", startDate = LocalDate.parse("2021-03-04"), endDate = LocalDate.parse("2021-04-04"), courtDate = LocalDate.parse("2021-05-04"), statuteCode = "RR54"),
-            Offence(cjsCode = "RR24680", description = "Third Offence", startDate = LocalDate.parse("2022-04-05"), endDate = LocalDate.parse("2022-05-05"), courtDate = LocalDate.parse("2022-06-05"), statuteCode = "RR24"),
+            prisonOffence1,
+            prisonOffence2,
+            prisonOffence3,
+          ),
+        ),
+      )
+
+      whenever(nDeliusGateway.getOffencesForPerson(nDeliusCRN)).thenReturn(
+        Response(
+          data = listOf(
+            probationOffence1,
+            probationOffence2,
+            probationOffence3,
           ),
         ),
       )
@@ -56,20 +85,59 @@ internal class GetOffencesForPersonServiceTest(
       verify(prisonerOffenderSearchGateway, VerificationModeFactory.times(1)).getPersons(pncId = pncId)
     }
 
-    it("retrieves offences for a person from NOMIS using prisoner number") {
+    it("retrieves nDelius CRN from Probation Offender Search using a PNC ID") {
+      getOffencesForPersonService.execute(pncId)
+
+      verify(probationOffenderSearchGateway, VerificationModeFactory.times(1)).getPerson(pncId = pncId)
+    }
+
+    it("retrieves offences from NOMIS using a prisoner number") {
       getOffencesForPersonService.execute(pncId)
 
       verify(nomisGateway, VerificationModeFactory.times(1)).getOffencesForPerson(prisonerNumber)
     }
 
-    it("returns all offences for a person") {
-      val response = getOffencesForPersonService.execute(pncId)
+    it("retrieves offences from nDelius using a CRN") {
+      getOffencesForPersonService.execute(pncId)
 
-      response.data.shouldHaveSize(3)
+      verify(nDeliusGateway, VerificationModeFactory.times(1)).getOffencesForPerson(nDeliusCRN)
     }
 
-    it("returns an error when person cannot be found in NOMIS from a PNCID") {
+    it("combines and returns offences from Nomis and nDelius") {
+      val response = getOffencesForPersonService.execute(pncId)
+
+      response.data.shouldBe(
+        listOf(
+          prisonOffence1,
+          prisonOffence2,
+          prisonOffence3,
+          probationOffence1,
+          probationOffence2,
+          probationOffence3,
+        ),
+      )
+    }
+
+    it("records errors when offences cannot be found in NOMIS") {
       whenever(nomisGateway.getOffencesForPerson(prisonerNumber)).thenReturn(
+        Response(
+          data = emptyList(),
+          errors = listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NOMIS,
+              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+            ),
+          ),
+        ),
+      )
+
+      val response = getOffencesForPersonService.execute(pncId)
+
+      response.errors.shouldHaveSize(1)
+    }
+
+    it("returns errors when offences cannot be found in nDelius") {
+      whenever(nDeliusGateway.getOffencesForPerson(nDeliusCRN)).thenReturn(
         Response(
           data = emptyList(),
           errors = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
@@ -23,7 +23,7 @@ class OffencesSmokeTest : DescribeSpec(
     val httpClient = HttpClient.newBuilder().build()
     val httpRequest = HttpRequest.newBuilder()
 
-    it("returns offences for a person") {
+    xit("returns offences for a person") {
       val response = httpClient.send(
         httpRequest.uri(URI.create("$baseUrl/$basePath")).build(),
         HttpResponse.BodyHandlers.ofString(),
@@ -41,6 +41,14 @@ class OffencesSmokeTest : DescribeSpec(
             "endDate": "2018-03-10",
             "startDate": "2018-02-10",
             "statuteCode": "RR84"
+          },
+          {
+            "cjsCode": null,
+            "courtDate": null,
+            "description": "Commit an act / series of acts with intent to pervert the course of public justice",
+            "endDate": null,
+            "startDate": null,
+            "statuteCode": null
           }
         ],
           "pagination": {


### PR DESCRIPTION
This is a minimal integration with nDelius to pull back the description
of the main offence.

Pull requests to follow this:
  - The court date field will become a list
  - Check nullability of fields and remove where possible
  - Enable smoke tests for offences once API documentation is public
  - Combine main and additional offences
  - Include other fields to fill out the schema