### PR TITLE
Hia 623 person search by pnc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -32,19 +32,20 @@ class PersonController(
 
   @GetMapping
   fun getPersons(
+    @RequestParam(required = false, name = "pnc_number") pncNumber: String?,
     @RequestParam(required = false, name = "first_name") firstName: String?,
     @RequestParam(required = false, name = "last_name") lastName: String?,
     @RequestParam(required = false, defaultValue = "false", name = "search_within_aliases") searchWithinAliases: Boolean,
     @RequestParam(required = false, defaultValue = "1", name = "page") page: Int,
     @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
   ): PaginatedResponse<Person?> {
-    if (firstName == null && lastName == null) {
+    if (firstName == null && lastName == null && pncNumber == null) {
       throw ValidationException("No query parameters specified.")
     }
 
-    val response = getPersonsService.execute(firstName, lastName, searchWithinAliases)
+    val response = getPersonsService.execute(firstName, lastName, pncNumber, searchWithinAliases)
 
-    auditService.createEvent("SEARCH_PERSON", "Person searched with first name: $firstName, last name: $lastName and search within aliases: $searchWithinAliases")
+    auditService.createEvent("SEARCH_PERSON", "Person searched with first name: $firstName, last name: $lastName, search within aliases: $searchWithinAliases, pnc number: $pncNumber")
     return response.data.paginateWith(page, perPage)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -63,8 +63,8 @@ class ProbationOffenderSearchGateway(@Value("\${services.probation-offender-sear
     }
   }
 
-  fun getPersons(firstName: String?, surname: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
-    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "includeAliases" to searchWithinAliases)
+  fun getPersons(firstName: String?, surname: String?, pncNumber: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
+    val requestBody = mapOf("firstName" to firstName, "surname" to surname, "pncNumber" to pncNumber, "includeAliases" to searchWithinAliases)
       .filterValues { it != null }
 
     val result = webClient.requestList<Offender>(HttpMethod.POST, "/search", authenticationHeader(), UpstreamApi.PROBATION_OFFENDER_SEARCH, requestBody)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
@@ -13,10 +13,16 @@ class GetPersonsService(
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
 ) {
 
-  fun execute(firstName: String?, lastName: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
-    val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = searchWithinAliases)
-    val personsFromProbationOffenderSearch = probationOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = searchWithinAliases)
+  fun execute(firstName: String?, lastName: String?, pncNumber: String?, searchWithinAliases: Boolean = false): Response<List<Person>> {
+    var hmppsId: String? = null
 
+    val personsFromProbationOffenderSearch = probationOffenderSearchGateway.getPersons(firstName, lastName, pncNumber, searchWithinAliases)
+
+    if (pncNumber != null) {
+      hmppsId = personsFromProbationOffenderSearch.data.firstOrNull()?.identifiers?.deliusCrn
+    }
+
+    val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(firstName, lastName, hmppsId, searchWithinAliases)
     return Response(data = responseFromPrisonerOffenderSearch.data + personsFromProbationOffenderSearch.data)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -43,6 +43,7 @@ internal class PersonControllerTest(
 ) : DescribeSpec(
   {
     val hmppsId = "2003/13116M"
+    val pncNumber = "2003/13116M"
     val encodedHmppsId = URLEncoder.encode(hmppsId, StandardCharsets.UTF_8)
     val basePath = "/v1/persons"
     val firstName = "Barry"
@@ -53,7 +54,7 @@ internal class PersonControllerTest(
       beforeTest {
         Mockito.reset(getPersonsService)
         Mockito.reset(auditService)
-        whenever(getPersonsService.execute(firstName, lastName)).thenReturn(
+        whenever(getPersonsService.execute(firstName, lastName, null)).thenReturn(
           Response(
             data =
             listOf(
@@ -75,33 +76,39 @@ internal class PersonControllerTest(
       }
 
       it("gets a person with matching search criteria") {
-        mockMvc.performAuthorised("$basePath?first_name=$firstName&last_name=$lastName")
+        mockMvc.performAuthorised("$basePath?first_name=$firstName&last_name=$lastName&pnc_number=$pncNumber")
 
-        verify(getPersonsService, times(1)).execute(firstName, lastName)
+        verify(getPersonsService, times(1)).execute(firstName, lastName, pncNumber)
       }
 
       it("gets a person with matching first name") {
         mockMvc.performAuthorised("$basePath?first_name=$firstName")
 
-        verify(getPersonsService, times(1)).execute(firstName, null)
+        verify(getPersonsService, times(1)).execute(firstName, null, null)
       }
 
       it("gets a person with matching last name") {
         mockMvc.performAuthorised("$basePath?last_name=$lastName")
 
-        verify(getPersonsService, times(1)).execute(null, lastName)
+        verify(getPersonsService, times(1)).execute(null, lastName, null)
       }
 
       it("gets a person with matching alias") {
         mockMvc.performAuthorised("$basePath?first_name=$firstName&search_within_aliases=true")
 
-        verify(getPersonsService, times(1)).execute(firstName, null, searchWithinAliases = true)
+        verify(getPersonsService, times(1)).execute(firstName, null, null, searchWithinAliases = true)
+      }
+
+      it("gets a person with matching pncNumber") {
+        mockMvc.performAuthorised("$basePath?pnc_number=$pncNumber")
+
+        verify(getPersonsService, times(1)).execute(null, null, pncNumber)
       }
 
       it("defaults to not searching within aliases") {
         mockMvc.performAuthorised("$basePath?first_name=$firstName")
 
-        verify(getPersonsService, times(1)).execute(firstName, null, searchWithinAliases = false)
+        verify(getPersonsService, times(1)).execute(firstName, null, null)
       }
 
       it("returns a person with matching first and last name") {
@@ -147,12 +154,12 @@ internal class PersonControllerTest(
       }
 
       it("logs audit") {
-        mockMvc.performAuthorised("$basePath?first_name=$firstName&last_name=$lastName")
-        verify(auditService, times(1)).createEvent("SEARCH_PERSON", "Person searched with first name: $firstName, last name: $lastName and search within aliases: false")
+        mockMvc.performAuthorised("$basePath?first_name=$firstName&last_name=$lastName&pnc_number=$pncNumber")
+        verify(auditService, times(1)).createEvent("SEARCH_PERSON", "Person searched with first name: $firstName, last name: $lastName, search within aliases: false, pnc number: $pncNumber")
       }
 
       it("returns paginated results") {
-        whenever(getPersonsService.execute(firstName, lastName)).thenReturn(
+        whenever(getPersonsService.execute(firstName, lastName, null)).thenReturn(
           Response(
             data =
             List(20) { i ->
@@ -175,7 +182,7 @@ internal class PersonControllerTest(
         val firstNameThatDoesNotExist = "Bob21345"
         val lastNameThatDoesNotExist = "Gun36773"
 
-        whenever(getPersonsService.execute(firstNameThatDoesNotExist, lastNameThatDoesNotExist)).thenReturn(
+        whenever(getPersonsService.execute(firstNameThatDoesNotExist, lastNameThatDoesNotExist, null)).thenReturn(
           Response(
             data = emptyList(),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -44,7 +44,7 @@ class PrisonerOffenderSearchGatewayTest(
   describe("#getPersons") {
     val firstName = "JAMES"
     val lastName = "HOWLETT"
-    val hmppsId = "2003/13116A"
+    val hmppsId = "B9731BB"
 
     beforeEach {
       prisonerOffenderSearchApiMockServer.stubPostPrisonerSearch(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
@@ -25,61 +25,62 @@ internal class GetPersonsServiceTest(
 ) : DescribeSpec({
   val firstName = "Bruce"
   val lastName = "Wayne"
+  val pncNumber = "2003/13116M"
 
   beforeEach {
     Mockito.reset(prisonerOffenderSearchGateway)
     Mockito.reset(probationOffenderSearchGateway)
 
-    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(Response(data = emptyList()))
-    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(Response(data = emptyList()))
+    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, null)).thenReturn(Response(data = emptyList()))
+    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, null, false)).thenReturn(Response(data = emptyList()))
   }
 
   it("gets person(s) from Prisoner Offender Search") {
-    getPersonsService.execute(firstName, lastName)
+    getPersonsService.execute(firstName, lastName, null)
 
     verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName)
   }
 
   it("gets person(s) from Probation Offender Search") {
-    getPersonsService.execute(firstName, lastName)
+    getPersonsService.execute(firstName, lastName, null)
 
-    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName)
+    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, null)
   }
 
   it("defaults to not searching within aliases") {
-    getPersonsService.execute(firstName, lastName)
+    getPersonsService.execute(firstName, lastName, null)
 
-    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = false)
-    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = false)
+    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, null, searchWithinAliases = false)
+    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName, null, searchWithinAliases = false)
   }
 
   it("allows searching within aliases") {
-    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = true)).thenReturn(Response(data = emptyList()))
-    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, searchWithinAliases = true)).thenReturn(Response(data = emptyList()))
+    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, null, searchWithinAliases = true)).thenReturn(Response(data = emptyList()))
+    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, null, searchWithinAliases = true)).thenReturn(Response(data = emptyList()))
 
-    getPersonsService.execute(firstName, lastName, searchWithinAliases = true)
+    getPersonsService.execute(firstName, lastName, null, true)
 
-    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = true)
-    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, searchWithinAliases = true)
+    verify(probationOffenderSearchGateway, times(1)).getPersons(firstName, lastName, null, true)
+    verify(prisonerOffenderSearchGateway, times(1)).getPersons(firstName, lastName, null, searchWithinAliases = true)
   }
 
   it("returns person(s)") {
-    val responseFromPrisonerOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "Gary")))
     val responseFromProbationOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "John")))
+    val responseFromPrisonerOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "Gary")))
 
-    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(responseFromPrisonerOffenderSearch)
-    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(responseFromProbationOffenderSearch)
+    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, pncNumber)).thenReturn(responseFromProbationOffenderSearch)
+    whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, null)).thenReturn(responseFromPrisonerOffenderSearch)
 
-    val response = getPersonsService.execute(firstName, lastName)
+    val response = getPersonsService.execute(firstName, lastName, pncNumber)
 
     response.data.shouldBe(responseFromPrisonerOffenderSearch.data + responseFromProbationOffenderSearch.data)
   }
 
   it("returns an empty list when no person(s) are found") {
+    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, null)).thenReturn(Response(emptyList()))
     whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(Response(emptyList()))
-    whenever(probationOffenderSearchGateway.getPersons(firstName, lastName)).thenReturn(Response(emptyList()))
 
-    val response = getPersonsService.execute(firstName, lastName)
+    val response = getPersonsService.execute(firstName, lastName, null)
 
     response.data.shouldBe(emptyList())
   }


### PR DESCRIPTION
## Context

This PR is for adding PNC search functionality to our initial entry persons endpoint. This endpoint uses Prisoner and Probation Offender search to return persons information. Complexity is around the Prisoner endpoint which cannot be queried using PNC number only Probation offender search can be queried with PNC.

As a result we take the response from Probation offender search and use the CRN provided to query the Prisoner search.

## Changes proposed in this PR
- Added PNC search functionality to our persons endpoint