### PR TITLE
Fix 404 error condition for finding a person

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -53,10 +53,7 @@ class PersonController(
     val hmppsId = encodedHmppsId.decodeUrlCharacters()
     val response = getPersonService.execute(hmppsId)
 
-    if (
-      response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS) &&
-      response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH)
-    ) {
+    if (response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -224,10 +224,6 @@ internal class PersonControllerTest(
                   causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
                   type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
                 ),
-                UpstreamApiError(
-                  causedBy = UpstreamApi.NOMIS,
-                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-                ),
               ),
             ),
           )


### PR DESCRIPTION
We should throw a 404 when a person could not be found in Probation Offender Search. Previously this checked if the person could not be found in the Prison API as well before throwing a 404.