### PR TITLE
Hia 537 implement golden record for risk needs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Needs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Needs.kt
@@ -4,4 +4,5 @@ import java.time.LocalDateTime
 
 data class Needs(
   val assessedOn: LocalDateTime? = null,
+  val unansweredNeeds: UnansweredNeeds = UnansweredNeeds(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UnansweredNeeds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UnansweredNeeds.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class UnansweredNeeds(
+  val type: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Needs.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Needs.kt
@@ -5,8 +5,10 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Needs as Integrat
 
 data class Needs(
   val assessedOn: LocalDateTime? = null,
+  val unansweredNeeds: UnansweredNeeds = UnansweredNeeds(),
 ) {
   fun toNeeds(): IntegrationApiNeeds = IntegrationApiNeeds(
     assessedOn = this.assessedOn,
+    unansweredNeeds = this.unansweredNeeds.toUnansweredNeeds(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/UnansweredNeeds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/UnansweredNeeds.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UnansweredNeeds as IntegrationApiUnansweredNeeds
+
+data class UnansweredNeeds(
+  val section: String? = null,
+) {
+  fun toUnansweredNeeds(): IntegrationApiUnansweredNeeds = IntegrationApiUnansweredNeeds(
+    type = this.section,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/NeedsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/NeedsControllerTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetNeedsForPers
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UnansweredNeeds as IntegrationApiUnansweredNeeds
 
 @WebMvcTest(controllers = [NeedsController::class])
 internal class NeedsControllerTest(
@@ -47,6 +48,7 @@ internal class NeedsControllerTest(
                 21,
                 33,
               ),
+              unansweredNeeds = IntegrationApiUnansweredNeeds(type = "LIFESTYLE_AND_ASSOCIATES"),
             ),
           ),
         )
@@ -70,7 +72,10 @@ internal class NeedsControllerTest(
         result.response.contentAsString.shouldContain(
           """
           "data": {
-               "assessedOn": "2021-05-29T11:21:33"
+               "assessedOn": "2021-05-29T11:21:33",
+               "unansweredNeeds": {
+                  "type": "LIFESTYLE_AND_ASSOCIATES"
+               }
             }
           """.removeWhitespaceAndNewlines(),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/GetNeedsForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/GetNeedsForPersonTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMoc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Needs as IntegrationApiNeeds
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UnansweredNeeds as IntegrationApiUnansweredNeeds
 
 @ActiveProfiles("test")
 @ContextConfiguration(
@@ -41,7 +42,10 @@ class GetNeedsForPersonTest(
           crn,
           """
               {
-                "assessedOn": "2023-02-13T12:43:38"
+                "assessedOn": "2023-02-13T12:43:38",
+                "unansweredNeeds": {
+                      "section": "FINANCIAL_MANAGEMENT_AND_INCOME"
+                  }
               }
           """,
         )
@@ -64,7 +68,10 @@ class GetNeedsForPersonTest(
         val response = assessRisksAndNeedsGateway.getNeedsForPerson(crn)
 
         response.data.shouldBe(
-          IntegrationApiNeeds(LocalDateTime.of(2023, 2, 13, 12, 43, 38)),
+          IntegrationApiNeeds(
+            assessedOn = LocalDateTime.of(2023, 2, 13, 12, 43, 38),
+            unansweredNeeds = IntegrationApiUnansweredNeeds(type = "FINANCIAL_MANAGEMENT_AND_INCOME"),
+          ),
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/NeedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/NeedsTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.Needs as ArnNeeds
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.UnansweredNeeds as ArnUnansweredNeeds
 
 class NeedsTest : DescribeSpec(
   {
@@ -11,11 +12,13 @@ class NeedsTest : DescribeSpec(
       it("maps one-to-one attributes to Integration API attributes") {
         val arnNeeds = ArnNeeds(
           assessedOn = LocalDateTime.parse("2000-11-27T10:15:41"),
+          unansweredNeeds = ArnUnansweredNeeds(section = "EDUCATION_TRAINING_AND_EMPLOYABILITY"),
         )
 
         val integrationApiNeeds = arnNeeds.toNeeds()
 
         integrationApiNeeds.assessedOn.shouldBe(arnNeeds.assessedOn)
+        integrationApiNeeds.unansweredNeeds.type.shouldBe(arnNeeds.unansweredNeeds.section)
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/UnansweredNeedsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/UnansweredNeedsTest.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.UnansweredNeeds as ArnUnansweredNeeds
+class UnansweredNeedsTest : DescribeSpec(
+  {
+    describe("#toUnansweredNeeds") {
+      it("maps one-to-one attributes to integration API attributes") {
+        val arnUnansweredNeeds = ArnUnansweredNeeds(
+          section = "ACCOMMODATION",
+        )
+
+        val integrationApiUnansweredNeeds = arnUnansweredNeeds.toUnansweredNeeds()
+
+        integrationApiUnansweredNeeds.type.shouldBe(arnUnansweredNeeds.section)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetNeedsForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetNeedsForPersonServiceTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Needs as IntegrationApiNeeds
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UnansweredNeeds as IntegrationApiUnansweredNeeds
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
@@ -67,7 +68,10 @@ internal class GetNeedsForPersonServiceTest(
     }
 
     it("returns needs for a person") {
-      val needs = IntegrationApiNeeds(assessedOn = LocalDateTime.now())
+      val needs = IntegrationApiNeeds(
+        assessedOn = LocalDateTime.now(),
+        unansweredNeeds = IntegrationApiUnansweredNeeds(type = "RELATIONSHIPS"),
+      )
 
       whenever(assessRisksAndNeedsGateway.getNeedsForPerson(deliusCrn)).thenReturn(Response(data = needs))
 


### PR DESCRIPTION
## Context

The original risk assessment gateway, service and controller was created in [PR 505](https://github.com/ministryofjustice/hmpps-integration-api/pull/259). This PR builds upon the work done in this [needs thin slice pr](https://github.com/ministryofjustice/hmpps-integration-api/pull/266) adding the remaining golden record risk needs fields.

Worth noting that this PR does not include smoke tests as the api docs for ARN are not public. We are requesting/exploring making them public in this [ticket](https://dsdmoj.atlassian.net/jira/software/c/projects/HIA/boards/1056?modal=detail&selectedIssue=HIA-504)

## Changes proposed in this PR

- Implementation of risk needs golden record
- Updating openApi spec with new endpoint