### PR TITLE
Updated gradle spring boot version to 5.10.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.10.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.10.1"
   kotlin("plugin.spring") version "1.9.20"
 }
 


### PR DESCRIPTION
## Context

Pipelines are failing on our gradle_owasp_dependency_check step due to a new version of uk.gov.justice.hmpps.gradle-spring-boot being released. As a result we need to upgrade versions.

## Changes proposed in this PR
- update uk.gov.justice.hmpps.gradle-spring-boot version specified