### PR TITLE
Convert single court date to list of court dates for Offences

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Offence.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class Offence(
   val cjsCode: String? = null,
-  val courtDate: LocalDate? = null,
+  val courtDates: List<LocalDate?> = listOf(),
   val description: String? = null,
   val endDate: LocalDate? = null,
   val startDate: LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/CourtAppearance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/CourtAppearance.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
+
+data class CourtAppearance(
+  val date: CharSequence? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervision.kt
@@ -1,13 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 data class Supervision(
   val mainOffence: MainOffence = MainOffence(),
+  val courtAppearances: List<CourtAppearance> = listOf(CourtAppearance()),
 ) {
   fun toOffence(): Offence = Offence(
     cjsCode = null,
-    courtDate = null,
+    courtDates = this.courtAppearances.map { LocalDate.parse(it.date, DateTimeFormatter.ISO_OFFSET_DATE_TIME) }.filterNotNull(),
     endDate = null,
     startDate = null,
     statuteCode = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetail.kt
@@ -13,7 +13,7 @@ data class OffenceHistoryDetail(
 ) {
   fun toOffence(): Offence = Offence(
     cjsCode = this.offenceCode,
-    courtDate = this.courtDate,
+    courtDates = listOf(this.courtDate).filterNotNull(),
     description = this.offenceDescription,
     endDate = this.offenceRangeDate,
     startDate = this.offenceDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -42,7 +42,7 @@ internal class OffencesControllerTest(
             data = listOf(
               Offence(
                 cjsCode = "RR99999",
-                courtDate = LocalDate.parse("2023-03-03"),
+                courtDates = listOf(LocalDate.parse("2023-03-03")),
                 description = "This is a description of an offence.",
                 endDate = LocalDate.parse("2023-02-01"),
                 startDate = LocalDate.parse("2023-01-01"),
@@ -73,7 +73,7 @@ internal class OffencesControllerTest(
           "data": [
             {
               "cjsCode": "RR99999",
-              "courtDate":"2023-03-03",
+              "courtDates": ["2023-03-03"],
               "description": "This is a description of an offence.",
               "endDate":"2023-02-01",
               "startDate": "2023-01-01",
@@ -128,7 +128,7 @@ internal class OffencesControllerTest(
             List(20) {
               Offence(
                 cjsCode = "RR99999",
-                courtDate = LocalDate.parse("2023-03-03"),
+                courtDates = listOf(LocalDate.parse("2023-03-03")),
                 description = "This is a description of an offence.",
                 endDate = LocalDate.parse("2023-02-01"),
                 startDate = LocalDate.parse("2023-01-01"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/OffenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/OffenceHelper.kt
@@ -8,13 +8,13 @@ fun generateTestOffence(
   description: String? = "Some description",
   startDate: LocalDate? = LocalDate.parse("2020-02-03"),
   endDate: LocalDate? = LocalDate.parse("2020-03-03"),
-  courtDate: LocalDate? = LocalDate.parse("2020-04-03"),
+  courtDates: List<LocalDate?> = listOf(LocalDate.parse("2020-04-03")),
   statuteCode: String? = "RR12",
 ): Offence = Offence(
   cjsCode = cjsCode,
   description = description,
   startDate = startDate,
   endDate = endDate,
-  courtDate = courtDate,
+  courtDates = courtDates,
   statuteCode = statuteCode,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import java.time.LocalDate
 
 class SupervisionsTest : DescribeSpec(
   {
@@ -10,8 +11,18 @@ class SupervisionsTest : DescribeSpec(
       it("maps one-to-one attributes to integration API attributes") {
         val supervisions = Supervisions(
           supervisions = listOf(
-            Supervision(mainOffence = MainOffence(description = "foobar")),
-            Supervision(mainOffence = MainOffence(description = "barbaz")),
+            Supervision(
+              mainOffence = MainOffence(description = "foobar"),
+              courtAppearances = listOf(
+                CourtAppearance(date = "2009-07-07T00:00:00+01:00"),
+              ),
+            ),
+            Supervision(
+              mainOffence = MainOffence(description = "barbaz"),
+              courtAppearances = listOf(
+                CourtAppearance(date = "2010-07-07T00:00:00+01:00"),
+              ),
+            ),
           ),
         )
 
@@ -19,8 +30,14 @@ class SupervisionsTest : DescribeSpec(
 
         integrationApiOffences.shouldBe(
           listOf(
-            Offence(description = "foobar"),
-            Offence(description = "barbaz"),
+            Offence(
+              description = "foobar",
+              courtDates = listOf(LocalDate.parse("2009-07-07")),
+            ),
+            Offence(
+              description = "barbaz",
+              courtDates = listOf(LocalDate.parse("2010-07-07")),
+            ),
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetailTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenceHistoryDetailTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import java.time.LocalDate
@@ -21,7 +22,7 @@ class OffenceHistoryDetailTest : DescribeSpec(
         val integrationApiOffence = offenceHistoryDetail.toOffence()
 
         integrationApiOffence.cjsCode.shouldBe(offenceHistoryDetail.offenceCode)
-        integrationApiOffence.courtDate.shouldBe(offenceHistoryDetail.courtDate)
+        integrationApiOffence.courtDates.shouldBe(listOf(offenceHistoryDetail.courtDate))
         integrationApiOffence.description.shouldBe(offenceHistoryDetail.offenceDescription)
         integrationApiOffence.endDate.shouldBe(offenceHistoryDetail.offenceRangeDate)
         integrationApiOffence.startDate.shouldBe(offenceHistoryDetail.offenceDate)
@@ -38,7 +39,7 @@ class OffenceHistoryDetailTest : DescribeSpec(
         val integrationApiOffence = offenceHistoryDetail.toOffence()
 
         integrationApiOffence.cjsCode.shouldBe(offenceHistoryDetail.offenceCode)
-        integrationApiOffence.courtDate.shouldBeNull()
+        integrationApiOffence.courtDates.shouldBeEmpty()
         integrationApiOffence.description.shouldBe(offenceHistoryDetail.offenceDescription)
         integrationApiOffence.endDate.shouldBeNull()
         integrationApiOffence.startDate.shouldBeNull()


### PR DESCRIPTION
Support Offences with multiple court dates

An offence in Nomis only has one associated court date, where nDelius
has multiple. Update our schema to support multiple dates, where Nomis
would always be a list of one.