### PR TITLE
Hia 623-B person search by pnc fix

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
@@ -19,7 +19,7 @@ class GetPersonsService(
     val personsFromProbationOffenderSearch = probationOffenderSearchGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth, searchWithinAliases)
 
     if (!pncNumber.isNullOrEmpty()) {
-      hmppsId = personsFromProbationOffenderSearch.data.firstOrNull()?.identifiers?.deliusCrn
+      hmppsId = personsFromProbationOffenderSearch.data.firstOrNull()?.identifiers?.nomisNumber
     }
 
     val responseFromPrisonerOffenderSearch = prisonerOffenderSearchGateway.getPersons(firstName, lastName, hmppsId, dateOfBirth, searchWithinAliases)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
@@ -68,7 +68,7 @@ internal class GetPersonsServiceTest(
   }
 
   it("allows prisonerOffenderSearchGateway to search with a hmppsId if a pncNumber is passed in") {
-    val responseFromProbationOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "John", identifiers = Identifiers(deliusCrn = "A1234AA"))))
+    val responseFromProbationOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "John", identifiers = Identifiers(nomisNumber = "A1234AA"))))
 
     whenever(probationOffenderSearchGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth)).thenReturn(responseFromProbationOffenderSearch)
     whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, hmppsId, dateOfBirth)).thenReturn(Response(data = emptyList()))


### PR DESCRIPTION
## Context

Currently when a PNC search is carried out we start with probation and get a response where we then extract an ID and use this extracted ID to query PrisonerOffenderSearch. This ID was previously CRN however it makes more sense for this to be a NomisNumber. This is all because we cant directly query PrisonerOffenderSearch with PNC.

## Changes proposed in this PR
- Changed PNC search flow