### PR TITLE
Fix naming convention for pagination per page param

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -459,7 +459,7 @@ components:
       required: false
       description: The page number (starting from 1)
     PerPage:
-      name: per_page
+      name: perPage
       in: query
       schema:
         type: number


### PR DESCRIPTION
## Context

Our OpenApi documentation showed the pagination per page param as `per_page` when in the code base it was actually `perPage`. We agreed upon changing this to be camelCase and as a result needed to update our documentation

## Changes proposed in this PR

- Updated openApi pagination param `per_page` to be `perPage`