### PR TITLE
Update get person risks endpoint to return other risks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/OtherRisks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/OtherRisks.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class OtherRisks(
+  val escapeOrAbscond: String? = null,
+  val controlIssuesDisruptiveBehaviour: String? = null,
+  val breachOfTrust: String? = null,
+  val riskToOtherPrisoners: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risks.kt
@@ -5,4 +5,5 @@ import java.time.LocalDateTime
 data class Risks(
   val assessedOn: LocalDateTime? = null,
   val riskToSelf: RiskToSelf = RiskToSelf(),
+  val otherRisks: OtherRisks = OtherRisks(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/OtherRisks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/OtherRisks.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.OtherRisks as IntegrationApiOtherRisks
+
+data class OtherRisks(
+  val escapeOrAbscond: String? = null,
+  val controlIssuesDisruptiveBehaviour: String? = null,
+  val breachOfTrust: String? = null,
+  val riskToOtherPrisoners: String? = null,
+) {
+  fun toOtherRisks(): IntegrationApiOtherRisks = IntegrationApiOtherRisks(
+    escapeOrAbscond = this.escapeOrAbscond,
+    controlIssuesDisruptiveBehaviour = this.controlIssuesDisruptiveBehaviour,
+    breachOfTrust = this.breachOfTrust,
+    riskToOtherPrisoners = this.riskToOtherPrisoners,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risks.kt
@@ -6,9 +6,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risks as Integrat
 data class Risks(
   val assessedOn: LocalDateTime? = null,
   val riskToSelf: RiskToSelf = RiskToSelf(),
+  val otherRisks: OtherRisks = OtherRisks(),
 ) {
   fun toRisks(): IntegrationApiRisks = IntegrationApiRisks(
     assessedOn = this.assessedOn,
     riskToSelf = this.riskToSelf.toRiskToSelf(),
+    otherRisks = this.otherRisks.toOtherRisks(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.OtherRisks
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risk
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskToSelf
@@ -50,12 +51,13 @@ internal class RisksControllerTest(
                 38,
               ),
               riskToSelf = RiskToSelf(
-                suicide = Risk(risk = "No"),
-                selfHarm = Risk(risk = "No"),
-                custody = Risk(risk = "No"),
-                hostelSetting = Risk(risk = "No"),
-                vulnerability = Risk(risk = "No"),
+                suicide = Risk(risk = "NO"),
+                selfHarm = Risk(risk = "NO"),
+                custody = Risk(risk = "NO"),
+                hostelSetting = Risk(risk = "NO"),
+                vulnerability = Risk(risk = "NO"),
               ),
+              otherRisks = OtherRisks(breachOfTrust = "NO"),
             ),
           ),
         )
@@ -82,41 +84,48 @@ internal class RisksControllerTest(
             "assessedOn": "2023-09-19T12:51:38",
             "riskToSelf": {
               "suicide": {
-                 "risk": "No",
+                 "risk": "NO",
                  "previous": null,
                  "previousConcernsText": null,
                  "current": null,
                  "currentConcernsText": null
               },
               "selfHarm": {
-                 "risk": "No",
+                 "risk": "NO",
                  "previous": null,
                  "previousConcernsText": null,
                  "current": null,
                  "currentConcernsText": null
               },
               "custody": {
-                 "risk": "No",
+                 "risk": "NO",
                  "previous": null,
                  "previousConcernsText": null,
                  "current": null,
                  "currentConcernsText": null
               },
               "hostelSetting": {
-                 "risk": "No",
+                 "risk": "NO",
                  "previous": null,
                  "previousConcernsText": null,
                  "current": null,
                  "currentConcernsText": null
               },
               "vulnerability": {
-                 "risk": "No",
+                 "risk": "NO",
                  "previous": null,
                  "previousConcernsText": null,
                  "current": null,
                  "currentConcernsText": null
               }
+            },
+            "otherRisks": {
+              "escapeOrAbscond": null,
+              "controlIssuesDisruptiveBehaviour": null,
+              "breachOfTrust": "NO",
+              "riskToOtherPrisoners": null
             }
+          }
           """.removeWhitespaceAndNewlines(),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/OtherRisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/OtherRisksTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.OtherRisks as ArnOtherRisks
+
+class OtherRisksTest : DescribeSpec(
+  {
+    describe("#toOtherRisks") {
+      it("maps one-to-one attributes to Integration API attributes") {
+        val arnOtherRisks = ArnOtherRisks(
+          escapeOrAbscond = "YES",
+          controlIssuesDisruptiveBehaviour = "YES",
+          breachOfTrust = "YES",
+          riskToOtherPrisoners = "YES",
+        )
+
+        val integrationApiOtherRisks = arnOtherRisks.toOtherRisks()
+
+        integrationApiOtherRisks.escapeOrAbscond.shouldBe(arnOtherRisks.escapeOrAbscond)
+        integrationApiOtherRisks.controlIssuesDisruptiveBehaviour.shouldBe(arnOtherRisks.controlIssuesDisruptiveBehaviour)
+        integrationApiOtherRisks.breachOfTrust.shouldBe(arnOtherRisks.breachOfTrust)
+        integrationApiOtherRisks.riskToOtherPrisoners.shouldBe(arnOtherRisks.riskToOtherPrisoners)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
@@ -12,12 +12,13 @@ class RisksTest : DescribeSpec(
         val arnRisks = ArnRisks(
           assessedOn = LocalDateTime.now(),
           riskToSelf = RiskToSelf(
-            suicide = Risk(risk = "risk"),
-            selfHarm = Risk(risk = "risk"),
-            custody = Risk(risk = "risk"),
-            hostelSetting = Risk(risk = "risk"),
-            vulnerability = Risk(risk = "risk"),
+            suicide = Risk(risk = "NO"),
+            selfHarm = Risk(risk = "NO"),
+            custody = Risk(risk = "NO"),
+            hostelSetting = Risk(risk = "NO"),
+            vulnerability = Risk(risk = "NO"),
           ),
+          otherRisks = OtherRisks(breachOfTrust = "YES"),
         )
 
         val integrationApiRisks = arnRisks.toRisks()
@@ -28,6 +29,7 @@ class RisksTest : DescribeSpec(
         integrationApiRisks.riskToSelf.custody.risk.shouldBe(arnRisks.riskToSelf.custody.risk)
         integrationApiRisks.riskToSelf.hostelSetting.risk.shouldBe(arnRisks.riskToSelf.hostelSetting.risk)
         integrationApiRisks.riskToSelf.vulnerability.risk.shouldBe(arnRisks.riskToSelf.vulnerability.risk)
+        integrationApiRisks.otherRisks.breachOfTrust.shouldBe(arnRisks.otherRisks.breachOfTrust)
       }
     }
   },


### PR DESCRIPTION
## Context

In #261, we created the thin slice for the `/v1/persons/{id}/risks` endpoint which will return the risk to serious harm (RoSH) risks.

Our golden record includes four top-level properties:

1. `riskToSelf` - added in #262 
2. `otherRisks` - added in this PR
3. `summary`
4. `assessedOn` - added in thin slice.

## Changes proposed in this pull request

- Add models for Assess Risks and Needs (ARN) and our API to return `otherRisks`. These attributes map one to one to our golden record so not transforming is done.

## Next steps

1. Add `summary` to `Risks` so our get person risks endpoint returns the full golden record.