### PR TITLE
Update get person risks endpoint to return risk to self

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risk.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risk.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class Risk(
+  val risk: String? = null,
+  val previous: String? = null,
+  val previousConcernsText: String? = null,
+  val current: String? = null,
+  val currentConcernsText: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/RiskToSelf.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/RiskToSelf.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class RiskToSelf(
+  val suicide: Risk = Risk(),
+  val selfHarm: Risk = Risk(),
+  val custody: Risk = Risk(),
+  val hostelSetting: Risk = Risk(),
+  val vulnerability: Risk = Risk(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risks.kt
@@ -4,4 +4,5 @@ import java.time.LocalDateTime
 
 data class Risks(
   val assessedOn: LocalDateTime? = null,
+  val riskToSelf: RiskToSelf = RiskToSelf(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risk.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risk.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risk
+
+data class Risk(
+  val risk: String? = null,
+  val previous: String? = null,
+  val previousConcernsText: String? = null,
+  val current: String? = null,
+  val currentConcernsText: String? = null,
+) {
+  fun toRisk(): Risk = Risk(
+    risk = this.risk,
+    previous = this.previous,
+    previousConcernsText = this.previousConcernsText,
+    current = this.current,
+    currentConcernsText = this.currentConcernsText,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskToSelf.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskToSelf.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskToSelf as IntegrationApiRiskToSelf
+
+data class RiskToSelf(
+  val suicide: Risk = Risk(),
+  val selfHarm: Risk = Risk(),
+  val custody: Risk = Risk(),
+  val hostelSetting: Risk = Risk(),
+  val vulnerability: Risk = Risk(),
+) {
+  fun toRiskToSelf(): IntegrationApiRiskToSelf = IntegrationApiRiskToSelf(
+    suicide = this.suicide.toRisk(),
+    selfHarm = this.selfHarm.toRisk(),
+    custody = this.custody.toRisk(),
+    hostelSetting = this.hostelSetting.toRisk(),
+    vulnerability = this.vulnerability.toRisk(),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risks.kt
@@ -5,8 +5,10 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risks as Integrat
 
 data class Risks(
   val assessedOn: LocalDateTime? = null,
+  val riskToSelf: RiskToSelf = RiskToSelf(),
 ) {
   fun toRisks(): IntegrationApiRisks = IntegrationApiRisks(
     assessedOn = this.assessedOn,
+    riskToSelf = this.riskToSelf.toRiskToSelf(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
@@ -78,15 +78,12 @@ internal class RisksControllerTest(
 
       it("returns null embedded in a JSON object when no risks are found") {
         val pncIdForPersonWithNoRisks = "0000/11111A"
-        val encodedPncIdForPersonWithNoRisks =
-          URLEncoder.encode(pncIdForPersonWithNoRisks, StandardCharsets.UTF_8)
-        val path = "/v1/persons/$encodedPncIdForPersonWithNoRisks/risks"
+        val encodedPncIdForPersonWithNoRisks = URLEncoder.encode(pncIdForPersonWithNoRisks, StandardCharsets.UTF_8)
+        val pathForPersonWithNoRisks = "/v1/persons/$encodedPncIdForPersonWithNoRisks/risks"
 
         whenever(getRisksForPersonService.execute(pncIdForPersonWithNoRisks)).thenReturn(Response(data = null))
 
-        val result =
-          mockMvc.perform(MockMvcRequestBuilders.get(path))
-            .andReturn()
+        val result = mockMvc.perform(MockMvcRequestBuilders.get(pathForPersonWithNoRisks)).andReturn()
 
         result.response.contentAsString.shouldContain("\"data\":null")
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
@@ -15,6 +15,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risk
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskToSelf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risks
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
@@ -47,6 +49,13 @@ internal class RisksControllerTest(
                 51,
                 38,
               ),
+              riskToSelf = RiskToSelf(
+                suicide = Risk(risk = "No"),
+                selfHarm = Risk(risk = "No"),
+                custody = Risk(risk = "No"),
+                hostelSetting = Risk(risk = "No"),
+                vulnerability = Risk(risk = "No"),
+              ),
             ),
           ),
         )
@@ -70,7 +79,43 @@ internal class RisksControllerTest(
         result.response.contentAsString.shouldContain(
           """
           "data": {
-               "assessedOn": "2023-09-19T12:51:38"
+            "assessedOn": "2023-09-19T12:51:38",
+            "riskToSelf": {
+              "suicide": {
+                 "risk": "No",
+                 "previous": null,
+                 "previousConcernsText": null,
+                 "current": null,
+                 "currentConcernsText": null
+              },
+              "selfHarm": {
+                 "risk": "No",
+                 "previous": null,
+                 "previousConcernsText": null,
+                 "current": null,
+                 "currentConcernsText": null
+              },
+              "custody": {
+                 "risk": "No",
+                 "previous": null,
+                 "previousConcernsText": null,
+                 "current": null,
+                 "currentConcernsText": null
+              },
+              "hostelSetting": {
+                 "risk": "No",
+                 "previous": null,
+                 "previousConcernsText": null,
+                 "current": null,
+                 "currentConcernsText": null
+              },
+              "vulnerability": {
+                 "risk": "No",
+                 "previous": null,
+                 "previousConcernsText": null,
+                 "current": null,
+                 "currentConcernsText": null
+              }
             }
           """.removeWhitespaceAndNewlines(),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
@@ -53,19 +53,19 @@ internal class RisksControllerTest(
       }
 
       it("responds with a 200 OK status") {
-        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+        val result = mockMvc.perform(MockMvcRequestBuilders.get(path)).andReturn()
 
         result.response.status.shouldBe(HttpStatus.OK.value())
       }
 
       it("retrieves the risks for a person with the matching ID") {
-        mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+        mockMvc.perform(MockMvcRequestBuilders.get(path)).andReturn()
 
         verify(getRisksForPersonService, VerificationModeFactory.times(1)).execute(pncId)
       }
 
       it("returns the risks for a person with the matching ID") {
-        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+        val result = mockMvc.perform(MockMvcRequestBuilders.get(path)).andReturn()
 
         result.response.contentAsString.shouldContain(
           """
@@ -85,7 +85,7 @@ internal class RisksControllerTest(
         whenever(getRisksForPersonService.execute(pncIdForPersonWithNoRisks)).thenReturn(Response(data = null))
 
         val result =
-          mockMvc.perform(MockMvcRequestBuilders.get("$path"))
+          mockMvc.perform(MockMvcRequestBuilders.get(path))
             .andReturn()
 
         result.response.contentAsString.shouldContain("\"data\":null")
@@ -104,7 +104,7 @@ internal class RisksControllerTest(
           ),
         )
 
-        val result = mockMvc.perform(MockMvcRequestBuilders.get("$path")).andReturn()
+        val result = mockMvc.perform(MockMvcRequestBuilders.get(path)).andReturn()
 
         result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.Risk as ArnRisk
+
+class RiskTest : DescribeSpec(
+  {
+    describe("#toRisk") {
+      it("maps one-to-one attributes to Integration API attributes") {
+        val arnRisk = ArnRisk(
+          risk = "risk",
+          previous = "previous",
+          previousConcernsText = "previousConcernsText",
+          current = "current",
+          currentConcernsText = "currentConcernsText",
+        )
+
+        val integrationApiRisk = arnRisk.toRisk()
+
+        integrationApiRisk.risk.shouldBe(arnRisk.risk)
+        integrationApiRisk.previous.shouldBe(arnRisk.previous)
+        integrationApiRisk.previousConcernsText.shouldBe(arnRisk.previousConcernsText)
+        integrationApiRisk.current.shouldBe(arnRisk.current)
+        integrationApiRisk.currentConcernsText.shouldBe(arnRisk.currentConcernsText)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskToSelfTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskToSelfTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.RiskToSelf as ArnRiskToSelf
+
+class RiskToSelfTest : DescribeSpec(
+  {
+    describe("#toRiskToSelf") {
+      it("maps one-to-one attributes to Integration API attributes") {
+        val arnRisk = ArnRiskToSelf(
+          suicide = Risk(risk = "risk"),
+          selfHarm = Risk(risk = "risk"),
+          custody = Risk(risk = "risk"),
+          hostelSetting = Risk(risk = "risk"),
+          vulnerability = Risk(risk = "risk"),
+        )
+
+        val integrationApiRisk = arnRisk.toRiskToSelf()
+
+        integrationApiRisk.suicide.risk.shouldBe(arnRisk.suicide.risk)
+        integrationApiRisk.selfHarm.risk.shouldBe(arnRisk.selfHarm.risk)
+        integrationApiRisk.custody.risk.shouldBe(arnRisk.custody.risk)
+        integrationApiRisk.hostelSetting.risk.shouldBe(arnRisk.hostelSetting.risk)
+        integrationApiRisk.vulnerability.risk.shouldBe(arnRisk.vulnerability.risk)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
@@ -11,13 +11,23 @@ class RisksTest : DescribeSpec(
       it("maps one-to-one attributes to Integration API attributes") {
         val arnRisks = ArnRisks(
           assessedOn = LocalDateTime.now(),
+          riskToSelf = RiskToSelf(
+            suicide = Risk(risk = "risk"),
+            selfHarm = Risk(risk = "risk"),
+            custody = Risk(risk = "risk"),
+            hostelSetting = Risk(risk = "risk"),
+            vulnerability = Risk(risk = "risk"),
+          ),
         )
 
         val integrationApiRisks = arnRisks.toRisks()
 
-        integrationApiRisks.assessedOn.shouldBe(
-          arnRisks.assessedOn,
-        )
+        integrationApiRisks.assessedOn.shouldBe(arnRisks.assessedOn)
+        integrationApiRisks.riskToSelf.suicide.risk.shouldBe(arnRisks.riskToSelf.suicide.risk)
+        integrationApiRisks.riskToSelf.selfHarm.risk.shouldBe(arnRisks.riskToSelf.selfHarm.risk)
+        integrationApiRisks.riskToSelf.custody.risk.shouldBe(arnRisks.riskToSelf.custody.risk)
+        integrationApiRisks.riskToSelf.hostelSetting.risk.shouldBe(arnRisks.riskToSelf.hostelSetting.risk)
+        integrationApiRisks.riskToSelf.vulnerability.risk.shouldBe(arnRisks.riskToSelf.vulnerability.risk)
       }
     }
   },


### PR DESCRIPTION
## Context

In #261, we created the thin slice for the `/v1/persons/{id}/risks` endpoint which will return the risk to serious harm (RoSH) risks.

Our golden record includes four top-level properties:

1. `riskToSelf`
2. `otherRisks`
3. `summary`
4. `assessedOn` - added in thin slice.

## Changes proposed in this pull request

- Add models for Assess Risks and Needs (ARN) and our API to return `riskToSelf`. These attributes map one to one to our golden record so not transforming is done.

## Next steps

1. Add `otherRisks` to `Risks` so our get person risks endpoint returns `otherRisks`.
2. Add `summary` to `Risks` so our get person risks endpoint returns the full golden record.