### PR TITLE
Update guidance for setting up a CircleCI context

### DIFF
--- a/docs/setting-up-circleci-context-for-deployment.md
+++ b/docs/setting-up-circleci-context-for-deployment.md
@@ -4,14 +4,15 @@ To set up deployment for an environment using [CircleCI](https://circleci.com/),
 new [context](https://circleci.com/docs/contexts/) must be created for it that contains the following:
 
 - `AWS_DEFAULT_REGION`
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `KUBE_ENV_TOKEN`
+- `AWS_ECR_REGISTRY_ID`
+- `ECR_ENDPOINT`
+- `ECR_REPOSITORY`
+- `ECR_ROLE_TO_ASSUME`
+- `KUBE_ENV_API`
 - `KUBE_ENV_CACERT`
 - `KUBE_ENV_NAME`
 - `KUBE_ENV_NAMESPACE`
-- `KUBE_ENV_API`
-- `ECR_ENDPOINT`
+- `KUBE_ENV_TOKEN`
 
 ## Prerequisites
 
@@ -30,51 +31,47 @@ new [context](https://circleci.com/docs/contexts/) must be created for it that c
    environment: `hmpps-integration-api-<environment>` e.g. `hmpps-integration-api-dev`.
 4. Click on "Add Environment Variable" button.
 5. Add an environment variable called `AWS_DEFAULT_REGION` and set the value to `eu-west-2`.
-6. Add an environment variable called `AWS_ACCESS_KEY_ID` and set the value to the response of the command below.
+6. Using the command-line, output the Kubernetes ConfigMap for ECR within the namespace for the environment.
 
 ```bash
-kubectl get secret aws-services -n hmpps-integration-api-<environment> -o json | jq -r ".data.ecr" | base64 --decode | jq -r '."access-credentials"."access-key-id"'
-# E.g. kubectl get secret aws-services -n hmpps-integration-api-dev -o json | jq -r ".data.ecr" | base64 --decode | jq -r '."access-credentials"."access-key-id"'
+kubectl describe configmap hmpps-integration-api-<environment>-ecr-circleci -n hmpps-integration-api-<environment>
+# E.g. kubectl describe configmap hmpps-integration-api-dev-ecr-circleci -n hmpps-integration-api-dev
 ```
 
-7. Add an environment variable called `AWS_SECRET_ACCESS_KEY` and set the value to the response of the command below.
-
-```bash
-kubectl get secret aws-services -n hmpps-integration-api-<environment> -o json | jq -r ".data.ecr" | base64 --decode | jq -r '."access-credentials"."secret-access-key"'
-# E.g. kubectl get secret aws-services -n hmpps-integration-api-dev -o json | jq -r ".data.ecr" | base64 --decode | jq -r '."access-credentials"."secret-access-key"'
-```
-
-8. Add an environment variable called `KUBE_ENV_NAMESPACE` and set the value to the Kubernetes namespace for the
+7. Add an environment variable called `ECR_REPOSITORY` and set the value of `ecr_repository` in the response of the command in step 6.
+8. Add an environment variable called `ECR_ROLE_TO_ASSUME` and set the value of `ecr_role_to_assume` in the response of the command in step 6.
+9. Add an environment variable called `AWS_ECR_REGISTRY_ID` and set the value of `ecr_registry_id` in the response of the command in step 6.
+10. Add an environment variable called `KUBE_ENV_NAMESPACE` and set the value to the Kubernetes namespace for the
    environment e.g. `hmpps-integration-api-dev`.
-9. Add an environment variable called `KUBE_ENV_NAME` and set the value
+11. Add an environment variable called `KUBE_ENV_NAME` and set the value
     to `DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`.
-10. Add an environment variable called `KUBE_ENV_API` and set the value
+12. Add an environment variable called `KUBE_ENV_API` and set the value
     to `https://DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com`.
 
-11. Using the command-line, list the name of all the secrets within the Kubernetes namespace for the environment.
+13. Using the command-line, list the name of all the secrets within the Kubernetes namespace for the environment.
 
 ```bash
 kubectl get secrets -n hmpps-integration-api-<environment>
 # E.g. kubectl get secrets -n hmpps-integration-api-dev
 ```
 
-12. Using the name of the CircleCI service account secret, retrieve the token for it.
+14. Using the name of the CircleCI service account secret, retrieve the token for it.
 
 ```bash
 cloud-platform decode-secret -n hmpps-integration-api-<environment> -s <circleci-token-secret-name> | jq -r '.data."token"'
 # E.g. cloud-platform decode-secret -n hmpps-integration-api-dev -s circleci-token-z123 | jq -r '.data."token"'
 ```
 
-13. Add an environment variable called `KUBE_ENV_TOKEN` and set the value to the response of the previous command.
-14. Using the command-line, retrieve the CA certificate for the CircleCI service account.
+15. Add an environment variable called `KUBE_ENV_TOKEN` and set the value to the response of the previous command.
+16. Using the command-line, retrieve the CA certificate for the CircleCI service account.
 
 ```bash
 kubectl -n hmpps-integration-api-<environment> get secrets <circleci-token-secret-name> -o json | jq -r '.data."ca.crt"'
 # E.g. kubectl -n hmpps-integration-api-dev get secrets circleci-token-z123 -o json | jq -r '.data."ca.crt"'
 ```
 
-15. Add an environment variable called `KUBE_ENV_CACERT` and set the value to the response of the previous command.
-16. Add an environment variable called `ECR_ENDPOINT` and set the value to the response of the command below.
+17. Add an environment variable called `KUBE_ENV_CACERT` and set the value to the response of the previous command.
+18. Add an environment variable called `ECR_ENDPOINT` and set the value to the response of the command below.
 
 ```bash
 kubectl get secret aws-services -n hmpps-integration-api-<environment> -o json | jq -r ".data.ecr" | base64 --decode | jq -r '."repo-url"'


### PR DESCRIPTION
## Context

We've updated our pipeline as a result of Cloud Platform deprecating long-lived access credentials for its modules. 

## Changes proposed in this PR

- Update guidance for setting up a CircleCI context to use new environment variables for short-lived access credentials.