### PR TITLE
Hia 631 update request wrapper to handle multiple 4 xx errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
 
 class WebClientWrapper(
   val baseUrl: String,
@@ -21,6 +25,11 @@ class WebClientWrapper(
     )
     .build()
 
+  sealed class WebClientWrapperResponse<out T> {
+    data class Success<T>(val data: T) : WebClientWrapperResponse<T>()
+    data class Error(val errors: List<UpstreamApiError>) : WebClientWrapperResponse<Nothing>()
+  }
+
   inline fun <reified T> request(method: HttpMethod, uri: String, headers: Map<String, String>, requestBody: Map<String, Any?>? = null): T {
     val responseBodySpec = client.method(method)
       .uri(uri)
@@ -33,6 +42,39 @@ class WebClientWrapper(
     return responseBodySpec.retrieve()
       .bodyToMono(T::class.java)
       .block()!!
+  }
+
+  inline fun <reified T> requestWithErrorHandling(method: HttpMethod, uri: String, headers: Map<String, String>, upstreamApi: UpstreamApi, requestBody: Map<String, Any?>? = null): WebClientWrapperResponse<T> {
+    try {
+      val responseBodySpec = client.method(method)
+        .uri(uri)
+        .headers { header -> headers.forEach { requestHeader -> header.set(requestHeader.key, requestHeader.value) } }
+
+      if (method == HttpMethod.POST && requestBody != null) {
+        responseBodySpec.body(BodyInserters.fromValue(requestBody))
+      }
+
+      val responseData = responseBodySpec.retrieve()
+        .bodyToMono(T::class.java)
+        .block()!!
+
+      return WebClientWrapperResponse.Success(responseData)
+    } catch (exception: WebClientResponseException) {
+      val errorType = when (exception.statusCode) {
+        HttpStatus.NOT_FOUND -> UpstreamApiError.Type.ENTITY_NOT_FOUND
+        HttpStatus.FORBIDDEN -> UpstreamApiError.Type.FORBIDDEN
+        HttpStatus.BAD_REQUEST -> UpstreamApiError.Type.BAD_REQUEST
+        else -> UpstreamApiError.Type.INTERNAL_SERVER_ERROR
+      }
+      return WebClientWrapperResponse.Error(
+        listOf(
+          UpstreamApiError(
+            causedBy = upstreamApi,
+            type = errorType,
+          ),
+        ),
+      )
+    }
   }
 
   inline fun <reified T> requestList(method: HttpMethod, uri: String, headers: Map<String, String>, requestBody: Map<String, Any?>? = null): List<T> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/AssessRisksAndNeedsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/AssessRisksAndNeedsGateway.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
@@ -46,46 +47,46 @@ class AssessRisksAndNeedsGateway(@Value("\${services.assess-risks-and-needs.base
   }
 
   fun getRisksForPerson(id: String): Response<IntegrationApiRisk?> {
-    return try {
-      Response(
-        data = webClient.request<ArnRisk>(
-          HttpMethod.GET,
-          "/risks/crn/$id",
-          authenticationHeader(),
-        ).toRisks(),
-      )
-    } catch (exception: WebClientResponseException.NotFound) {
-      Response(
-        data = null,
-        errors = listOf(
-          UpstreamApiError(
-            causedBy = UpstreamApi.ASSESS_RISKS_AND_NEEDS,
-            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-          ),
-        ),
-      )
+    val result = webClient.requestWithErrorHandling<ArnRisk>(
+      HttpMethod.GET,
+      "/risks/crn/$id",
+      authenticationHeader(),
+      UpstreamApi.ASSESS_RISKS_AND_NEEDS,
+    )
+
+    return when (result) {
+      is WebClientWrapperResponse.Success -> {
+        Response(data = result.data.toRisks())
+      }
+
+      is WebClientWrapperResponse.Error -> {
+        Response(
+          data = null,
+          errors = result.errors,
+        )
+      }
     }
   }
 
   fun getNeedsForPerson(id: String): Response<IntegrationApiNeeds?> {
-    return try {
-      Response(
-        data = webClient.request<ArnNeeds>(
-          HttpMethod.GET,
-          "/needs/crn/$id",
-          authenticationHeader(),
-        ).toNeeds(),
-      )
-    } catch (exception: WebClientResponseException.NotFound) {
-      Response(
-        data = null,
-        errors = listOf(
-          UpstreamApiError(
-            causedBy = UpstreamApi.ASSESS_RISKS_AND_NEEDS,
-            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-          ),
-        ),
-      )
+    val result = webClient.requestWithErrorHandling<ArnNeeds>(
+      HttpMethod.GET,
+      "/needs/crn/$id",
+      authenticationHeader(),
+      UpstreamApi.ASSESS_RISKS_AND_NEEDS,
+    )
+
+    return when (result) {
+      is WebClientWrapperResponse.Success -> {
+        Response(data = result.data.toNeeds())
+      }
+
+      is WebClientWrapperResponse.Error -> {
+        Response(
+          data = null,
+          errors = result.errors,
+        )
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -6,11 +6,8 @@ import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.*
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.Supervisions
 
 @Component
@@ -21,24 +18,24 @@ class NDeliusGateway(@Value("\${services.ndelius.base-url}") baseUrl: String) {
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getOffencesForPerson(id: String): Response<List<Offence>> {
-    return try {
-      Response(
-        data = webClient.request<Supervisions>(
-          HttpMethod.GET,
-          "/case/$id/supervisions",
-          authenticationHeader(),
-        ).supervisions.flatMap { it.toOffences() },
-      )
-    } catch (exception: WebClientResponseException.NotFound) {
-      Response(
-        data = emptyList(),
-        errors = listOf(
-          UpstreamApiError(
-            causedBy = UpstreamApi.NDELIUS,
-            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-          ),
-        ),
-      )
+    val result = webClient.requestWithErrorHandling<Supervisions>(
+      HttpMethod.GET,
+      "/case/$id/supervisions",
+      authenticationHeader(),
+      UpstreamApi.NDELIUS,
+    )
+
+    return when (result) {
+      is WebClientWrapperResponse.Success -> {
+        Response(data = result.data.supervisions.flatMap { it.toOffences() })
+      }
+
+      is WebClientWrapperResponse.Error -> {
+        Response(
+          data = emptyList(),
+          errors = result.errors,
+        )
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -4,10 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.Sentence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.Supervisions
 
 @Component
@@ -40,24 +42,24 @@ class NDeliusGateway(@Value("\${services.ndelius.base-url}") baseUrl: String) {
   }
 
   fun getSentencesForPerson(id: String): Response<List<Sentence>> {
-    return try {
-      Response(
-        data = webClient.request<Supervisions>(
-          HttpMethod.GET,
-          "/case/$id/supervisions",
-          authenticationHeader(),
-        ).supervisions.map { it.toSentence() },
-      )
-    } catch (exception: WebClientResponseException.NotFound) {
-      Response(
-        data = emptyList(),
-        errors = listOf(
-          UpstreamApiError(
-            causedBy = UpstreamApi.NDELIUS,
-            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-          ),
-        ),
-      )
+    val result = webClient.requestWithErrorHandling<Supervisions>(
+      HttpMethod.GET,
+      "/case/$id/supervisions",
+      authenticationHeader(),
+      UpstreamApi.NDELIUS,
+    )
+
+    return when (result) {
+      is WebClientWrapperResponse.Success -> {
+        Response(data = result.data.supervisions.map { it.toSentence() })
+      }
+
+      is WebClientWrapperResponse.Error -> {
+        Response(
+          data = emptyList(),
+          errors = result.errors,
+        )
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/UpstreamApiError.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models
 
 data class UpstreamApiError(val causedBy: UpstreamApi, val type: Type, val description: String? = null) {
   enum class Type {
-    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND, BAD_REQUEST
+    ENTITY_NOT_FOUND, ATTRIBUTE_NOT_FOUND, BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR
   }
 }


### PR DESCRIPTION
## Context

With there being LAO’s in our upstream systems we may receive a 403 as an error when someone searches for these offenders/nominals. As a result our API is erroring and throwing a 500 when in fact we should pass up this 403 error with some mild context.

Rather than go through every API upstream call in our gateways and add a check for whether there was a 403 returned we can move this error handling into the pre-existing request functionality and handle everything there. This will make any further error updates much more manageable going forward but will require a large initial change carried out in this ticket

This PR contains changes for moving to using a request wrapper with built in error handling for all our simple standard requests. As a result endpoints using requestList will need error handling also being added and this work will be carried out in this [PR](https://github.com/ministryofjustice/hmpps-integration-api/pull/328).

Any older non standard upstream gateways without error handling will be refactored and then moved to using the new request wrapper also in a different PR.

## Changes proposed in this PR
- Created a request wrapper with built in error handling
- Moved basic upstream endpoint calls to use new request wrapper