### PR TITLE
Sorted imageMetaData from new to old

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -120,7 +120,7 @@ paths:
     get:
       tags:
         - persons
-      summary: Returns metadata of images associated with a person.
+      summary: Returns metadata of images associated with a person ordered by date newest to oldest.
       parameters:
         - $ref: "#/components/parameters/HmppsId"
         - $ref: "#/components/parameters/Page"

--- a/openapi.yml
+++ b/openapi.yml
@@ -120,7 +120,7 @@ paths:
     get:
       tags:
         - persons
-      summary: Returns metadata of images associated with a person ordered by date newest to oldest.
+      summary: Returns metadata of images associated with a person ordered by newest to oldest date.
       parameters:
         - $ref: "#/components/parameters/HmppsId"
         - $ref: "#/components/parameters/Page"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NomisGateway.kt
@@ -49,7 +49,7 @@ class NomisGateway(
 
     return when (result) {
       is WebClientWrapperResponse.Success -> {
-        Response(data = result.data.map { it.toImageMetadata() })
+        Response(data = result.data.map { it.toImageMetadata() }.sortedByDescending { it.captureDateTime })
       }
 
       is WebClientWrapperResponse.Error -> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -14,14 +14,10 @@ class GetImageMetadataForPersonService(
 ) {
   fun execute(hmppsId: String): Response<List<ImageMetadata>> {
     val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(hmppsId)
-    val nomisNumber = responseFromProbationOffenderSearch.data?.identifiers?.nomisNumber
-
-    if (nomisNumber == null) {
-      return Response(
-        data = emptyList(),
-        errors = responseFromProbationOffenderSearch.errors,
-      )
-    }
+    val nomisNumber = responseFromProbationOffenderSearch.data?.identifiers?.nomisNumber ?: return Response(
+      data = emptyList(),
+      errors = responseFromProbationOffenderSearch.errors,
+    )
 
     return nomisGateway.getImageMetadataForPerson(nomisNumber)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -14,10 +14,11 @@ class GetImageMetadataForPersonService(
 ) {
   fun execute(hmppsId: String): Response<List<ImageMetadata>> {
     val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(hmppsId)
-    val nomisNumber = responseFromProbationOffenderSearch.data?.identifiers?.nomisNumber ?: return Response(
-      data = emptyList(),
-      errors = responseFromProbationOffenderSearch.errors,
-    )
+    val nomisNumber =
+      responseFromProbationOffenderSearch.data?.identifiers?.nomisNumber ?: return Response(
+        data = emptyList(),
+        errors = responseFromProbationOffenderSearch.errors,
+      )
 
     return nomisGateway.getImageMetadataForPerson(nomisNumber)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetImageMetadataForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetImageMetadataForPersonTest.kt
@@ -92,12 +92,12 @@ class GetImageMetadataForPersonTest(
         response.data[1].type.shouldBe("OFF_BKG")
       }
 
-    it("returns sorted by newest date image metadata for the matching person ID") {
-      val response = nomisGateway.getImageMetadataForPerson(offenderNo)
+      it("returns sorted by newest date image metadata for the matching person ID") {
+        val response = nomisGateway.getImageMetadataForPerson(offenderNo)
 
-      response.data[0].captureDateTime.shouldBe(LocalDateTime.parse("2010-08-27T16:35:00"))
-      response.data[1].captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
-    }
+        response.data[0].captureDateTime.shouldBe(LocalDateTime.parse("2010-08-27T16:35:00"))
+        response.data[1].captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
+      }
 
       it("returns a person without image metadata when no images are found") {
         nomisApiMockServer.stubNomisApiResponse(imagePath, "[]")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetImageMetadataForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetImageMetadataForPersonTest.kt
@@ -47,6 +47,14 @@ class GetImageMetadataForPersonTest(
             "imageView": "FACE",
             "imageOrientation": "FRONT",
             "imageType": "OFF_BKG"
+          },
+          {
+            "imageId": 24299,
+            "active": true,
+            "captureDateTime": "2010-08-27T16:35:00",
+            "imageView": "FACE",
+            "imageOrientation": "FRONT",
+            "imageType": "OFF_BKG"
           }
         ]
       """,
@@ -69,12 +77,27 @@ class GetImageMetadataForPersonTest(
       it("returns image metadata for the matching person ID") {
         val response = nomisGateway.getImageMetadataForPerson(offenderNo)
 
-        response.data.first().active.shouldBe(true)
-        response.data.first().captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
-        response.data.first().view.shouldBe("FACE")
-        response.data.first().orientation.shouldBe("FRONT")
-        response.data.first().type.shouldBe("OFF_BKG")
+        response.data[0].id.shouldBe(24299)
+        response.data[0].active.shouldBe(true)
+        response.data[0].captureDateTime.shouldBe(LocalDateTime.parse("2010-08-27T16:35:00"))
+        response.data[0].view.shouldBe("FACE")
+        response.data[0].orientation.shouldBe("FRONT")
+        response.data[0].type.shouldBe("OFF_BKG")
+
+        response.data[1].id.shouldBe(24213)
+        response.data[1].active.shouldBe(true)
+        response.data[1].captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
+        response.data[1].view.shouldBe("FACE")
+        response.data[1].orientation.shouldBe("FRONT")
+        response.data[1].type.shouldBe("OFF_BKG")
       }
+
+    it("returns sorted by newest date image metadata for the matching person ID") {
+      val response = nomisGateway.getImageMetadataForPerson(offenderNo)
+
+      response.data[0].captureDateTime.shouldBe(LocalDateTime.parse("2010-08-27T16:35:00"))
+      response.data[1].captureDateTime.shouldBe(LocalDateTime.parse("2008-08-27T16:35:00"))
+    }
 
       it("returns a person without image metadata when no images are found") {
         nomisApiMockServer.stubNomisApiResponse(imagePath, "[]")


### PR DESCRIPTION
## Context

- A consumer of our Api wants to display the most recent photo first, descending in chronological order. At the moment when we grab the image metadata from the API they are sorted by date, but this is in descending order with the oldest photo being loaded in first, not the most recent. [HIA-718](https://dsdmoj.atlassian.net/jira/software/c/projects/HIA/boards/1056?selectedIssue=HIA-718)

## Changes proposed in this PR
- Sorted ImageMetaData gateway response so the most recent image is the first item
- Updated tests and docs



[HIA-718]: https://dsdmoj.atlassian.net/browse/HIA-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ