### PR TITLE
Update NOMIS Gateway to get latest sentence key dates and adjustments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -194,7 +194,7 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
     }
   }
 
-  fun getSentenceAdjustmentsForPerson(id: String): Response<SentenceAdjustment?> {
+  fun getLatestSentenceAdjustmentsForPerson(id: String): Response<SentenceAdjustment?> {
     return try {
       Response(
         data = webClient.request<SentenceSummary>(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -17,12 +17,14 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Person
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceAdjustment
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceKeyDates
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Booking
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.ImageDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.OffenceHistoryDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Offender
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.OffenderSentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.SentenceSummary
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Address as AddressFromNomis
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.Alert as AlertFromNomis
@@ -200,6 +202,28 @@ class NomisGateway(@Value("\${services.prison-api.base-url}") baseUrl: String) {
           "/api/offenders/$id/booking/latest/sentence-summary",
           authenticationHeader(),
         ).latestPrisonTerm.sentenceAdjustments.toSentenceAdjustment(),
+      )
+    } catch (exception: WebClientResponseException.NotFound) {
+      Response(
+        data = null,
+        errors = listOf(
+          UpstreamApiError(
+            causedBy = UpstreamApi.NOMIS,
+            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+          ),
+        ),
+      )
+    }
+  }
+
+  fun getLatestSentenceKeyDatesForPerson(id: String): Response<SentenceKeyDates?> {
+    return try {
+      Response(
+        data = webClient.request<OffenderSentence>(
+          HttpMethod.GET,
+          "/api/offenders/$id/sentences",
+          authenticationHeader(),
+        ).sentenceDetail.toSentenceKeyDates(),
       )
     } catch (exception: WebClientResponseException.NotFound) {
       Response(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceAdjustment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceAdjustment.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class SentenceAdjustment(
+  val additionalDaysAwarded: Number? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceKeyDate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceKeyDate.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+import java.time.LocalDate
+
+data class SentenceKeyDate(
+  val date: LocalDate? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceKeyDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/SentenceKeyDates.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
+
+data class SentenceKeyDates(
+  val automaticRelease: SentenceKeyDate = SentenceKeyDate(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenderSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/OffenderSentence.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+data class OffenderSentence(
+  val sentenceDetail: SentenceKeyDates = SentenceKeyDates(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PrisonTerm.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PrisonTerm.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+data class PrisonTerm(
+  val sentenceAdjustments: SentenceAdjustment = SentenceAdjustment(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceAdjustment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceAdjustment.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceAdjustment
+
+data class SentenceAdjustment(
+  val additionalDaysAwarded: Number? = null,
+) {
+  fun toSentenceAdjustment(): SentenceAdjustment = SentenceAdjustment(
+    additionalDaysAwarded = this.additionalDaysAwarded,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceKeyDates.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceKeyDates.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceKeyDate
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.SentenceKeyDates
+import java.time.LocalDate
+
+data class SentenceKeyDates(
+  val automaticReleaseDate: LocalDate? = null,
+) {
+  fun toSentenceKeyDates(): SentenceKeyDates = SentenceKeyDates(
+    automaticRelease = SentenceKeyDate(date = automaticReleaseDate),
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceSummary.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+data class SentenceSummary(
+  val latestPrisonTerm: PrisonTerm = PrisonTerm(),
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetLatestSentenceAdjustmentsForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetLatestSentenceAdjustmentsForPersonTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
   initializers = [ConfigDataApplicationContextInitializer::class],
   classes = [NomisGateway::class],
 )
-class GetSentenceAdjustmentsForPersonTest(
+class GetLatestSentenceAdjustmentsForPersonTest(
   @MockBean val hmppsAuthGateway: HmppsAuthGateway,
   private val nomisGateway: NomisGateway,
 ) : DescribeSpec(
@@ -33,7 +33,7 @@ class GetSentenceAdjustmentsForPersonTest(
 
     beforeEach {
       nomisApiMockServer.start()
-      nomisApiMockServer.stubGetSentenceAdjustmentsForPerson(
+      nomisApiMockServer.stubGetLatestSentenceAdjustmentsForPerson(
         offenderNo,
         """
           {
@@ -56,19 +56,19 @@ class GetSentenceAdjustmentsForPersonTest(
     }
 
     it("authenticates using HMPPS Auth with credentials") {
-      nomisGateway.getSentenceAdjustmentsForPerson(offenderNo)
+      nomisGateway.getLatestSentenceAdjustmentsForPerson(offenderNo)
 
       verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
     }
 
     it("returns sentence adjustments for a person with the matching ID") {
-      val response = nomisGateway.getSentenceAdjustmentsForPerson(offenderNo)
+      val response = nomisGateway.getLatestSentenceAdjustmentsForPerson(offenderNo)
 
       response.data?.additionalDaysAwarded.shouldBe(12)
     }
 
     it("returns an error when 404 NOT FOUND is returned") {
-      nomisApiMockServer.stubGetSentenceAdjustmentsForPerson(
+      nomisApiMockServer.stubGetLatestSentenceAdjustmentsForPerson(
         offenderNo,
         """
         {
@@ -78,7 +78,7 @@ class GetSentenceAdjustmentsForPersonTest(
         HttpStatus.NOT_FOUND,
       )
 
-      val response = nomisGateway.getSentenceAdjustmentsForPerson(offenderNo)
+      val response = nomisGateway.getLatestSentenceAdjustmentsForPerson(offenderNo)
 
       response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetLatestSentenceKeyDatesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetLatestSentenceKeyDatesForPersonTest.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.nomis
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import java.time.LocalDate
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [NomisGateway::class],
+)
+class GetLatestSentenceKeyDatesForPersonTest(
+  @MockBean val hmppsAuthGateway: HmppsAuthGateway,
+  private val nomisGateway: NomisGateway,
+) : DescribeSpec(
+  {
+    val nomisApiMockServer = NomisApiMockServer()
+    val offenderNo = "abc123"
+
+    beforeEach {
+      nomisApiMockServer.start()
+      nomisApiMockServer.stubGetLatestSentenceKeyDatesForPerson(
+        offenderNo,
+        """
+          {
+            "sentenceDetail": {
+              "automaticReleaseDate": "2023-03-01"
+            }
+          }
+        """,
+      )
+
+      Mockito.reset(hmppsAuthGateway)
+      whenever(hmppsAuthGateway.getClientToken("NOMIS")).thenReturn(HmppsAuthMockServer.TOKEN)
+    }
+
+    afterTest {
+      nomisApiMockServer.stop()
+    }
+
+    it("authenticates using HMPPS Auth with credentials") {
+      nomisGateway.getLatestSentenceKeyDatesForPerson(offenderNo)
+
+      verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+    }
+
+    it("returns latest sentence key dates for a person with the matching ID") {
+      val response = nomisGateway.getLatestSentenceKeyDatesForPerson(offenderNo)
+
+      response.data?.automaticRelease?.date.shouldBe(LocalDate.parse("2023-03-01"))
+    }
+
+    it("returns an error when 404 NOT FOUND is returned") {
+      nomisApiMockServer.stubGetLatestSentenceKeyDatesForPerson(
+        offenderNo,
+        """
+        {
+          "developerMessage": "cannot find person"
+        }
+        """,
+        HttpStatus.NOT_FOUND,
+      )
+
+      val response = nomisGateway.getLatestSentenceKeyDatesForPerson(offenderNo)
+
+      response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentenceAdjustmentsForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetSentenceAdjustmentsForPersonTest.kt
@@ -1,0 +1,86 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.nomis
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NomisApiMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+
+@ActiveProfiles("test")
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [NomisGateway::class],
+)
+class GetSentenceAdjustmentsForPersonTest(
+  @MockBean val hmppsAuthGateway: HmppsAuthGateway,
+  private val nomisGateway: NomisGateway,
+) : DescribeSpec(
+  {
+    val nomisApiMockServer = NomisApiMockServer()
+    val offenderNo = "abc123"
+
+    beforeEach {
+      nomisApiMockServer.start()
+      nomisApiMockServer.stubGetSentenceAdjustmentsForPerson(
+        offenderNo,
+        """
+          {
+            "prisonerNumber": "A1234AA",
+            "latestPrisonTerm": {
+              "sentenceAdjustments": {
+                "additionalDaysAwarded": 12
+              }
+            }
+          }
+        """,
+      )
+
+      Mockito.reset(hmppsAuthGateway)
+      whenever(hmppsAuthGateway.getClientToken("NOMIS")).thenReturn(HmppsAuthMockServer.TOKEN)
+    }
+
+    afterTest {
+      nomisApiMockServer.stop()
+    }
+
+    it("authenticates using HMPPS Auth with credentials") {
+      nomisGateway.getSentenceAdjustmentsForPerson(offenderNo)
+
+      verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("NOMIS")
+    }
+
+    it("returns sentence adjustments for a person with the matching ID") {
+      val response = nomisGateway.getSentenceAdjustmentsForPerson(offenderNo)
+
+      response.data?.additionalDaysAwarded.shouldBe(12)
+    }
+
+    it("returns an error when 404 NOT FOUND is returned") {
+      nomisApiMockServer.stubGetSentenceAdjustmentsForPerson(
+        offenderNo,
+        """
+        {
+          "developerMessage": "cannot find person"
+        }
+        """,
+        HttpStatus.NOT_FOUND,
+      )
+
+      val response = nomisGateway.getSentenceAdjustmentsForPerson(offenderNo)
+
+      response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND).shouldBeTrue()
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -145,4 +145,19 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
         ),
     )
   }
+
+  fun stubGetLatestSentenceKeyDatesForPerson(nomisNumber: String, body: String, status: HttpStatus = HttpStatus.OK) {
+    stubFor(
+      get("/api/offenders/$nomisNumber/sentences")
+        .withHeader(
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
+        ).willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+            .withBody(body.trimIndent()),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -130,4 +130,19 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
         ),
     )
   }
+
+  fun stubGetSentenceAdjustmentsForPerson(nomisNumber: String, body: String, status: HttpStatus = HttpStatus.OK) {
+    stubFor(
+      get("/api/offenders/$nomisNumber/booking/latest/sentence-summary")
+        .withHeader(
+          "Authorization",
+          matching("Bearer ${HmppsAuthMockServer.TOKEN}"),
+        ).willReturn(
+          aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(status.value())
+            .withBody(body.trimIndent()),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NomisApiMockServer.kt
@@ -131,7 +131,7 @@ class NomisApiMockServer : WireMockServer(WIREMOCK_PORT) {
     )
   }
 
-  fun stubGetSentenceAdjustmentsForPerson(nomisNumber: String, body: String, status: HttpStatus = HttpStatus.OK) {
+  fun stubGetLatestSentenceAdjustmentsForPerson(nomisNumber: String, body: String, status: HttpStatus = HttpStatus.OK) {
     stubFor(
       get("/api/offenders/$nomisNumber/booking/latest/sentence-summary")
         .withHeader(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceAdjustmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceAdjustmentTest.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.SentenceAdjustment as SentenceAdjustmentFromNomis
+
+class SentenceAdjustmentTest : DescribeSpec(
+  {
+    describe("#toSentenceAdjustment") {
+      it("maps one-to-one attributes to integration API attributes") {
+        val sentenceAdjustmentFromNomis = SentenceAdjustmentFromNomis(
+          additionalDaysAwarded = 12,
+        )
+
+        val sentenceAdjustment = sentenceAdjustmentFromNomis.toSentenceAdjustment()
+
+        sentenceAdjustment.additionalDaysAwarded.shouldBe(12)
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceKeyDatesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/SentenceKeyDatesTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis.SentenceKeyDates as SentenceKeyDatesFromNomis
+
+class SentenceKeyDatesTest : DescribeSpec(
+  {
+    describe("#toSentenceKeyDates") {
+      it("maps one-to-one attributes to integration API attributes") {
+        val sentenceKeyDatesFromNomis = SentenceKeyDatesFromNomis(
+          automaticReleaseDate = LocalDate.parse("2022-03-01"),
+        )
+
+        val sentenceKeyDates = sentenceKeyDatesFromNomis.toSentenceKeyDates()
+
+        sentenceKeyDates.automaticRelease.date.shouldBe(sentenceKeyDatesFromNomis.automaticReleaseDate)
+      }
+    }
+  },
+)


### PR DESCRIPTION
## Context

We want to build an endpoint to return the latest sentence key dates and adjustments i.e. prisoner release dates and adjustments.

First, we're going to build a thin slice of the API endpoint and then flesh out the response. As we're going to need to call two API endpoints from NOMIS (via Prison API), this PR has been split at this point and will have a follow-up PR that add the service and controller bits later.

## Changes proposed in this pull request

- Add two new methods within our NOMIS gateway to return the latest sentence key dates and adjustments.
- Add models for only returning one field for sentence key dates and adjustments.