### PR TITLE
Fix GetImageMetadataForPersonService not handling not found error

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -6,6 +6,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ImageMetadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 
 @Service
 class GetImageMetadataForPersonService(
@@ -14,6 +16,18 @@ class GetImageMetadataForPersonService(
 ) {
   fun execute(pncId: String): Response<List<ImageMetadata>> {
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(pncId = pncId)
+
+    if (responseFromPrisonerOffenderSearch.data.isEmpty()) {
+      return Response(
+        data = emptyList(),
+        errors = listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH,
+            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+          ),
+        ),
+      )
+    }
 
     return nomisGateway.getImageMetadataForPerson(responseFromPrisonerOffenderSearch.data.first().identifiers.nomisNumber!!)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonServiceTest.kt
@@ -71,6 +71,16 @@ internal class GetImageMetadataForPersonServiceTest(
     response.data.shouldBe(imageMetadataFromNomis)
   }
 
+  it("returns a not found error when person cannot be found in Prisoner Offender Search") {
+    whenever(prisonerOffenderSearchGateway.getPersons(pncId = pncId)).thenReturn(Response(data = emptyList()))
+
+    val response = getImageMetadataForPersonService.execute(pncId)
+
+    response.errors.shouldHaveSize(1)
+    response.errors.first().causedBy.shouldBe(UpstreamApi.PRISONER_OFFENDER_SEARCH)
+    response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
+  }
+
   it("returns the error from NOMIS when an error occurs") {
     whenever(nomisGateway.getImageMetadataForPerson(prisonerNumber)).thenReturn(
       Response(


### PR DESCRIPTION
# Context 
When hitting our Image Metadata endpoint with a HMPPS ID that does not exist, a 500 error was returned rather than the documented 404.

# Changes
Added logic to catch when a person is not found in the upstream API for image metadata, returning a 404 error.