### PR TITLE
Refactor address controllers within person to be in their own class

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AddressController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AddressController.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Address
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+
+@RestController
+@RequestMapping("/v1/persons")
+class AddressController(
+  @Autowired val auditService: AuditService,
+  @Autowired val getAddressesForPersonService: GetAddressesForPersonService,
+) {
+
+  @GetMapping("{encodedHmppsId}/addresses")
+  fun getPersonAddresses(
+    @PathVariable encodedHmppsId: String,
+  ): Map<String, List<Address>> {
+    val hmppsId = encodedHmppsId.decodeUrlCharacters()
+    val response = getAddressesForPersonService.execute(hmppsId)
+
+    if (
+      response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.NOMIS) &&
+      response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH)
+    ) {
+      throw EntityNotFoundException("Could not find person with id: $hmppsId")
+    }
+    auditService.createEvent("GET_PERSON_ADDRESS", "Person address details with hmpps id: $hmppsId has been retrieved")
+    return mapOf("data" to response.data)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/AddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/AddressControllerTest.kt
@@ -1,0 +1,140 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestAddress
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetAddressesForPersonService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@WebMvcTest(controllers = [AddressController::class])
+@ActiveProfiles("test")
+internal class AddressControllerTest(
+  @Autowired var springMockMvc: MockMvc,
+  @MockBean val getAddressesForPersonService: GetAddressesForPersonService,
+  @MockBean val auditService: AuditService,
+) : DescribeSpec(
+  {
+    val hmppsId = "2003/13116M"
+    val encodedHmppsId = URLEncoder.encode(hmppsId, StandardCharsets.UTF_8)
+    val basePath = "/v1/persons"
+    val mockMvc = IntegrationAPIMockMvc(springMockMvc)
+
+    describe("GET $basePath/{encodedHmppsId}/addresses") {
+      beforeTest {
+        Mockito.reset(getAddressesForPersonService)
+        Mockito.reset(auditService)
+        whenever(getAddressesForPersonService.execute(hmppsId)).thenReturn(Response(data = listOf(generateTestAddress())))
+      }
+
+      it("returns a 200 OK status code") {
+        val result = mockMvc.performAuthorised("$basePath/$encodedHmppsId/addresses")
+
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+
+      it("gets the addresses for a person with the matching ID") {
+        mockMvc.performAuthorised("$basePath/$encodedHmppsId/addresses")
+
+        verify(getAddressesForPersonService, VerificationModeFactory.times(1)).execute(hmppsId)
+      }
+
+      it("returns the addresses for a person with the matching ID") {
+        val result = mockMvc.performAuthorised("$basePath/$encodedHmppsId/addresses")
+        result.response.contentAsString.shouldBe(
+          """
+        {
+          "data": [
+            {
+              "country": "England",
+              "county": "Greater London",
+              "endDate": "2023-05-20",
+              "locality": "London Bridge",
+              "name": "The chocolate factory",
+              "noFixedAddress": false,
+              "number": "89",
+              "postcode": "SE1 1TZ",
+              "startDate": "2021-05-10",
+              "street": "Omeara",
+              "town": "London Town",
+              "types": [
+                {
+                  "code": "A99",
+                  "description": "Chocolate Factory"
+                },
+                {
+                  "code": "B99",
+                  "description": "Glass Elevator"
+                }
+              ],
+              "notes": "some interesting note"
+            }
+          ]
+        }
+        """.removeWhitespaceAndNewlines(),
+        )
+      }
+
+      it("logs audit") {
+        mockMvc.performAuthorised("$basePath/$encodedHmppsId/addresses")
+        verify(auditService, VerificationModeFactory.times(1)).createEvent("GET_PERSON_ADDRESS", "Person address details with hmpps id: $hmppsId has been retrieved")
+      }
+
+      it("returns a 404 NOT FOUND status code when person isn't found in all upstream APIs") {
+        whenever(getAddressesForPersonService.execute(hmppsId)).thenReturn(
+          Response(
+            data = emptyList(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+              UpstreamApiError(
+                causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+          ),
+        )
+
+        val result = mockMvc.performAuthorised("$basePath/$encodedHmppsId/addresses")
+
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
+
+      it("returns a 200 OK status code when person is found in one upstream API but not another") {
+        whenever(getAddressesForPersonService.execute(hmppsId)).thenReturn(
+          Response(
+            data = emptyList(),
+            errors = listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+          ),
+        )
+
+        val result = mockMvc.performAuthorised("$basePath/$encodedHmppsId/addresses")
+
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/AddressSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/AddressSmokeTest.kt
@@ -1,0 +1,78 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke.person
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIHttpClient
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+class AddressSmokeTest : DescribeSpec(
+
+  {
+    val hmppsId = "2003/13116M"
+    val encodedHmppsId = URLEncoder.encode(hmppsId, StandardCharsets.UTF_8)
+    val basePath = "v1/persons"
+    val httpClient = IntegrationAPIHttpClient()
+
+    it("returns addresses for a person") {
+      val response = httpClient.performAuthorised("$basePath/$encodedHmppsId/addresses")
+
+      response.statusCode().shouldBe(HttpStatus.OK.value())
+      response.body().shouldEqualJson(
+        """
+      {
+        "data": [
+          {
+            "country": "ENG",
+            "county": "HEREFORD",
+            "endDate": "2021-02-12",
+            "locality": "Brincliffe",
+            "name": "Liverpool Prison",
+            "noFixedAddress": false,
+            "number": "3B",
+            "postcode": "LI1 5TH",
+            "startDate": "2005-05-12",
+            "street": "Slinn Street",
+            "town": "Liverpool",
+            "types": [
+              {
+                "code": "HDC",
+                "description": "HDC Address"
+              },
+              {
+                "code": "BUS",
+                "description": "Business Address"
+              }
+            ],
+            "notes": "This is a comment text"
+          },
+          {
+            "country": null,
+            "county": "string",
+            "endDate": "2019-08-24",
+            "locality": "string",
+            "name": "string",
+            "noFixedAddress": true,
+            "number": "string",
+            "postcode": "string",
+            "startDate": "2019-08-24",
+            "street": "string",
+            "town": "string",
+            "types": [
+              {
+                "code": "string",
+                "description": "string"
+              }
+            ],
+            "notes": "string"
+          }
+        ]
+      }
+      """.removeWhitespaceAndNewlines(),
+      )
+    }
+  },
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
@@ -13,9 +13,7 @@ class OffencesSmokeTest : DescribeSpec(
   {
     val hmppsId = "2004/13116M"
     val encodedHmppsId = URLEncoder.encode(hmppsId, StandardCharsets.UTF_8)
-
     val basePath = "v1/persons/$encodedHmppsId/offences"
-
     val httpClient = IntegrationAPIHttpClient()
 
     it("returns offences for a person") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke.person
 
-import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -14,7 +13,6 @@ class PersonSmokeTest : DescribeSpec(
   {
     val basePath = "v1/persons"
     val httpClient = IntegrationAPIHttpClient()
-
     val hmppsId = "2004/13116M"
     val encodedHmppsId = URLEncoder.encode(hmppsId, StandardCharsets.UTF_8)
 
@@ -88,64 +86,6 @@ class PersonSmokeTest : DescribeSpec(
             "view":"OIC",
             "orientation":"NECK",
             "type":"OFF_IDM"
-      """.removeWhitespaceAndNewlines(),
-      )
-    }
-
-    it("returns addresses for a person") {
-      val response = httpClient.performAuthorised("$basePath/$encodedHmppsId/addresses")
-
-      response.statusCode().shouldBe(HttpStatus.OK.value())
-      response.body().shouldEqualJson(
-        """
-      {
-        "data": [
-          {
-            "country": "ENG",
-            "county": "HEREFORD",
-            "endDate": "2021-02-12",
-            "locality": "Brincliffe",
-            "name": "Liverpool Prison",
-            "noFixedAddress": false,
-            "number": "3B",
-            "postcode": "LI1 5TH",
-            "startDate": "2005-05-12",
-            "street": "Slinn Street",
-            "town": "Liverpool",
-            "types": [
-              {
-                "code": "HDC",
-                "description": "HDC Address"
-              },
-              {
-                "code": "BUS",
-                "description": "Business Address"
-              }
-            ],
-            "notes": "This is a comment text"
-          },
-          {
-            "country": null,
-            "county": "string",
-            "endDate": "2019-08-24",
-            "locality": "string",
-            "name": "string",
-            "noFixedAddress": true,
-            "number": "string",
-            "postcode": "string",
-            "startDate": "2019-08-24",
-            "street": "string",
-            "town": "string",
-            "types": [
-              {
-                "code": "string",
-                "description": "string"
-              }
-            ],
-            "notes": "string"
-          }
-        ]
-      }
       """.removeWhitespaceAndNewlines(),
       )
     }


### PR DESCRIPTION
We separated the controllers related to offences from the PersonController into a new OffencesController. This keeps our controllers smaller. We now have the same for Addresses related endpoints.