### PR TITLE
Update OpenAPI spec to fix rendering issue in our API docs

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -672,13 +672,15 @@ components:
           type: string
           example: RR84170
           description: Criminal Justice System offence code
+        # Court dates has been documented as single string, however it's actually a list of strings. This has been done
+        # in order to temporarily fix a rendering issue in our API docs whilst we look for a longer term solution for it.
         courtDates:
-          type: array
-          example: ["2018-02-10", "2019-02-10"]
+          type: string
+          format: date
           description: Court dates associated with offences
-          items:
-            type: string
-            format: date
+          example:
+            - "2018-02-10"
+            - "2019-02-10"
         description:
           type: string
           example: Commit an act / series of acts with intent to pervert the course of public justice


### PR DESCRIPTION
## Context

In [our API docs](https://ministryofjustice.github.io/hmpps-integration-api-docs/), the court dates property of an offence incorrectly renders in the example response of our get offences for a person endpoint.

The issue is that the [tech docs gem](https://github.com/alphagov/tech-docs-gem) that we use for our API docs does not handle primitive lists i.e. a list of strings. As a result, court dates does not render properly, instead it renders an array and a single empty object.

## Changes proposed in this PR

Update our OpenAPI spec in a way to fix the rendering of court dates in the example response.

This is a short-term solution whilst we look into more longer term solutions as there are further pitfalls we're aware of with our current API docs setup.

A consequence of this change is that if a consumer creates a simulator based off our OpenAPI spec, then it will incorrectly respond with a single date string. As we only have one consumer at the moment and we know no one is doing this, we can temporarily take on this risk for now.

| Before | After |
| ------ | ----- |
| <img width="643" alt="image" src="https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/85b87c9b-3a8c-4bd0-928c-14003e0d05f5">       |   <img width="602" alt="image" src="https://github.com/ministryofjustice/hmpps-integration-api/assets/42817036/682c9caa-2a6c-4995-ad6e-e1bd386521cc">    |