### PR TITLE
Update sentence length restructure

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Length.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Length.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
-
-data class Length(
-  val duration: Int? = null,
-  val units: String? = null,
-  val terms: List<Term> = listOf(Term()),
-)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Length.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Length.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class Length(
+  val duration: Int? = null,
+  val units: String? = null,
+  val terms: List<Term> = listOf(Term()),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Sentence.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength as IntegrationApiLength
 
 data class Sentence(
   val dataSource: UpstreamApi,
@@ -10,5 +9,5 @@ data class Sentence(
   val isActive: Boolean? = null,
   val isCustodial: Boolean,
   val fineAmount: Number? = null,
-  val length: IntegrationApiLength = IntegrationApiLength(),
+  val length: SentenceLength = SentenceLength(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Sentence.kt
@@ -1,7 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length as IntegrationApiLength
+
 data class Sentence(
   val dataSource: UpstreamApi,
   val dateOfSentencing: LocalDate? = null,
@@ -9,5 +10,5 @@ data class Sentence(
   val isActive: Boolean? = null,
   val isCustodial: Boolean,
   val fineAmount: Number? = null,
-  val terms: List<IntegrationApiTerm> = listOf(IntegrationApiTerm()),
+  val length: IntegrationApiLength = IntegrationApiLength(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Sentence.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length as IntegrationApiLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength as IntegrationApiLength
 
 data class Sentence(
   val dataSource: UpstreamApi,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceLength.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceLength.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 data class SentenceLength(
   val duration: Int? = null,
   val units: String? = null,
-  val terms: List<SentenceTerm> = listOf(SentenceTerm()),
+  val terms: List<SentenceTerm> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceLength.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceLength.kt
@@ -3,5 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 data class SentenceLength(
   val duration: Int? = null,
   val units: String? = null,
-  val terms: List<Term> = listOf(Term()),
+  val terms: List<SentenceTerm> = listOf(SentenceTerm()),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceLength.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceLength.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class SentenceLength(
-  val days: Int? = null,
-  val weeks: Int? = null,
-  val months: Int? = null,
-  val years: Int? = null,
+  val duration: Int? = null,
+  val units: String? = null,
+  val terms: List<Term> = listOf(Term()),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceTerm.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceTerm.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
-data class Term(
+data class SentenceTerm(
   val years: Int? = null,
   val months: Int? = null,
   val weeks: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Sentence.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length as IntegrationApiLength
 
 data class Sentence(
   val date: String? = null,
@@ -8,14 +8,11 @@ data class Sentence(
   val length: Int? = null,
   val lengthUnits: String? = null,
 ) {
-  fun toTerm(): List<IntegrationApiTerm> {
-    return when (this.lengthUnits?.lowercase()) {
-      "years" -> listOf(IntegrationApiTerm(years = this.length))
-      "months" -> listOf(IntegrationApiTerm(months = this.length))
-      "weeks" -> listOf(IntegrationApiTerm(weeks = this.length))
-      "days" -> listOf(IntegrationApiTerm(days = this.length))
-      "hours" -> listOf(IntegrationApiTerm(hours = this.length))
-      else -> listOf(IntegrationApiTerm())
-    }
+  fun toLength(): IntegrationApiLength {
+    return IntegrationApiLength(
+      duration = this.length,
+      units = this.lengthUnits?.lowercase(),
+      terms = emptyList(),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Sentence.kt
@@ -11,7 +11,7 @@ data class Sentence(
   fun toLength(): IntegrationApiLength {
     return IntegrationApiLength(
       duration = this.length,
-      units = this.lengthUnits?.lowercase(),
+      units = this.lengthUnits,
       terms = emptyList(),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Sentence.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length as IntegrationApiLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength as IntegrationApiLength
 
 data class Sentence(
   val date: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/Supervision.kt
@@ -28,7 +28,7 @@ data class Supervision(
       fineAmount = null,
       isActive = this.active,
       isCustodial = this.custodial,
-      terms = this.sentence.toTerm(),
+      length = this.sentence.toLength(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Sentence.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length as IntegrationApiLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength as IntegrationApiLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence as IntegrationApiSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Term as NomisTerm
 data class Sentence(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Sentence.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength as IntegrationApiLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence as IntegrationApiSentence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength as IntegrationApiSentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Term as NomisTerm
 data class Sentence(
   val fineAmount: Number? = null,
@@ -19,7 +19,7 @@ data class Sentence(
     fineAmount = this.fineAmount,
     isActive = sentenceStatusToBoolean(this.sentenceStatus),
     isCustodial = true,
-    length = IntegrationApiLength(terms = this.terms.map { it.toTerm() }),
+    length = IntegrationApiSentenceLength(terms = this.terms.map { it.toTerm() }),
   )
 }
 private fun sentenceStatusToBoolean(sentenceStatus: String?): Boolean? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Sentence.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length as IntegrationApiLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence as IntegrationApiSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Term as NomisTerm
 data class Sentence(
@@ -18,7 +19,7 @@ data class Sentence(
     fineAmount = this.fineAmount,
     isActive = sentenceStatusToBoolean(this.sentenceStatus),
     isCustodial = true,
-    terms = this.terms.map { it.toTerm() },
+    length = IntegrationApiLength(terms = this.terms.map { it.toTerm() }),
   )
 }
 private fun sentenceStatusToBoolean(sentenceStatus: String?): Boolean? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Term.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/Term.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceTerm as IntegrationApiTerm
 
 data class Term(
   val years: Int? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/SentencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/SentencesControllerTest.kt
@@ -72,24 +72,28 @@ internal class SentencesControllerTest(
                 "isActive": true,
                 "isCustodial": true,
                 "fineAmount": null,
-                "terms": [
-                  {
-                    "years": null,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": 2,
-                    "prisonTermCode": null
-                  },
-                  {
-                    "years": 25,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": null,
-                    "prisonTermCode": null
-                  }
-                ]
+                "length": {
+                  "duration": null,
+                  "units": null,
+                  "terms": [
+                    {
+                      "years": null,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": 2,
+                      "prisonTermCode": null
+                    },
+                    {
+                      "years": 25,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": null,
+                      "prisonTermCode": null
+                    }
+                  ]
+                }
               },
               {
                 "dataSource": "NOMIS",
@@ -98,24 +102,28 @@ internal class SentencesControllerTest(
                 "isActive": true,
                 "isCustodial": true,
                 "fineAmount": null,
-                "terms": [
-                  {
-                    "years": null,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": 2,
-                    "prisonTermCode": null
-                  },
-                  {
-                    "years": 25,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": null,
-                    "prisonTermCode": null
-                  }
-                ]
+                "length": {
+                  "duration": null,
+                  "units": null,
+                  "terms": [
+                    {
+                      "years": null,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": 2,
+                      "prisonTermCode": null
+                    },
+                    {
+                      "years": 25,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": null,
+                      "prisonTermCode": null
+                    }
+                  ]
+                }
               }
             ]
           """.removeWhitespaceAndNewlines(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NDeliusApiMockServer
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.io.File
@@ -70,7 +70,7 @@ class GetSentencesForPersonTest(
               description = "CJA - Community Order",
               isActive = false,
               isCustodial = false,
-              length = Length(
+              length = SentenceLength(
                 duration = 12,
                 units = "months",
                 terms = emptyList(),
@@ -82,7 +82,7 @@ class GetSentencesForPersonTest(
               description = "CJA - Suspended Sentence Order",
               isActive = true,
               isCustodial = false,
-              length = Length(
+              length = SentenceLength(
                 duration = 12,
                 units = "years",
                 terms = emptyList(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
@@ -72,7 +72,7 @@ class GetSentencesForPersonTest(
               isCustodial = false,
               length = SentenceLength(
                 duration = 12,
-                units = "months",
+                units = "Months",
                 terms = emptyList(),
               ),
             ),
@@ -84,7 +84,7 @@ class GetSentencesForPersonTest(
               isCustodial = false,
               length = SentenceLength(
                 duration = 12,
-                units = "years",
+                units = "Years",
                 terms = emptyList(),
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
@@ -18,11 +18,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NDeliusApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.io.File
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
 
 @ActiveProfiles("test")
 @ContextConfiguration(
@@ -70,7 +70,11 @@ class GetSentencesForPersonTest(
               description = "CJA - Community Order",
               isActive = false,
               isCustodial = false,
-              terms = listOf(IntegrationApiTerm(months = 12)),
+              length = Length(
+                duration = 12,
+                units = "months",
+                terms = emptyList(),
+              ),
             ),
             generateTestSentence(
               dataSource = UpstreamApi.NDELIUS,
@@ -78,7 +82,11 @@ class GetSentencesForPersonTest(
               description = "CJA - Suspended Sentence Order",
               isActive = true,
               isCustodial = false,
-              terms = listOf(IntegrationApiTerm(years = 12)),
+              length = Length(
+                duration = 12,
+                units = "years",
+                terms = emptyList(),
+              ),
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentencesForPersonTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceTerm as IntegrationApiTerm
 
 @ActiveProfiles("test")
 @ContextConfiguration(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentencesForPersonTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.time.LocalDate
@@ -100,12 +101,14 @@ class GetSentencesForPersonTest(
               fineAmount = 40,
               isActive = true,
               isCustodial = true,
-              terms = listOf(
-                IntegrationApiTerm(
-                  years = 1,
-                  months = 2,
-                  weeks = 3,
-                  days = 4,
+              length = Length(
+                terms = listOf(
+                  IntegrationApiTerm(
+                    years = 1,
+                    months = 2,
+                    weeks = 3,
+                    days = 4,
+                  ),
                 ),
               ),
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentencesForPersonTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.time.LocalDate
@@ -101,7 +101,7 @@ class GetSentencesForPersonTest(
               fineAmount = 40,
               isActive = true,
               isCustodial = true,
-              length = Length(
+              length = SentenceLength(
                 terms = listOf(
                   IntegrationApiTerm(
                     years = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceTerm
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
 
@@ -17,8 +17,8 @@ fun generateTestSentence(
     duration = null,
     units = null,
     terms = listOf(
-      Term(hours = 2),
-      Term(years = 25),
+      SentenceTerm(hours = 2),
+      SentenceTerm(years = 25),
     ),
   ),
 ): Sentence = Sentence(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
@@ -13,7 +13,7 @@ fun generateTestSentence(
   fineAmount: Number? = null,
   isActive: Boolean? = true,
   isCustodial: Boolean = true,
-  length: Length = Length(
+  length: SentenceLength = SentenceLength(
     duration = null,
     units = null,
     terms = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
@@ -12,9 +13,13 @@ fun generateTestSentence(
   fineAmount: Number? = null,
   isActive: Boolean? = true,
   isCustodial: Boolean = true,
-  terms: List<Term> = listOf(
-    Term(hours = 2),
-    Term(years = 25),
+  length: Length = Length(
+    duration = null,
+    units = null,
+    terms = listOf(
+      Term(hours = 2),
+      Term(years = 25),
+    ),
   ),
 ): Sentence = Sentence(
   dataSource = dataSource,
@@ -23,5 +28,5 @@ fun generateTestSentence(
   fineAmount = fineAmount,
   isActive = isActive,
   isCustodial = isCustodial,
-  terms = terms,
+  length = length,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
@@ -140,7 +140,7 @@ class SupervisionsTest : DescribeSpec(
               dataSource = UpstreamApi.NDELIUS,
               dateOfSentencing = LocalDate.parse("2009-07-07"),
               description = "CJA - Community Order",
-              length = Length(
+              length = SentenceLength(
                 duration = 10,
                 units = "years",
                 terms = emptyList(),
@@ -151,7 +151,7 @@ class SupervisionsTest : DescribeSpec(
               dateOfSentencing = LocalDate.parse("2010-07-07"),
               isActive = false,
               description = "CJA - Suspended Sentence Order",
-              length = Length(
+              length = SentenceLength(
                 duration = 4,
                 units = "weeks",
                 terms = emptyList(),
@@ -175,7 +175,7 @@ class SupervisionsTest : DescribeSpec(
             isCustodial = true,
             description = null,
             dateOfSentencing = null,
-            length = Length(
+            length = SentenceLength(
               duration = null,
               units = null,
               terms = emptyList(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.Sentence as NDeliusSentence

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -1,11 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.Sentence as NDeliusSentence
@@ -109,8 +109,26 @@ class SupervisionsTest : DescribeSpec(
       it("maps one-to-one attributes to integration API sentence attributes") {
         val supervisions = Supervisions(
           listOf(
-            Supervision(active = true, custodial = true, sentence = NDeliusSentence(date = "2009-07-07", description = "CJA - Community Order")),
-            Supervision(active = false, custodial = true, sentence = NDeliusSentence(date = "2010-07-07", description = "CJA - Suspended Sentence Order")),
+            Supervision(
+              active = true,
+              custodial = true,
+              sentence = NDeliusSentence(
+                date = "2009-07-07",
+                description = "CJA - Community Order",
+                length = 10,
+                lengthUnits = "years",
+              ),
+            ),
+            Supervision(
+              active = false,
+              custodial = true,
+              sentence = NDeliusSentence(
+                date = "2010-07-07",
+                description = "CJA - Suspended Sentence Order",
+                length = 4,
+                lengthUnits = "weeks",
+              ),
+            ),
           ),
         )
 
@@ -122,50 +140,48 @@ class SupervisionsTest : DescribeSpec(
               dataSource = UpstreamApi.NDELIUS,
               dateOfSentencing = LocalDate.parse("2009-07-07"),
               description = "CJA - Community Order",
-              terms = listOf(Term()),
+              length = Length(
+                duration = 10,
+                units = "years",
+                terms = emptyList(),
+              ),
             ),
             generateTestSentence(
               dataSource = UpstreamApi.NDELIUS,
               dateOfSentencing = LocalDate.parse("2010-07-07"),
               isActive = false,
               description = "CJA - Suspended Sentence Order",
-              terms = listOf(Term()),
+              length = Length(
+                duration = 4,
+                units = "weeks",
+                terms = emptyList(),
+              ),
             ),
           ),
         )
       }
 
-      xit("maps nDelius sentence length to Integration API terms") {
+      it("can be constructed with NULL values") {
         val supervisions = Supervisions(
           listOf(
-            Supervision(active = true, custodial = true, sentence = NDeliusSentence(date = "2009-07-07", description = "CJA - Community Order")),
-            Supervision(active = false, custodial = true, sentence = NDeliusSentence(date = "2010-07-07", description = "CJA - Suspended Sentence Order")),
-          ),
-        )
-
-        val integrationApiSentences = supervisions.supervisions.map { it.toSentence() }
-
-        integrationApiSentences[0].terms.shouldBe(listOf(Term()))
-        integrationApiSentences[1].terms.shouldBe(listOf(Term()))
-      }
-
-      it("deals with NULL values") {
-        val supervisions = Supervisions(
-          listOf(
-            Supervision(custodial = true),
             Supervision(custodial = true),
           ),
         )
 
-        val integrationApiSentences = supervisions.supervisions.map { it.toSentence() }
-
-        for (integrationApiSentence in integrationApiSentences) {
-          integrationApiSentence.dateOfSentencing.shouldBeNull()
-          integrationApiSentence.isActive.shouldBeNull()
-          integrationApiSentence.description.shouldBeNull()
-          integrationApiSentence.terms.first().prisonTermCode.shouldBeNull()
-          integrationApiSentence.terms.shouldBe(listOf(Term()))
-        }
+        supervisions.supervisions.first().toSentence().shouldBe(
+          Sentence(
+            dataSource = UpstreamApi.NDELIUS,
+            isActive = null,
+            isCustodial = true,
+            description = null,
+            dateOfSentencing = null,
+            length = Length(
+              duration = null,
+              units = null,
+              terms = emptyList(),
+            ),
+          ),
+        )
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence as IntegrationApiSentence
@@ -50,23 +50,27 @@ class PersonSentencesTest : DescribeSpec(
 
         val integrationApiSentence = nomisSentence.toSentence()
 
-        integrationApiSentence.terms.shouldBe(
-          listOf(
-            IntegrationApiTerm(
-              years = 3,
-              months = 4,
-              weeks = null,
-              days = 2,
-              hours = null,
-              prisonTermCode = "Z",
-            ),
-            IntegrationApiTerm(
-              years = 7,
-              months = 3,
-              weeks = 4,
-              days = null,
-              hours = null,
-              prisonTermCode = "Y",
+        integrationApiSentence.length.shouldBe(
+          Length(
+            duration = null,
+            units = null,
+            terms = listOf(
+              IntegrationApiTerm(
+                years = 3,
+                months = 4,
+                weeks = null,
+                days = 2,
+                hours = null,
+                prisonTermCode = "Z",
+              ),
+              IntegrationApiTerm(
+                years = 7,
+                months = 3,
+                weeks = 4,
+                days = null,
+                hours = null,
+                prisonTermCode = "Y",
+              ),
             ),
           ),
         )
@@ -86,23 +90,27 @@ class PersonSentencesTest : DescribeSpec(
 
         val integrationApiSentence = nomisSentence.toSentence()
 
-        integrationApiSentence.terms.shouldBe(
-          listOf(
-            IntegrationApiTerm(
-              years = 3,
-              months = null,
-              weeks = null,
-              days = null,
-              hours = null,
-              prisonTermCode = null,
-            ),
-            IntegrationApiTerm(
-              years = null,
-              months = 3,
-              weeks = null,
-              days = null,
-              hours = null,
-              prisonTermCode = null,
+        integrationApiSentence.length.shouldBe(
+          Length(
+            duration = null,
+            units = null,
+            terms = listOf(
+              IntegrationApiTerm(
+                years = 3,
+                months = null,
+                weeks = null,
+                days = null,
+                hours = null,
+                prisonTermCode = null,
+              ),
+              IntegrationApiTerm(
+                years = null,
+                months = 3,
+                weeks = null,
+                days = null,
+                hours = null,
+                prisonTermCode = null,
+              ),
             ),
           ),
         )
@@ -120,15 +128,19 @@ class PersonSentencesTest : DescribeSpec(
 
         val integrationApiSentence = nomisSentence.toSentence()
 
-        integrationApiSentence.terms.shouldBe(
-          listOf(
-            IntegrationApiTerm(
-              years = 3,
-              months = 9,
-              weeks = null,
-              days = null,
-              hours = null,
-              prisonTermCode = null,
+        integrationApiSentence.length.shouldBe(
+          Length(
+            duration = null,
+            units = null,
+            terms = listOf(
+              IntegrationApiTerm(
+                years = 3,
+                months = 9,
+                weeks = null,
+                days = null,
+                hours = null,
+                prisonTermCode = null,
+              ),
             ),
           ),
         )
@@ -160,11 +172,30 @@ class PersonSentencesTest : DescribeSpec(
 
       it("deals with NULL values") {
         val integrationApiSentence = IntegrationApiSentence(isCustodial = true, dataSource = UpstreamApi.NOMIS)
-        integrationApiSentence.dateOfSentencing.shouldBeNull()
-        integrationApiSentence.isActive.shouldBeNull()
-        integrationApiSentence.fineAmount.shouldBeNull()
-        integrationApiSentence.terms.shouldBe(listOf(IntegrationApiTerm()))
-        integrationApiSentence.description.shouldBeNull()
+        integrationApiSentence.shouldBe(
+          IntegrationApiSentence(
+            dataSource = UpstreamApi.NOMIS,
+            dateOfSentencing = null,
+            description = null,
+            isActive = null,
+            isCustodial = true,
+            fineAmount = null,
+            length = Length(
+              duration = null,
+              units = null,
+              terms = listOf(
+                IntegrationApiTerm(
+                  years = null,
+                  months = null,
+                  weeks = null,
+                  days = null,
+                  hours = null,
+                  prisonTermCode = null,
+                ),
+              ),
+            ),
+          ),
+        )
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence as IntegrationApiSentence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceTerm as IntegrationApiTerm
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Sentence as NomisSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Term as NomisTerm
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence as IntegrationApiSentence
@@ -51,7 +51,7 @@ class PersonSentencesTest : DescribeSpec(
         val integrationApiSentence = nomisSentence.toSentence()
 
         integrationApiSentence.length.shouldBe(
-          Length(
+          SentenceLength(
             duration = null,
             units = null,
             terms = listOf(
@@ -91,7 +91,7 @@ class PersonSentencesTest : DescribeSpec(
         val integrationApiSentence = nomisSentence.toSentence()
 
         integrationApiSentence.length.shouldBe(
-          Length(
+          SentenceLength(
             duration = null,
             units = null,
             terms = listOf(
@@ -129,7 +129,7 @@ class PersonSentencesTest : DescribeSpec(
         val integrationApiSentence = nomisSentence.toSentence()
 
         integrationApiSentence.length.shouldBe(
-          Length(
+          SentenceLength(
             duration = null,
             units = null,
             terms = listOf(
@@ -180,7 +180,7 @@ class PersonSentencesTest : DescribeSpec(
             isActive = null,
             isCustodial = true,
             fineAmount = null,
-            length = Length(
+            length = SentenceLength(
               duration = null,
               units = null,
               terms = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
@@ -183,16 +183,7 @@ class PersonSentencesTest : DescribeSpec(
             length = SentenceLength(
               duration = null,
               units = null,
-              terms = listOf(
-                IntegrationApiTerm(
-                  years = null,
-                  months = null,
-                  weeks = null,
-                  days = null,
-                  hours = null,
-                  prisonTermCode = null,
-                ),
-              ),
+              terms = emptyList(),
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffende
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Identifiers
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
@@ -71,9 +72,11 @@ internal class GetSentencesForPersonServiceTest(
             generateTestSentence(
               dateOfSentencing = LocalDate.parse("2001-01-01"),
               description = "ORA CJA03 Standard Determinate Sentence",
-              terms = listOf(
-                IntegrationApiTerm(years = 15, months = 6, weeks = 2),
-                IntegrationApiTerm(months = 6, weeks = 2, days = 5),
+              length = Length(
+                terms = listOf(
+                  IntegrationApiTerm(years = 15, months = 6, weeks = 2),
+                  IntegrationApiTerm(months = 6, weeks = 2, days = 5),
+                ),
               ),
             ),
           ),
@@ -87,9 +90,11 @@ internal class GetSentencesForPersonServiceTest(
               dateOfSentencing = LocalDate.parse("2002-01-01"),
               description = "ORA CJA04 Stealing hamburgers from the local restaurant",
               isActive = null,
-              terms = listOf(
-                IntegrationApiTerm(years = 10, weeks = 5, days = 5),
-                IntegrationApiTerm(years = 25, weeks = 5, days = 4),
+              length = Length(
+                terms = listOf(
+                  IntegrationApiTerm(years = 10, weeks = 5, days = 5),
+                  IntegrationApiTerm(years = 25, weeks = 5, days = 4),
+                ),
               ),
             ),
           ),
@@ -102,18 +107,20 @@ internal class GetSentencesForPersonServiceTest(
             generateTestSentence(
               dateOfSentencing = LocalDate.parse("2003-01-01"),
               description = "CJA - Community Order",
-              terms = listOf(
-                IntegrationApiTerm(years = 4),
-                IntegrationApiTerm(weeks = 12),
+              length = Length(
+                duration = 5,
+                units = "weeks",
+                terms = emptyList(),
               ),
             ),
             generateTestSentence(
               dateOfSentencing = LocalDate.parse("2004-01-01"),
               description = "CJA - Suspended Sentence Order",
               isActive = false,
-              terms = listOf(
-                IntegrationApiTerm(weeks = 18),
-                IntegrationApiTerm(hours = 24),
+              length = Length(
+                duration = 24,
+                units = "hours",
+                terms = emptyList(),
               ),
             ),
           ),
@@ -256,35 +263,41 @@ internal class GetSentencesForPersonServiceTest(
           generateTestSentence(
             dateOfSentencing = LocalDate.parse("2001-01-01"),
             description = "ORA CJA03 Standard Determinate Sentence",
-            terms = listOf(
-              IntegrationApiTerm(years = 15, months = 6, weeks = 2),
-              IntegrationApiTerm(months = 6, weeks = 2, days = 5),
+            length = Length(
+              terms = listOf(
+                IntegrationApiTerm(years = 15, months = 6, weeks = 2),
+                IntegrationApiTerm(months = 6, weeks = 2, days = 5),
+              ),
             ),
           ),
           generateTestSentence(
             dateOfSentencing = LocalDate.parse("2002-01-01"),
             description = "ORA CJA04 Stealing hamburgers from the local restaurant",
             isActive = null,
-            terms = listOf(
-              IntegrationApiTerm(years = 10, weeks = 5, days = 5),
-              IntegrationApiTerm(years = 25, weeks = 5, days = 4),
+            length = Length(
+              terms = listOf(
+                IntegrationApiTerm(years = 10, weeks = 5, days = 5),
+                IntegrationApiTerm(years = 25, weeks = 5, days = 4),
+              ),
             ),
           ),
           generateTestSentence(
             dateOfSentencing = LocalDate.parse("2003-01-01"),
             description = "CJA - Community Order",
-            terms = listOf(
-              IntegrationApiTerm(years = 4),
-              IntegrationApiTerm(weeks = 12),
+            length = Length(
+              duration = 5,
+              units = "weeks",
+              terms = emptyList(),
             ),
           ),
           generateTestSentence(
             dateOfSentencing = LocalDate.parse("2004-01-01"),
             description = "CJA - Suspended Sentence Order",
             isActive = false,
-            terms = listOf(
-              IntegrationApiTerm(weeks = 18),
-              IntegrationApiTerm(hours = 24),
+            length = Length(
+              duration = 24,
+              units = "hours",
+              terms = emptyList(),
             ),
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
@@ -16,14 +16,14 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffende
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Identifiers
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Booking
 import java.time.LocalDate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Term as IntegrationApiTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceTerm as IntegrationApiTerm
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffende
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Identifiers
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Length
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
@@ -72,7 +72,7 @@ internal class GetSentencesForPersonServiceTest(
             generateTestSentence(
               dateOfSentencing = LocalDate.parse("2001-01-01"),
               description = "ORA CJA03 Standard Determinate Sentence",
-              length = Length(
+              length = SentenceLength(
                 terms = listOf(
                   IntegrationApiTerm(years = 15, months = 6, weeks = 2),
                   IntegrationApiTerm(months = 6, weeks = 2, days = 5),
@@ -90,7 +90,7 @@ internal class GetSentencesForPersonServiceTest(
               dateOfSentencing = LocalDate.parse("2002-01-01"),
               description = "ORA CJA04 Stealing hamburgers from the local restaurant",
               isActive = null,
-              length = Length(
+              length = SentenceLength(
                 terms = listOf(
                   IntegrationApiTerm(years = 10, weeks = 5, days = 5),
                   IntegrationApiTerm(years = 25, weeks = 5, days = 4),
@@ -107,7 +107,7 @@ internal class GetSentencesForPersonServiceTest(
             generateTestSentence(
               dateOfSentencing = LocalDate.parse("2003-01-01"),
               description = "CJA - Community Order",
-              length = Length(
+              length = SentenceLength(
                 duration = 5,
                 units = "weeks",
                 terms = emptyList(),
@@ -117,7 +117,7 @@ internal class GetSentencesForPersonServiceTest(
               dateOfSentencing = LocalDate.parse("2004-01-01"),
               description = "CJA - Suspended Sentence Order",
               isActive = false,
-              length = Length(
+              length = SentenceLength(
                 duration = 24,
                 units = "hours",
                 terms = emptyList(),
@@ -263,7 +263,7 @@ internal class GetSentencesForPersonServiceTest(
           generateTestSentence(
             dateOfSentencing = LocalDate.parse("2001-01-01"),
             description = "ORA CJA03 Standard Determinate Sentence",
-            length = Length(
+            length = SentenceLength(
               terms = listOf(
                 IntegrationApiTerm(years = 15, months = 6, weeks = 2),
                 IntegrationApiTerm(months = 6, weeks = 2, days = 5),
@@ -274,7 +274,7 @@ internal class GetSentencesForPersonServiceTest(
             dateOfSentencing = LocalDate.parse("2002-01-01"),
             description = "ORA CJA04 Stealing hamburgers from the local restaurant",
             isActive = null,
-            length = Length(
+            length = SentenceLength(
               terms = listOf(
                 IntegrationApiTerm(years = 10, weeks = 5, days = 5),
                 IntegrationApiTerm(years = 25, weeks = 5, days = 4),
@@ -284,7 +284,7 @@ internal class GetSentencesForPersonServiceTest(
           generateTestSentence(
             dateOfSentencing = LocalDate.parse("2003-01-01"),
             description = "CJA - Community Order",
-            length = Length(
+            length = SentenceLength(
               duration = 5,
               units = "weeks",
               terms = emptyList(),
@@ -294,7 +294,7 @@ internal class GetSentencesForPersonServiceTest(
             dateOfSentencing = LocalDate.parse("2004-01-01"),
             description = "CJA - Suspended Sentence Order",
             isActive = false,
-            length = Length(
+            length = SentenceLength(
               duration = 24,
               units = "hours",
               terms = emptyList(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
@@ -46,16 +46,20 @@ class SentencesSmokeTest : DescribeSpec(
               "fineAmount": $fineAmountMinNumberValue,
               "isActive": null,
               "isCustodial": true,
-              "terms": [
-                {
-                  "years": 1,
-                  "months": 2,
-                  "weeks": 3,
-                  "days": 4,
-                  "hours": null,
-                  "prisonTermCode": "string"
-                }
-              ]
+              "length": {
+                "duration": null,
+                "units": null,
+                "terms": [
+                  {
+                    "years": 1,
+                    "months": 2,
+                    "weeks": 3,
+                    "days": 4,
+                    "hours": null,
+                    "prisonTermCode": "string"
+                  }
+                ]
+              }
             },
             {
               "dataSource": "NDELIUS",
@@ -64,16 +68,11 @@ class SentencesSmokeTest : DescribeSpec(
               "fineAmount": null,
               "isActive": true,
               "isCustodial": false,
-              "terms": [
-                {
-                  "years": null,
-                  "months": null,
-                  "weeks": null,
-                  "days": null,
-                  "hours": $hourMinIntValue,
-                  "prisonTermCode": null
-                }
-              ]
+              "length": {
+                "duration": $hourMinIntValue,
+                "units": "hours",
+                "terms": []
+              }
             }
           ],
           "pagination": {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
@@ -46,16 +46,18 @@ class SentencesSmokeTest : DescribeSpec(
               "fineAmount": $fineAmountMinNumberValue,
               "isActive": null,
               "isCustodial": true,
-              "terms": [
-                {
-                  "years": 1,
-                  "months": 2,
-                  "weeks": 3,
-                  "days": 4,
-                  "hours": null,
-                  "prisonTermCode": "string"
-                }
-              ]
+              "length": {
+                "terms": [
+                  {
+                    "years": 1,
+                    "months": 2,
+                    "weeks": 3,
+                    "days": 4,
+                    "hours": null,
+                    "prisonTermCode": "string"
+                  }
+                ]
+              }
             },
             {
               "dataSource": "NDELIUS",
@@ -64,16 +66,18 @@ class SentencesSmokeTest : DescribeSpec(
               "fineAmount": null,
               "isActive": true,
               "isCustodial": false,
-              "terms": [
-                {
-                  "years": null,
-                  "months": null,
-                  "weeks": null,
-                  "days": null,
-                  "hours": $hourMinIntValue,
-                  "prisonTermCode": null
-                }
-              ]
+              "length": {
+                "terms": [
+                  {
+                    "years": null,
+                    "months": null,
+                    "weeks": null,
+                    "days": null,
+                    "hours": $hourMinIntValue,
+                    "prisonTermCode": null
+                  }
+                ]
+              }
             }
           ],
           "pagination": {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
@@ -46,18 +46,16 @@ class SentencesSmokeTest : DescribeSpec(
               "fineAmount": $fineAmountMinNumberValue,
               "isActive": null,
               "isCustodial": true,
-              "length": {
-                "terms": [
-                  {
-                    "years": 1,
-                    "months": 2,
-                    "weeks": 3,
-                    "days": 4,
-                    "hours": null,
-                    "prisonTermCode": "string"
-                  }
-                ]
-              }
+              "terms": [
+                {
+                  "years": 1,
+                  "months": 2,
+                  "weeks": 3,
+                  "days": 4,
+                  "hours": null,
+                  "prisonTermCode": "string"
+                }
+              ]
             },
             {
               "dataSource": "NDELIUS",
@@ -66,18 +64,16 @@ class SentencesSmokeTest : DescribeSpec(
               "fineAmount": null,
               "isActive": true,
               "isCustodial": false,
-              "length": {
-                "terms": [
-                  {
-                    "years": null,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": $hourMinIntValue,
-                    "prisonTermCode": null
-                  }
-                ]
-              }
+              "terms": [
+                {
+                  "years": null,
+                  "months": null,
+                  "weeks": null,
+                  "days": null,
+                  "hours": $hourMinIntValue,
+                  "prisonTermCode": null
+                }
+              ]
             }
           ],
           "pagination": {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
@@ -70,7 +70,7 @@ class SentencesSmokeTest : DescribeSpec(
               "isCustodial": false,
               "length": {
                 "duration": $hourMinIntValue,
-                "units": "hours",
+                "units": "Hours",
                 "terms": []
               }
             }


### PR DESCRIPTION
Since we cannot cleanly combine community and custodial sentences, we're changing the structure to accommodate both, while preserving the context. Introduce a length object which has "duration" for community sentences, and "terms" for custodial sentences.