### PR TITLE
Handle person not found in upstream search APIs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -33,7 +33,7 @@ class GetOffencesForPersonService(
 
     var nomisOffences: Response<List<Offence>> = Response(data = emptyList())
 
-    if(nomisNumber != null) {
+    if (nomisNumber != null) {
       nomisOffences = nomisGateway.getOffencesForPerson(nomisNumber)
 
       if (nomisOffences.errors.isNotEmpty()) {
@@ -43,7 +43,7 @@ class GetOffencesForPersonService(
 
     var nDeliusOffences: Response<List<Offence>> = Response(data = emptyList())
 
-    if(deliusCrn != null) {
+    if (deliusCrn != null) {
       nDeliusOffences = nDeliusGateway.getOffencesForPerson(deliusCrn)
 
       if (nDeliusOffences.errors.isNotEmpty()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -34,11 +34,11 @@ class GetOffencesForPersonService(
 
     return Response(
       data = nomisOffences.data +
-             nDeliusOffences.data,
+        nDeliusOffences.data,
       errors = responseFromPrisonerOffenderSearch.errors +
-               responseFromProbationOffenderSearch.errors +
-               nomisOffences.errors +
-               nDeliusOffences.errors
+        responseFromProbationOffenderSearch.errors +
+        nomisOffences.errors +
+        nDeliusOffences.errors,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonService.kt
@@ -28,15 +28,27 @@ class GetOffencesForPersonService(
       return Response(emptyList(), responseFromProbationOffenderSearch.errors)
     }
 
-    val nomisOffences = nomisGateway.getOffencesForPerson(responseFromPrisonerOffenderSearch.data.first().identifiers.nomisNumber!!)
-    val nDeliusOffences = nDeliusGateway.getOffencesForPerson(responseFromProbationOffenderSearch.data?.identifiers?.deliusCrn!!)
+    val nomisNumber = responseFromPrisonerOffenderSearch.data.firstOrNull()?.identifiers?.nomisNumber
+    val deliusCrn = responseFromProbationOffenderSearch.data?.identifiers?.deliusCrn
 
-    if (nomisOffences.errors.isNotEmpty()) {
-      return Response(emptyList(), nomisOffences.errors)
+    var nomisOffences: Response<List<Offence>> = Response(data = emptyList())
+
+    if(nomisNumber != null) {
+      nomisOffences = nomisGateway.getOffencesForPerson(nomisNumber)
+
+      if (nomisOffences.errors.isNotEmpty()) {
+        return Response(emptyList(), nomisOffences.errors)
+      }
     }
 
-    if (nDeliusOffences.errors.isNotEmpty()) {
-      return Response(emptyList(), nDeliusOffences.errors)
+    var nDeliusOffences: Response<List<Offence>> = Response(data = emptyList())
+
+    if(deliusCrn != null) {
+      nDeliusOffences = nDeliusGateway.getOffencesForPerson(deliusCrn)
+
+      if (nDeliusOffences.errors.isNotEmpty()) {
+        return Response(emptyList(), nDeliusOffences.errors)
+      }
     }
 
     return Response(data = nomisOffences.data + nDeliusOffences.data)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
@@ -78,6 +78,30 @@ internal class GetOffencesForPersonServiceTest(
       )
     }
 
+    it("returns an empty list of offences when Prisoner Offender Search couldn't find any people by PNC ID") {
+      whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
+        Response(
+          data = emptyList(),
+        ),
+      )
+
+      val result = getOffencesForPersonService.execute(pncId)
+
+      result.shouldBe(Response(data = listOf(probationOffence1, probationOffence2, probationOffence3)))
+    }
+
+    it("returns an empty list of offences when Probation Offender Search couldn't find the person by PNC ID") {
+      whenever(probationOffenderSearchGateway.getPerson(pncId = pncId)).thenReturn(
+        Response(
+          data = null,
+        ),
+      )
+
+      val result = getOffencesForPersonService.execute(pncId)
+
+      result.shouldBe(Response(data = listOf(prisonOffence1, prisonOffence2, prisonOffence3)))
+    }
+
     it("retrieves prisoner ID from Prisoner Offender Search using a PNC ID") {
       getOffencesForPersonService.execute(pncId)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
@@ -154,7 +154,7 @@ internal class GetOffencesForPersonServiceTest(
                 type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
               ),
             ),
-          )
+          ),
         )
 
         whenever(probationOffenderSearchGateway.getPerson(pncId = pncId)).thenReturn(
@@ -166,7 +166,7 @@ internal class GetOffencesForPersonServiceTest(
                 type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
               ),
             ),
-          )
+          ),
         )
       }
 
@@ -196,7 +196,7 @@ internal class GetOffencesForPersonServiceTest(
               type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
             ),
           ),
-        )
+        ),
       )
 
       whenever(nomisGateway.getOffencesForPerson(id = prisonerNumber)).thenReturn(
@@ -208,7 +208,7 @@ internal class GetOffencesForPersonServiceTest(
               type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
             ),
           ),
-        )
+        ),
       )
 
       val response = getOffencesForPersonService.execute(pncId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetOffencesForPersonServiceTest.kt
@@ -78,10 +78,11 @@ internal class GetOffencesForPersonServiceTest(
       )
     }
 
-    it("returns an empty list of offences when Prisoner Offender Search couldn't find any people by PNC ID") {
+    it("Doesn't return prison offences when Prison Offender Search couldn't find the person by PNC ID") {
       whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(
         Response(
           data = emptyList(),
+          errors = emptyList(),
         ),
       )
 
@@ -90,10 +91,11 @@ internal class GetOffencesForPersonServiceTest(
       result.shouldBe(Response(data = listOf(probationOffence1, probationOffence2, probationOffence3)))
     }
 
-    it("returns an empty list of offences when Probation Offender Search couldn't find the person by PNC ID") {
+    it("Doesn't return probation offences when Probation Offender Search couldn't find the person by PNC ID") {
       whenever(probationOffenderSearchGateway.getPerson(pncId = pncId)).thenReturn(
         Response(
           data = null,
+          errors = emptyList(),
         ),
       )
 


### PR DESCRIPTION
When an upstream API returns 200 but no results for a person lookup, we need to stop further API calls with null values.