### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@6
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.1
   shellcheck: circleci/shellcheck@3
   aws-cli: circleci/aws-cli@4.0.0

--- a/helm_deploy/hmpps-integration-api/Chart.yaml
+++ b/helm_deploy/hmpps-integration-api/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-integration-api
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.1.0
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.1.0

--- a/helm_deploy/hmpps-integration-api/values.yaml
+++ b/helm_deploy/hmpps-integration-api/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-integration-api
 
@@ -6,14 +5,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-integration-api
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
     v1_2_enabled: true
     v0_47_enabled: false
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: ""
     annotations:
       nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
@@ -29,7 +28,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
 
   allowlist:
-    unrestricted: "0.0.0.0/0"
+    unrestricted: 0.0.0.0/0
 
 generic-prometheus-alerts:
   targetApplication: hmpps-integration-api


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-integration-api/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `1 => 1 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
