### PR TITLE
Update pipeline to use short lived ECR credentials for dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,12 @@ jobs:
           name: Run smoke tests
           command: make smoke-test
   create-and-push-image-to-ecr:
-    executor: aws-ecr/default
+    docker:
+      - image: ministryofjustice/cloud-platform-tools
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           name: Build application Docker image
           command: make build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ orbs:
   hmpps: ministryofjustice/hmpps@6
   slack: circleci/slack@4.12.1
   shellcheck: circleci/shellcheck@3
+  aws-cli: circleci/aws-cli@4.0.0
+  aws-ecr: circleci/aws-ecr@8.2.1
 
 parameters:
   alerts-slack-channel:
@@ -110,21 +112,19 @@ jobs:
           name: Run smoke tests
           command: make smoke-test
   create-and-push-image-to-ecr:
-    docker:
-      - image: ministryofjustice/cloud-platform-tools
+    executor: aws-ecr/default
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - run:
           name: Build application Docker image
-          command: |
-            make build
+          command: make build
       - hmpps/create_app_version
+      - aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME
+          region: AWS_DEFAULT_REGION
       - deploy:
           name: Push application Docker image
-          command: |
-            make publish
+          command: make publish
   heartbeat:
     machine:
       image: ubuntu-2204:2022.10.2

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} aws ecr get-login-password | docker login --username AWS --password-stdin 754256621582.dkr.ecr.eu-west-2.amazonaws.com
+aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
 
 echo "ecr endpoint"
 echo $ECR_ENDPOINT

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,13 +2,11 @@
 
 set -e
 
+echo "Logging into ECR."
 aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
 
-echo "ecr endpoint"
-echo $ECR_ENDPOINT
-
-echo "we are about to tag"
+echo "Tagging Docker image."
 docker tag hmpps-integration-api "${ECR_ENDPOINT}:${APP_VERSION}"
-echo "we are about to push"
-echo "${ECR_ENDPOINT}:${APP_VERSION}"
+
+echo "Pushing Docker image to ECR."
 docker push "${ECR_ENDPOINT}:${APP_VERSION}"


### PR DESCRIPTION
## Context

Cloud Platform are deprecating using long-lived credentials to access ECR, see [docs](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html).

For dev, we've already created a PR in Cloud Platform to enable this, see https://github.com/ministryofjustice/cloud-platform-environments/pull/16054.

## Changes proposed in this PR

- Update deployment pipeline to use long-lived credentials.
- Update logging for publish Docker image script.