### PR TITLE
Add headers for probation off search healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       dockerfile: Dockerfile.setup-probation-offender-search
     container_name: probation-offender-search
     healthcheck:
-      test: 'wget http://0.0.0.0:4010/synthetic-monitor -O /dev/null'
+      test: 'wget --header="Authorization: Bearer abc" http://0.0.0.0:4010/synthetic-monitor -O /dev/null'
     ports:
       - '4020:4010'
 


### PR DESCRIPTION
Smoketests were failing after change in probation offender search which required an authentication header to call the open API docs.