### PR TITLE
Hia 563 add a domain field to offences and sentences

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1194,11 +1194,16 @@ components:
     Sentence:
       type: object
       properties:
-        dataSource:
+        serviceSource:
           type: string
           enum: [NOMIS, NDELIUS]
           example: NOMIS
-          description: Which upstream API the sentence originates from
+          description: Which upstream API service the sentence originates from
+        systemSource:
+          type: string
+          enum: [ PRISON_SYSTEMS, PROBATION_SYSTEMS ]
+          example: PROBATION_SYSTEMS
+          description: Which upstream API system the sentence originates from
         dateOfSentencing:
           type: string
           format: date

--- a/openapi.yml
+++ b/openapi.yml
@@ -994,6 +994,16 @@ components:
     Offence:
       type: object
       properties:
+        serviceSource:
+          type: string
+          enum: [ NOMIS, NDELIUS ]
+          example: NOMIS
+          description: Which upstream API service the sentence originates from
+        systemSource:
+          type: string
+          enum: [ PRISON_SYSTEMS, PROBATION_SYSTEMS ]
+          example: PROBATION_SYSTEMS
+          description: Which upstream API system the sentence originates from
         cjsCode:
           type: string
           example: RR84170

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Offence.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 import java.time.LocalDate
 
 data class Offence(
+  val serviceSource: UpstreamApi,
+  val systemSource: SystemSource,
   val cjsCode: String? = null,
   val hoCode: String? = null,
   val courtDates: List<LocalDate?> = listOf(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Sentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Sentence.kt
@@ -3,7 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 import java.time.LocalDate
 
 data class Sentence(
-  val dataSource: UpstreamApi,
+  val serviceSource: UpstreamApi,
+  val systemSource: SystemSource,
   val dateOfSentencing: LocalDate? = null,
   val description: String? = null,
   val isActive: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/SystemSource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/SystemSource.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
+
+enum class SystemSource {
+  PRISON_SYSTEMS, PROBATION_SYSTEMS,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/NDeliusAdditionalOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/NDeliusAdditionalOffence.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 
 data class NDeliusAdditionalOffence(
@@ -9,6 +11,8 @@ data class NDeliusAdditionalOffence(
   val date: String? = null,
 ) {
   fun toOffence(courtDates: List<LocalDate>): Offence = Offence(
+    serviceSource = UpstreamApi.NDELIUS,
+    systemSource = SystemSource.PROBATION_SYSTEMS,
     cjsCode = null,
     hoCode = this.code,
     courtDates = courtDates,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/NDeliusMainOffence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/NDeliusMainOffence.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 
 data class NDeliusMainOffence(
@@ -9,6 +11,8 @@ data class NDeliusMainOffence(
   val date: String? = null,
 ) {
   fun toOffence(courtDates: List<LocalDate>): Offence = Offence(
+    serviceSource = UpstreamApi.NDELIUS,
+    systemSource = SystemSource.PROBATION_SYSTEMS,
     cjsCode = null,
     hoCode = this.code,
     courtDates = courtDates,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/NDeliusSupervision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/NDeliusSupervision.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -21,7 +22,8 @@ data class NDeliusSupervision(
 
   fun toSentence(): Sentence {
     return Sentence(
-      dataSource = UpstreamApi.NDELIUS,
+      serviceSource = UpstreamApi.NDELIUS,
+      systemSource = SystemSource.PROBATION_SYSTEMS,
       dateOfSentencing = if (!this.sentence.date.isNullOrEmpty()) LocalDate.parse(this.sentence.date) else null,
       description = this.sentence.description,
       fineAmount = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/NomisOffenceHistoryDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/NomisOffenceHistoryDetail.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 
 data class NomisOffenceHistoryDetail(
@@ -12,6 +14,8 @@ data class NomisOffenceHistoryDetail(
   val statuteCode: String,
 ) {
   fun toOffence(): Offence = Offence(
+    serviceSource = UpstreamApi.NOMIS,
+    systemSource = SystemSource.PRISON_SYSTEMS,
     cjsCode = this.offenceCode,
     courtDates = listOf(this.courtDate).filterNotNull(),
     description = this.offenceDescription,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/NomisSentence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/NomisSentence.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.nomis
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 
@@ -13,7 +14,8 @@ data class NomisSentence(
   val terms: List<NomisTerm> = listOf(NomisTerm()),
 ) {
   fun toSentence(): Sentence = Sentence(
-    dataSource = UpstreamApi.NOMIS,
+    serviceSource = UpstreamApi.NOMIS,
+    systemSource = SystemSource.PRISON_SYSTEMS,
     dateOfSentencing = this.sentenceDate,
     description = this.sentenceTypeDescription,
     fineAmount = this.fineAmount,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -16,7 +16,11 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetOffencesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 import java.net.URLEncoder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -16,10 +16,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.*
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetOffencesForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 import java.net.URLEncoder
@@ -47,6 +44,8 @@ internal class OffencesControllerTest(
           Response(
             data = listOf(
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 cjsCode = "RR99999",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2023-03-03")),
@@ -79,6 +78,8 @@ internal class OffencesControllerTest(
           """
           "data": [
             {
+              "serviceSource": "NDELIUS",
+              "systemSource": "PROBATION_SYSTEMS",
               "cjsCode": "RR99999",
               "hoCode": "05800",
               "courtDates": ["2023-03-03"],
@@ -138,6 +139,8 @@ internal class OffencesControllerTest(
             data =
             List(20) {
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 cjsCode = "RR99999",
                 courtDates = listOf(LocalDate.parse("2023-03-03")),
                 description = "This is a description of an offence.",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/SentencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/SentencesControllerTest.kt
@@ -72,69 +72,71 @@ internal class SentencesControllerTest(
 
       result.response.contentAsString.shouldContain(
         """
-          [
-            {
-              "dataSource": "NOMIS",
-              "dateOfSentencing": null,
-              "description": "Some description 1",
-              "isActive": true,
-              "isCustodial": true,
-              "fineAmount": null,
-              "length": {
+        [
+          {
+            "serviceSource": "NOMIS",
+            "systemSource": "PRISON_SYSTEMS",
+            "dateOfSentencing": null,
+            "description": "Some description 1",
+            "isActive": true,
+            "isCustodial": true,
+            "fineAmount": null,
+            "length": {
                 "duration": null,
                 "units": null,
                 "terms": [
-                  {
-                    "years": null,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": 2,
-                    "prisonTermCode": null
-                  },
-                  {
-                    "years": 25,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": null,
-                    "prisonTermCode": null
-                  }
+                    {
+                      "years": null,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": 2,
+                      "prisonTermCode": null
+                    },
+                    {
+                      "years": 25,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": null,
+                      "prisonTermCode": null
+                    }
                 ]
-              }
-            },
-            {
-              "dataSource": "NOMIS",
-              "dateOfSentencing": null,
-              "description": "Some description 2",
-              "isActive": true,
-              "isCustodial": true,
-              "fineAmount": null,
-              "length": {
-                "duration": null,
-                "units": null,
-                "terms": [
-                  {
-                    "years": null,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": 2,
-                    "prisonTermCode": null
-                  },
-                  {
-                    "years": 25,
-                    "months": null,
-                    "weeks": null,
-                    "days": null,
-                    "hours": null,
-                    "prisonTermCode": null
-                  }
-                ]
-              }
             }
-          ]
-          """.removeWhitespaceAndNewlines(),
+          },
+          {
+            "serviceSource": "NOMIS",
+            "systemSource": "PRISON_SYSTEMS",
+            "dateOfSentencing": null,
+            "description": "Some description 2",
+            "isActive": true,
+            "isCustodial": true,
+            "fineAmount": null,
+            "length": {
+                "duration": null,
+                "units": null,
+                "terms": [
+                    {
+                      "years": null,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": 2,
+                      "prisonTermCode": null
+                    },
+                    {
+                      "years": 25,
+                      "months": null,
+                      "weeks": null,
+                      "days": null,
+                      "hours": null,
+                      "prisonTermCode": null
+                    }
+                 ]
+             }
+          }
+        ]
+        """.removeWhitespaceAndNewlines(),
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ndelius/GetSentencesForPersonTest.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSent
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.NDeliusApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import java.io.File
@@ -65,7 +66,8 @@ class GetSentencesForPersonTest(
         response.data.shouldBe(
           listOf(
             generateTestSentence(
-              dataSource = UpstreamApi.NDELIUS,
+              serviceSource = UpstreamApi.NDELIUS,
+              systemSource = SystemSource.PROBATION_SYSTEMS,
               dateOfSentencing = LocalDate.parse("2009-07-07"),
               description = "CJA - Community Order",
               isActive = false,
@@ -77,7 +79,8 @@ class GetSentencesForPersonTest(
               ),
             ),
             generateTestSentence(
-              dataSource = UpstreamApi.NDELIUS,
+              serviceSource = UpstreamApi.NDELIUS,
+              systemSource = SystemSource.PROBATION_SYSTEMS,
               dateOfSentencing = LocalDate.parse("2009-09-01"),
               description = "CJA - Suspended Sentence Order",
               isActive = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/OffenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/OffenceHelper.kt
@@ -1,9 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 
 fun generateTestOffence(
+  serviceSource: UpstreamApi = UpstreamApi.NDELIUS,
+  systemSource: SystemSource = SystemSource.PROBATION_SYSTEMS,
   cjsCode: String? = "RR12345",
   hoCode: String? = "05800",
   description: String? = "Some description",
@@ -12,6 +16,8 @@ fun generateTestOffence(
   courtDates: List<LocalDate?> = listOf(LocalDate.parse("2020-04-03")),
   statuteCode: String? = "RR12",
 ): Offence = Offence(
+  serviceSource = serviceSource,
+  systemSource = systemSource,
   cjsCode = cjsCode,
   hoCode = hoCode,
   description = description,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
@@ -1,11 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
-
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceTerm
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import java.time.LocalDate
 
 fun generateTestSentence(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/SentenceHelper.kt
@@ -1,13 +1,16 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
+
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceTerm
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import java.time.LocalDate
 
 fun generateTestSentence(
-  dataSource: UpstreamApi = UpstreamApi.NOMIS,
+  serviceSource: UpstreamApi = UpstreamApi.NOMIS,
+  systemSource: SystemSource = SystemSource.PRISON_SYSTEMS,
   dateOfSentencing: LocalDate? = null,
   description: String? = "Some description",
   fineAmount: Number? = null,
@@ -22,7 +25,8 @@ fun generateTestSentence(
     ),
   ),
 ): Sentence = Sentence(
-  dataSource = dataSource,
+  serviceSource = serviceSource,
+  systemSource = systemSource,
   dateOfSentencing = dateOfSentencing,
   description = description,
   fineAmount = fineAmount,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -37,24 +37,32 @@ class SupervisionsTest : DescribeSpec(
           integrationApiOffences.shouldBe(
             listOf(
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "foobar",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
                 startDate = LocalDate.parse("2000-01-02"),
               ),
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "additionalFoo",
                 hoCode = "12345",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
                 startDate = LocalDate.parse("2001-01-01"),
               ),
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "barbaz",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2010-07-07")),
                 startDate = LocalDate.parse("2003-03-03"),
               ),
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "additionalFoo2",
                 hoCode = "98765",
                 courtDates = listOf(LocalDate.parse("2010-07-07")),
@@ -80,12 +88,16 @@ class SupervisionsTest : DescribeSpec(
           integrationApiOffences.shouldBe(
             listOf(
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "foobar",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
                 startDate = LocalDate.parse("2000-01-02"),
               ),
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "additionalFoo",
                 hoCode = "12345",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
@@ -112,12 +124,16 @@ class SupervisionsTest : DescribeSpec(
           integrationApiOffences.shouldBe(
             listOf(
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "foobar",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
                 startDate = LocalDate.parse("2000-01-02"),
               ),
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "additionalFoo",
                 hoCode = "12345",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
@@ -152,12 +168,16 @@ class SupervisionsTest : DescribeSpec(
           integrationApiOffences.shouldBe(
             listOf(
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "foobar",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2009-07-07")),
                 startDate = LocalDate.parse("2019-09-09"),
               ),
               Offence(
+                serviceSource = UpstreamApi.NDELIUS,
+                systemSource = SystemSource.PROBATION_SYSTEMS,
                 description = "barbaz",
                 hoCode = "05800",
                 courtDates = listOf(LocalDate.parse("2010-07-07")),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -6,7 +6,9 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.generateTestSent
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Offence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+
 import java.time.LocalDate
 
 class SupervisionsTest : DescribeSpec(
@@ -199,7 +201,8 @@ class SupervisionsTest : DescribeSpec(
         integrationApiSentences.shouldBe(
           listOf(
             generateTestSentence(
-              dataSource = UpstreamApi.NDELIUS,
+              serviceSource = UpstreamApi.NDELIUS,
+              systemSource = SystemSource.PROBATION_SYSTEMS,
               dateOfSentencing = LocalDate.parse("2009-07-07"),
               description = "CJA - Community Order",
               length = SentenceLength(
@@ -209,7 +212,8 @@ class SupervisionsTest : DescribeSpec(
               ),
             ),
             generateTestSentence(
-              dataSource = UpstreamApi.NDELIUS,
+              serviceSource = UpstreamApi.NDELIUS,
+              systemSource = SystemSource.PROBATION_SYSTEMS,
               dateOfSentencing = LocalDate.parse("2010-07-07"),
               isActive = false,
               description = "CJA - Suspended Sentence Order",
@@ -232,7 +236,8 @@ class SupervisionsTest : DescribeSpec(
 
         supervisions.supervisions.first().toSentence().shouldBe(
           Sentence(
-            dataSource = UpstreamApi.NDELIUS,
+            serviceSource = UpstreamApi.NDELIUS,
+            systemSource = SystemSource.PROBATION_SYSTEMS,
             isActive = null,
             isCustodial = true,
             description = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/ndelius/SupervisionsTest.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
-
 import java.time.LocalDate
 
 class SupervisionsTest : DescribeSpec(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceTerm
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
 import java.time.LocalDate
 
 class PersonSentencesTest : DescribeSpec(
@@ -169,10 +170,11 @@ class PersonSentencesTest : DescribeSpec(
       }
 
       it("deals with NULL values") {
-        val integrationApiSentence = Sentence(isCustodial = true, dataSource = UpstreamApi.NOMIS)
+        val integrationApiSentence = Sentence(isCustodial = true, serviceSource = UpstreamApi.NOMIS, systemSource = SystemSource.PRISON_SYSTEMS)
         integrationApiSentence.shouldBe(
           Sentence(
-            dataSource = UpstreamApi.NOMIS,
+            serviceSource = UpstreamApi.NOMIS,
+            systemSource = SystemSource.PRISON_SYSTEMS,
             dateOfSentencing = null,
             description = null,
             isActive = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/nomis/PersonSentencesTest.kt
@@ -5,8 +5,8 @@ import io.kotest.matchers.shouldBe
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Sentence
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceLength
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SentenceTerm
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.SystemSource
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import java.time.LocalDate
 
 class PersonSentencesTest : DescribeSpec(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/OffencesSmokeTest.kt
@@ -24,40 +24,46 @@ class OffencesSmokeTest : DescribeSpec(
         """
         {
           "data": [
-          {
-            "cjsCode": "RR84070",
-            "hoCode": null,
-            "courtDates": [
-              "2018-02-10"
-            ],
-            "description": "Commit an act / series of acts with intent to pervert the course of public justice",
-            "endDate": "2018-03-10",
-            "startDate": "2018-02-10",
-            "statuteCode": "RR84"
-          },
-          {
-            "cjsCode": null,
-            "hoCode": "string",
-            "courtDates": [
-              "2019-08-24"
-            ],
-            "description": "string",
-            "endDate": null,
-            "startDate": "2019-08-24",
-            "statuteCode": null
-          },
-          {
-            "cjsCode": null,
-            "hoCode": "string",
-            "courtDates": [
-              "2019-08-24"
-            ],
-            "description": "string",
-            "endDate": null,
-            "startDate": "2019-08-24",
-            "statuteCode": null
-          }
-        ],
+            {
+              "serviceSource": "NOMIS",
+              "systemSource": "PRISON_SYSTEMS",
+              "cjsCode": "RR84070",
+              "hoCode": null,
+              "courtDates": [
+                "2018-02-10"
+              ],
+              "description": "Commit an act / series of acts with intent to pervert the course of public justice",
+              "endDate": "2018-03-10",
+              "startDate": "2018-02-10",
+              "statuteCode": "RR84"
+            },
+            {
+              "serviceSource": "NDELIUS",
+              "systemSource": "PROBATION_SYSTEMS",
+              "cjsCode": null,
+              "hoCode": "string",
+              "courtDates": [
+                "2019-08-24"
+              ],
+              "description": "string",
+              "endDate": null,
+              "startDate": "2019-08-24",
+              "statuteCode": null
+            },
+            {
+              "serviceSource": "NDELIUS",
+              "systemSource": "PROBATION_SYSTEMS",
+              "cjsCode": null,
+              "hoCode": "string",
+              "courtDates": [
+                "2019-08-24"
+              ],
+              "description": "string",
+              "endDate": null,
+              "startDate": "2019-08-24",
+              "statuteCode": null
+            }
+         ],
         "pagination": {
           "isLastPage": true,
           "count": 3,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/SentencesSmokeTest.kt
@@ -29,42 +29,44 @@ class SentencesSmokeTest : DescribeSpec(
         """
         {
           "data": [
-            {
-              "dataSource": "NOMIS",
-              "dateOfSentencing": "2019-08-24",
-              "description": "string",
-              "fineAmount": $fineAmountMinNumberValue,
-              "isActive": null,
-              "isCustodial": true,
-              "length": {
-                "duration": null,
-                "units": null,
-                "terms": [
-                  {
-                    "years": 1,
-                    "months": 2,
-                    "weeks": 3,
-                    "days": 4,
-                    "hours": null,
-                    "prisonTermCode": "string"
-                  }
-                ]
+              {
+                "serviceSource": "NOMIS",
+                "systemSource": "PRISON_SYSTEMS",
+                "dateOfSentencing": "2019-08-24",
+                "description": "string",
+                "isActive": null,
+                "isCustodial": true,
+                "fineAmount": -1.7976931348623157E308,
+                "length": {
+                  "duration": null,
+                  "units": null,
+                  "terms": [
+                    {
+                      "years": 1,
+                      "months": 2,
+                      "weeks": 3,
+                      "days": 4,
+                      "hours": null,
+                      "prisonTermCode": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "serviceSource": "NDELIUS",
+                "systemSource": "PROBATION_SYSTEMS",
+                "dateOfSentencing": "2019-08-24",
+                "description": "string",
+                "isActive": true,
+                "isCustodial": false,
+                "fineAmount": null,
+                "length": {
+                  "duration": -2147483648,
+                  "units": "Hours",
+                  "terms": []
+                }
               }
-            },
-            {
-              "dataSource": "NDELIUS",
-              "dateOfSentencing": "2019-08-24",
-              "description": "string",
-              "fineAmount": null,
-              "isActive": true,
-              "isCustodial": false,
-              "length": {
-                "duration": $hourMinIntValue,
-                "units": "Hours",
-                "terms": []
-              }
-            }
-          ],
+            ],
           "pagination": {
             "isLastPage": true,
             "count": 2,


### PR DESCRIPTION
## Context

This PR is for adding a SystemSource field to sentences and offences to make it clearer where the data originated from. This is necessary due to the complex nature of building our sentences and offences response. There is value to the data in stating where its originated from. E.g a Nomis sentence isn't the same as an NDelius sentence

[HIA-563](https://dsdmoj.atlassian.net/jira/software/c/projects/HIA/boards/1056?selectedIssue=HIA-563)

## Changes proposed in this PR
- Added SystemSource field to Sentences and Offences
- Rename DataSource field to ServiceSource


[HIA-563]: https://dsdmoj.atlassian.net/browse/HIA-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ