### PR TITLE
Add debug info to see API GW header being sent

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -19,7 +19,7 @@ class AuthorisationFilter : Filter {
   ) {
     val req = request as HttpServletRequest
     println("****************** Header *******")
-    println(req.getHeader("api-key-id"))
+    println(req.getHeader("subject-distinguished-name"))
 
     println("****************** context Path *******")
     println(req.servletPath)


### PR DESCRIPTION
The header we are looking for is the subject Distinguished Name from the mTLS process. This will be used to do authorisation.