### PR TITLE
Refactor GetPersonService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonService.kt
@@ -29,7 +29,7 @@ class GetSentencesForPersonService(
       nDeliusSentencesResponse = nDeliusGateway.getSentencesForPerson(deliusCrn)
     }
 
-    val nomisSentences = bookingIdsResponse.data.map { nomisGateway.getSentencesForBooking(it.bookingId) }
+    val nomisSentenceResponses = bookingIdsResponse.data.map { nomisGateway.getSentencesForBooking(it.bookingId) }
     val nomisSentencesErrors = nomisSentences.map { it.errors }.flatten()
 
     return Response(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonService.kt
@@ -19,7 +19,7 @@ class GetSentencesForPersonService(
     val nomisNumber = personResponse.data["prisonerOffenderSearch"]?.identifiers?.nomisNumber
     val deliusCrn = personResponse.data["probationOffenderSearch"]?.identifiers?.deliusCrn
     var bookingIdsResponse: Response<List<Booking>> = Response(data = emptyList())
-    var nDeliusSentences: Response<List<Sentence>> = Response(data = emptyList())
+    var nDeliusSentencesResponse: Response<List<Sentence>> = Response(data = emptyList())
 
     if (nomisNumber != null) {
       bookingIdsResponse = nomisGateway.getBookingIdsForPerson(nomisNumber)
@@ -30,11 +30,10 @@ class GetSentencesForPersonService(
     }
 
     val nomisSentenceResponses = bookingIdsResponse.data.map { nomisGateway.getSentencesForBooking(it.bookingId) }
-    val nomisSentencesErrors = nomisSentences.map { it.errors }.flatten()
 
     return Response(
-      data = nomisSentences.map { it.data }.flatten() + nDeliusSentences.data,
-      errors = bookingIdsResponse.errors + nomisSentencesErrors + nDeliusSentences.errors,
+      data = nomisSentenceResponses.map { it.data }.flatten() + nDeliusSentencesResponse.data,
+      errors = bookingIdsResponse.errors + nomisSentenceResponses.map { it.errors }.flatten() + nDeliusSentencesResponse.errors,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonService.kt
@@ -26,7 +26,7 @@ class GetSentencesForPersonService(
     }
 
     if (deliusCrn != null) {
-      nDeliusSentences = nDeliusGateway.getSentencesForPerson(deliusCrn)
+      nDeliusSentencesResponse = nDeliusGateway.getSentencesForPerson(deliusCrn)
     }
 
     val nomisSentences = bookingIdsResponse.data.map { nomisGateway.getSentencesForBooking(it.bookingId) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetSentencesForPersonServiceTest.kt
@@ -139,7 +139,7 @@ internal class GetSentencesForPersonServiceTest(
         verify(nomisGateway, VerificationModeFactory.times(1)).getBookingIdsForPerson(id = nomisNumber)
       }
 
-      it("does not return sentences when booking IDs are not present") {
+      it("does not return prison sentences when booking IDs are not present") {
         whenever(nomisGateway.getBookingIdsForPerson(nomisNumber)).thenReturn(Response(data = emptyList()))
 
         val result = getSentencesForPersonService.execute(pncId)


### PR DESCRIPTION
Use GetPersonService instead of individual search gateways to find
person by PNC ID.
Return all upstream API errors instead of early returning each
individual error.

Refactor tests to use the generateTestSentence helper function
with defaults which allows removing unnecessary knowledge of the
structure of a sentence.

Summary of paths exercised with tests:
<img width="828" alt="Screenshot 2023-09-01 at 12 25 13" src="https://github.com/ministryofjustice/hmpps-integration-api/assets/1215147/ff39155d-7e51-4a99-9d2d-0b62fd9fd5ee">

