### PR TITLE
Limit requests per second at NGINX ingress level

### DIFF
--- a/helm_deploy/hmpps-integration-api/values.yaml
+++ b/helm_deploy/hmpps-integration-api/values.yaml
@@ -33,6 +33,7 @@ generic-service:
       nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
       nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
       nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+      nginx.ingress.kubernetes.io/limit-rps: "100"
 
   # Environment variables to load into the deployment
   env:


### PR DESCRIPTION
We will allow up to 100 RPS from one IP address.
This will prevent both intentional and unintentional flooding of the service.