### PR TITLE
Add Risk Summary to Risks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/RiskSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/RiskSummary.kt
@@ -7,4 +7,6 @@ data class RiskSummary(
   val riskIncreaseFactors: String? = null,
   val riskMitigationFactors: String? = null,
   val overallRiskLevel: String? = null,
+  val riskInCommunity: Map<String, String>? = null,
+  val riskInCustody: Map<String, String>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/RiskSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/RiskSummary.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class RiskSummary(
+  val whoIsAtRisk: String? = null,
+  val natureOfRisk: String? = null,
+  val riskImminence: String? = null,
+  val riskIncreaseFactors: String? = null,
+  val riskMitigationFactors: String? = null,
+  val overallRiskLevel: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/Risks.kt
@@ -6,4 +6,5 @@ data class Risks(
   val assessedOn: LocalDateTime? = null,
   val riskToSelf: RiskToSelf = RiskToSelf(),
   val otherRisks: OtherRisks = OtherRisks(),
+  val summary: RiskSummary = RiskSummary(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummary.kt
@@ -9,6 +9,8 @@ data class RiskSummary(
   val riskIncreaseFactors: String? = null,
   val riskMitigationFactors: String? = null,
   val overallRiskLevel: String? = null,
+  val riskInCommunity: Map<String, List<String>>? = null,
+  val riskInCustody: Map<String, List<String>>? = null,
 ) {
   fun toRiskSummary(): IntegrationApiRiskSummary = IntegrationApiRiskSummary(
     whoIsAtRisk = this.whoIsAtRisk,
@@ -17,5 +19,23 @@ data class RiskSummary(
     riskIncreaseFactors = this.riskIncreaseFactors,
     riskMitigationFactors = this.riskMitigationFactors,
     overallRiskLevel = this.overallRiskLevel,
+    riskInCommunity = if (!this.riskInCommunity.isNullOrEmpty()) toRiskInContext(this.riskInCommunity) else null,
+    riskInCustody = if (!this.riskInCustody.isNullOrEmpty()) toRiskInContext(this.riskInCustody) else null,
   )
+
+  private fun toRiskInContext(arnRiskInContext: Map<String, List<String>>): Map<String, String> {
+    var riskInContext = mutableMapOf<String, String>()
+
+    for ((riskLevel, personGroups) in arnRiskInContext) {
+      for (personGroup in personGroups) {
+        val personGroupKey = toCamelCase(personGroup)
+        riskInContext[personGroupKey] = riskLevel
+      }
+    }
+    return riskInContext
+  }
+
+  private fun toCamelCase(personGroup: String) =
+    personGroup.split(" ").map { it.replaceFirstChar(Char::uppercaseChar) }.joinToString("")
+      .replaceFirstChar(Char::lowercaseChar)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummary.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskSummary as IntegrationApiRiskSummary
+
+data class RiskSummary(
+  val whoIsAtRisk: String? = null,
+  val natureOfRisk: String? = null,
+  val riskImminence: String? = null,
+  val riskIncreaseFactors: String? = null,
+  val riskMitigationFactors: String? = null,
+  val overallRiskLevel: String? = null,
+) {
+  fun toRiskSummary(): IntegrationApiRiskSummary = IntegrationApiRiskSummary(
+    whoIsAtRisk = this.whoIsAtRisk,
+    natureOfRisk = this.natureOfRisk,
+    riskImminence = this.riskImminence,
+    riskIncreaseFactors = this.riskIncreaseFactors,
+    riskMitigationFactors = this.riskMitigationFactors,
+    overallRiskLevel = this.overallRiskLevel,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risks.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/Risks.kt
@@ -7,10 +7,12 @@ data class Risks(
   val assessedOn: LocalDateTime? = null,
   val riskToSelf: RiskToSelf = RiskToSelf(),
   val otherRisks: OtherRisks = OtherRisks(),
+  val summary: RiskSummary = RiskSummary(),
 ) {
   fun toRisks(): IntegrationApiRisks = IntegrationApiRisks(
     assessedOn = this.assessedOn,
     riskToSelf = this.riskToSelf.toRiskToSelf(),
     otherRisks = this.otherRisks.toOtherRisks(),
+    summary = this.summary.toRiskSummary(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
@@ -61,6 +61,25 @@ internal class RisksControllerTest(
               otherRisks = OtherRisks(breachOfTrust = "NO"),
               summary = RiskSummary(
                 overallRiskLevel = "LOW",
+                whoIsAtRisk = "X, Y and Z are at risk",
+                natureOfRisk = "The nature of the risk is X",
+                riskImminence = "the risk is imminent and more probably in X situation",
+                riskIncreaseFactors = "If offender in situation X the risk can be higher",
+                riskMitigationFactors = "Giving offender therapy in X will reduce the risk",
+                riskInCommunity = mapOf(
+                  "children" to "HIGH",
+                  "public" to "HIGH",
+                  "knownAdult" to "HIGH",
+                  "staff" to "MEDIUM",
+                  "prisoners" to "LOW",
+                ),
+                riskInCustody = mapOf(
+                  "children" to "LOW",
+                  "public" to "LOW",
+                  "knownAdult" to "HIGH",
+                  "staff" to "VERY_HIGH",
+                  "prisoners" to "VERY_HIGH",
+                ),
               ),
             ),
           ),
@@ -130,12 +149,26 @@ internal class RisksControllerTest(
               "riskToOtherPrisoners": null
             },
             "summary": {
-              "whoIsAtRisk": null,
-              "natureOfRisk":null,
-              "riskImminence":null,
-              "riskIncreaseFactors":null,
-              "riskMitigationFactors":null,
-              "overallRiskLevel": "LOW"
+              "whoIsAtRisk": "X, Y and Z are at risk",
+              "natureOfRisk": "The nature of the risk is X",
+              "riskImminence": "the risk is imminent and more probably in X situation",
+              "riskIncreaseFactors": "If offender in situation X the risk can be higher",
+              "riskMitigationFactors": "Giving offender therapy in X will reduce the risk",
+              "overallRiskLevel": "LOW",
+              "riskInCommunity": {
+                "children":"HIGH",
+                "public":"HIGH",
+                "knownAdult":"HIGH",
+                "staff":"MEDIUM",
+                "prisoners":"LOW"
+               },
+               "riskInCustody": {
+                "children":"LOW",
+                "public":"LOW",
+                "knownAdult":"HIGH",
+                "staff":"VERY_HIGH",
+                "prisoners":"VERY_HIGH"
+               }
             }
           }
           """.removeWhitespaceAndNewlines(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RisksControllerTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitesp
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.OtherRisks
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risk
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskSummary
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskToSelf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risks
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
@@ -58,6 +59,9 @@ internal class RisksControllerTest(
                 vulnerability = Risk(risk = "NO"),
               ),
               otherRisks = OtherRisks(breachOfTrust = "NO"),
+              summary = RiskSummary(
+                overallRiskLevel = "LOW",
+              ),
             ),
           ),
         )
@@ -124,6 +128,14 @@ internal class RisksControllerTest(
               "controlIssuesDisruptiveBehaviour": null,
               "breachOfTrust": "NO",
               "riskToOtherPrisoners": null
+            },
+            "summary": {
+              "whoIsAtRisk": null,
+              "natureOfRisk":null,
+              "riskImminence":null,
+              "riskIncreaseFactors":null,
+              "riskMitigationFactors":null,
+              "overallRiskLevel": "LOW"
             }
           }
           """.removeWhitespaceAndNewlines(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/GetRisksForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/GetRisksForPersonTest.kt
@@ -16,7 +16,12 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.AssessRisksAndN
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.AssessRisksAndNeedsApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.OtherRisks
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risk
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskSummary
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskToSelf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import java.io.File
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risks as IntegrationApiRisks
 
@@ -32,18 +37,14 @@ class GetRisksForPersonTest(
   DescribeSpec(
     {
       val assessRisksAndNeedsApiMockServer = AssessRisksAndNeedsApiMockServer()
-      val crn = "X777776"
+      val deliusCrn = "X777776"
 
       beforeEach {
         assessRisksAndNeedsApiMockServer.start()
         Mockito.reset(hmppsAuthGateway)
         assessRisksAndNeedsApiMockServer.stubGetRisksForPerson(
-          crn,
-          """
-              {
-                "assessedOn": "2023-09-19T12:51:38"
-              }
-          """,
+          deliusCrn,
+          File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/fixtures/GetRisksResponse.json").readText(),
         )
 
         Mockito.reset(hmppsAuthGateway)
@@ -55,23 +56,76 @@ class GetRisksForPersonTest(
       }
 
       it("authenticates using HMPPS Auth with credentials") {
-        assessRisksAndNeedsGateway.getRisksForPerson(crn)
+        assessRisksAndNeedsGateway.getRisksForPerson(deliusCrn)
 
         verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("ASSESS_RISKS_AND_NEEDS")
       }
 
       it("returns risks for the person with the matching CRN") {
-        val response = assessRisksAndNeedsGateway.getRisksForPerson(crn)
+        val response = assessRisksAndNeedsGateway.getRisksForPerson(deliusCrn)
 
         response.data.shouldBe(
-          IntegrationApiRisks(LocalDateTime.of(2023, 9, 19, 12, 51, 38)),
+          IntegrationApiRisks(
+            assessedOn = LocalDateTime.of(2023, 9, 27, 11, 46, 36),
+            riskToSelf = RiskToSelf(
+              suicide = Risk(
+                risk = "Yes",
+                previous = "Yes",
+                previousConcernsText = "Risk of self harms concerns due to ...",
+                current = "Yes",
+                currentConcernsText = "Risk of self harms concerns due to ...",
+              ),
+              selfHarm = Risk(
+                risk = "No",
+                previous = "No",
+                previousConcernsText = "Risk of self harms concerns due to ...",
+                current = "No",
+                currentConcernsText = "Risk of self harms concerns due to ...",
+              ),
+              custody = Risk(
+                risk = "Don't know",
+                previous = "Don't know",
+                previousConcernsText = "Risk of self harms concerns due to ...",
+                current = "Don't know",
+                currentConcernsText = "Risk of self harms concerns due to ...",
+              ),
+              hostelSetting = Risk(
+                risk = "Yes",
+                previous = "Yes",
+                previousConcernsText = "Risk of self harms concerns due to ...",
+                current = "Yes",
+                currentConcernsText = "Risk of self harms concerns due to ...",
+              ),
+              vulnerability = Risk(
+                risk = "Yes",
+                previous = "Yes",
+                previousConcernsText = "Risk of self harms concerns due to ...",
+                current = "Yes",
+                currentConcernsText = "Risk of self harms concerns due to ...",
+              ),
+            ),
+            otherRisks = OtherRisks(
+              escapeOrAbscond = "YES",
+              controlIssuesDisruptiveBehaviour = "YES",
+              breachOfTrust = "YES",
+              riskToOtherPrisoners = "YES",
+            ),
+            summary = RiskSummary(
+              whoIsAtRisk = "X, Y and Z are at risk",
+              natureOfRisk = "The nature of the risk is X",
+              riskImminence = "the risk is imminent and more probably in X situation",
+              riskIncreaseFactors = "If offender in situation X the risk can be higher",
+              riskMitigationFactors = "Giving offender therapy in X will reduce the risk",
+              overallRiskLevel = "HIGH",
+            ),
+          ),
         )
       }
 
       it("returns an error when 404 NOT FOUND is returned because no person is found") {
-        assessRisksAndNeedsApiMockServer.stubGetRisksForPerson(crn, "", HttpStatus.NOT_FOUND)
+        assessRisksAndNeedsApiMockServer.stubGetRisksForPerson(deliusCrn, "", HttpStatus.NOT_FOUND)
 
-        val response = assessRisksAndNeedsGateway.getRisksForPerson(crn)
+        val response = assessRisksAndNeedsGateway.getRisksForPerson(deliusCrn)
 
         response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/GetRisksForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/GetRisksForPersonTest.kt
@@ -117,6 +117,20 @@ class GetRisksForPersonTest(
               riskIncreaseFactors = "If offender in situation X the risk can be higher",
               riskMitigationFactors = "Giving offender therapy in X will reduce the risk",
               overallRiskLevel = "HIGH",
+              riskInCommunity = mapOf(
+                "children" to "HIGH",
+                "public" to "HIGH",
+                "knownAdult" to "HIGH",
+                "staff" to "MEDIUM",
+                "prisoners" to "LOW",
+              ),
+              riskInCustody = mapOf(
+                "children" to "LOW",
+                "public" to "LOW",
+                "knownAdult" to "HIGH",
+                "staff" to "VERY_HIGH",
+                "prisoners" to "VERY_HIGH",
+              ),
             ),
           ),
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/fixtures/GetRisksResponse.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/fixtures/GetRisksResponse.json
@@ -1,0 +1,80 @@
+{
+  "riskToSelf": {
+    "suicide": {
+      "risk": "Yes",
+      "previous": "Yes",
+      "previousConcernsText": "Risk of self harms concerns due to ...",
+      "current": "Yes",
+      "currentConcernsText": "Risk of self harms concerns due to ..."
+    },
+    "selfHarm": {
+      "risk": "No",
+      "previous": "No",
+      "previousConcernsText": "Risk of self harms concerns due to ...",
+      "current": "No",
+      "currentConcernsText": "Risk of self harms concerns due to ..."
+    },
+    "custody": {
+      "risk": "Don't know",
+      "previous": "Don't know",
+      "previousConcernsText": "Risk of self harms concerns due to ...",
+      "current": "Don't know",
+      "currentConcernsText": "Risk of self harms concerns due to ..."
+    },
+    "hostelSetting": {
+      "risk": "Yes",
+      "previous": "Yes",
+      "previousConcernsText": "Risk of self harms concerns due to ...",
+      "current": "Yes",
+      "currentConcernsText": "Risk of self harms concerns due to ..."
+    },
+    "vulnerability": {
+      "risk": "Yes",
+      "previous": "Yes",
+      "previousConcernsText": "Risk of self harms concerns due to ...",
+      "current": "Yes",
+      "currentConcernsText": "Risk of self harms concerns due to ..."
+    }
+  },
+  "otherRisks": {
+    "escapeOrAbscond": "YES",
+    "controlIssuesDisruptiveBehaviour": "YES",
+    "breachOfTrust": "YES",
+    "riskToOtherPrisoners": "YES"
+  },
+  "summary": {
+    "whoIsAtRisk": "X, Y and Z are at risk",
+    "natureOfRisk": "The nature of the risk is X",
+    "riskImminence": "the risk is imminent and more probably in X situation",
+    "riskIncreaseFactors": "If offender in situation X the risk can be higher",
+    "riskMitigationFactors": "Giving offender therapy in X will reduce the risk",
+    "riskInCommunity": {
+      "HIGH ": [
+        "Children",
+        "Public",
+        "Know adult"
+      ],
+      "MEDIUM": [
+        "Staff"
+      ],
+      "LOW": [
+        "Prisoners"
+      ]
+    },
+    "riskInCustody": {
+      "HIGH ": [
+        "Know adult"
+      ],
+      "VERY_HIGH": [
+        "Staff",
+        "Prisoners"
+      ],
+      "LOW": [
+        "Children",
+        "Public"
+      ]
+    },
+    "overallRiskLevel": "HIGH"
+  },
+  "assessedOn": "2023-09-27T11:46:36"
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/fixtures/GetRisksResponse.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/assessrisksandneeds/fixtures/GetRisksResponse.json
@@ -49,10 +49,10 @@
     "riskIncreaseFactors": "If offender in situation X the risk can be higher",
     "riskMitigationFactors": "Giving offender therapy in X will reduce the risk",
     "riskInCommunity": {
-      "HIGH ": [
+      "HIGH": [
         "Children",
         "Public",
-        "Know adult"
+        "Known adult"
       ],
       "MEDIUM": [
         "Staff"
@@ -62,8 +62,8 @@
       ]
     },
     "riskInCustody": {
-      "HIGH ": [
-        "Know adult"
+      "HIGH": [
+        "Known adult"
       ],
       "VERY_HIGH": [
         "Staff",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummaryTest.kt
@@ -27,5 +27,50 @@ class RiskSummaryTest : DescribeSpec(
         integrationApiRiskSummary.overallRiskLevel.shouldBe(arnRiskSummary.overallRiskLevel)
       }
     }
+
+    it("maps ARN Risk in Community to Integration API Risk in Community") {
+      val arnRiskSummary = ArnRiskSummary(
+        riskInCommunity = mapOf(
+          "HIGH" to listOf("Children", "Public", "Known adult"),
+          "MEDIUM" to listOf("Staff"),
+          "LOW" to listOf("Prisoners"),
+        ),
+      )
+
+      val integrationApiRiskSummary = arnRiskSummary.toRiskSummary()
+
+      integrationApiRiskSummary.riskInCommunity.shouldBe(
+        mapOf(
+          "children" to "HIGH",
+          "public" to "HIGH",
+          "knownAdult" to "HIGH",
+          "staff" to "MEDIUM",
+          "prisoners" to "LOW",
+        ),
+      )
+    }
+
+    it("maps ARN Risk in Custody to Integration API Risk in Custody") {
+      val arnRiskSummary = ArnRiskSummary(
+        riskInCustody = mapOf(
+          "VERY_HIGH" to listOf("Known adult"),
+          "HIGH" to listOf("Children"),
+          "MEDIUM" to listOf("Staff", "Public"),
+          "LOW" to listOf("Prisoners"),
+        ),
+      )
+
+      val integrationApiRiskSummary = arnRiskSummary.toRiskSummary()
+
+      integrationApiRiskSummary.riskInCustody.shouldBe(
+        mapOf(
+          "children" to "HIGH",
+          "public" to "MEDIUM",
+          "knownAdult" to "VERY_HIGH",
+          "staff" to "MEDIUM",
+          "prisoners" to "LOW",
+        ),
+      )
+    }
   },
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RiskSummaryTest.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.RiskSummary as ArnRiskSummary
+
+class RiskSummaryTest : DescribeSpec(
+  {
+    describe("#toRiskSummary") {
+      it("maps one-to-one attributes to Integration API attributes") {
+        val arnRiskSummary = ArnRiskSummary(
+          whoIsAtRisk = "X, Y and Z are at risk",
+          natureOfRisk = "The nature of the risk is X",
+          riskImminence = "the risk is imminent and more probably in X situation",
+          riskIncreaseFactors = "If offender in situation X the risk can be higher",
+          riskMitigationFactors = "Giving offender therapy in X will reduce the risk",
+          overallRiskLevel = "HIGH",
+        )
+
+        val integrationApiRiskSummary = arnRiskSummary.toRiskSummary()
+
+        integrationApiRiskSummary.whoIsAtRisk.shouldBe(arnRiskSummary.whoIsAtRisk)
+        integrationApiRiskSummary.natureOfRisk.shouldBe(arnRiskSummary.natureOfRisk)
+        integrationApiRiskSummary.riskImminence.shouldBe(arnRiskSummary.riskImminence)
+        integrationApiRiskSummary.riskIncreaseFactors.shouldBe(arnRiskSummary.riskIncreaseFactors)
+        integrationApiRiskSummary.riskMitigationFactors.shouldBe(arnRiskSummary.riskMitigationFactors)
+        integrationApiRiskSummary.overallRiskLevel.shouldBe(arnRiskSummary.overallRiskLevel)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
@@ -19,6 +19,9 @@ class RisksTest : DescribeSpec(
             vulnerability = Risk(risk = "NO"),
           ),
           otherRisks = OtherRisks(breachOfTrust = "YES"),
+          summary = RiskSummary(
+            whoIsAtRisk = "X, Y and Z are at risk",
+          ),
         )
 
         val integrationApiRisks = arnRisks.toRisks()
@@ -30,6 +33,7 @@ class RisksTest : DescribeSpec(
         integrationApiRisks.riskToSelf.hostelSetting.risk.shouldBe(arnRisks.riskToSelf.hostelSetting.risk)
         integrationApiRisks.riskToSelf.vulnerability.risk.shouldBe(arnRisks.riskToSelf.vulnerability.risk)
         integrationApiRisks.otherRisks.breachOfTrust.shouldBe(arnRisks.otherRisks.breachOfTrust)
+        integrationApiRisks.summary.whoIsAtRisk.shouldBe(arnRisks.summary.whoIsAtRisk)
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/assessRisksAndNeeds/RisksTest.kt
@@ -2,7 +2,16 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNe
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.OtherRisks
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risk
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskSummary
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.RiskToSelf
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Risks
 import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.OtherRisks as ArnOtherRisks
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.Risk as ArnRisk
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.RiskSummary as ArnRiskSummary
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.RiskToSelf as ArnRiskToSelf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.assessRisksAndNeeds.Risks as ArnRisks
 
 class RisksTest : DescribeSpec(
@@ -11,15 +20,15 @@ class RisksTest : DescribeSpec(
       it("maps one-to-one attributes to Integration API attributes") {
         val arnRisks = ArnRisks(
           assessedOn = LocalDateTime.now(),
-          riskToSelf = RiskToSelf(
-            suicide = Risk(risk = "NO"),
-            selfHarm = Risk(risk = "NO"),
-            custody = Risk(risk = "NO"),
-            hostelSetting = Risk(risk = "NO"),
-            vulnerability = Risk(risk = "NO"),
+          riskToSelf = ArnRiskToSelf(
+            suicide = ArnRisk(risk = "NO"),
+            selfHarm = ArnRisk(risk = "NO"),
+            custody = ArnRisk(risk = "NO"),
+            hostelSetting = ArnRisk(risk = "NO"),
+            vulnerability = ArnRisk(risk = "NO"),
           ),
-          otherRisks = OtherRisks(breachOfTrust = "YES"),
-          summary = RiskSummary(
+          otherRisks = ArnOtherRisks(breachOfTrust = "YES"),
+          summary = ArnRiskSummary(
             whoIsAtRisk = "X, Y and Z are at risk",
           ),
         )
@@ -34,6 +43,67 @@ class RisksTest : DescribeSpec(
         integrationApiRisks.riskToSelf.vulnerability.risk.shouldBe(arnRisks.riskToSelf.vulnerability.risk)
         integrationApiRisks.otherRisks.breachOfTrust.shouldBe(arnRisks.otherRisks.breachOfTrust)
         integrationApiRisks.summary.whoIsAtRisk.shouldBe(arnRisks.summary.whoIsAtRisk)
+      }
+
+      it("maps Risk in Community and Risk in Custody to Integration API attributes") {
+        val arnRisks = ArnRisks(
+          summary = ArnRiskSummary(
+            riskInCommunity = mapOf(
+              "HIGH" to listOf("Children", "Public", "Known adult"),
+              "MEDIUM" to listOf("Staff"),
+              "LOW" to listOf("Prisoners"),
+            ),
+            riskInCustody = mapOf(
+              "VERY_HIGH" to listOf("Known adult"),
+              "HIGH" to listOf("Children"),
+              "MEDIUM" to listOf("Staff", "Public"),
+              "LOW" to listOf("Prisoners"),
+            ),
+          ),
+        )
+
+        val integrationApiRisks = arnRisks.toRisks()
+
+        integrationApiRisks.summary.riskInCommunity.shouldBe(
+          mapOf(
+            "children" to "HIGH",
+            "public" to "HIGH",
+            "knownAdult" to "HIGH",
+            "staff" to "MEDIUM",
+            "prisoners" to "LOW",
+          ),
+        )
+
+        integrationApiRisks.summary.riskInCustody.shouldBe(
+          mapOf(
+            "children" to "HIGH",
+            "public" to "MEDIUM",
+            "knownAdult" to "VERY_HIGH",
+            "staff" to "MEDIUM",
+            "prisoners" to "LOW",
+          ),
+        )
+      }
+
+      it("handles null values") {
+        val arnRisks = ArnRisks()
+
+        val integrationApiRisks = arnRisks.toRisks()
+
+        integrationApiRisks.shouldBe(
+          Risks(
+            assessedOn = null,
+            riskToSelf = RiskToSelf(
+              suicide = Risk(),
+              selfHarm = Risk(),
+              custody = Risk(),
+              hostelSetting = Risk(),
+              vulnerability = Risk(),
+            ),
+            otherRisks = OtherRisks(),
+            summary = RiskSummary(),
+          ),
+        )
       }
     }
   },


### PR DESCRIPTION
## Context

In #261, we created the thin slice for the `/v1/persons/{id}/risks` endpoint which will return the risk to serious harm (RoSH) risks.

Our golden record includes four top-level properties:

1. `riskToSelf` - added in #262 
2. `otherRisks` - added in #263
3. `summary` - **added in this PR**
4. `assessedOn` - added in #261 (thin slice)

## Changes proposed in this pull request

- Add models for Assess Risks and Needs (ARN) and our API to return `riskSummary`. 
    - Some of these attributes map one to one to our golden record so no transformation is done.
    - The Risk in Community and Risk in Context attributes have been have been mapped onto a restructured model with person groups as keys and risk levels as values. This mapping is done via a Risk in Context function.

## Next steps

1. Documentation
