### PR TITLE
Add new PES prisoner endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PESPrisonerDetailController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PESPrisonerDetailController.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonIntegrationpes.PESPrisonerDetails
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPESPrisonerDetailsService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+
+@RestController
+@RequestMapping("/v1/pes/prisoner-details")
+class PESPrisonerDetailController(
+  @Autowired val getPESPersonDetailService: GetPESPrisonerDetailsService,
+  @Autowired val auditService: AuditService,
+) {
+  @GetMapping("{hmppsId}")
+  fun getPerson(
+    @PathVariable hmppsId: String,
+  ): Response<PESPrisonerDetails?> {
+    val response = getPESPersonDetailService.execute(hmppsId)
+
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not retrieve prisoner details for prisoner with id: $hmppsId")
+    }
+
+    auditService.createEvent(
+      "GET_PES_PRISONER_INFORMATION",
+      mapOf("hmppsId" to hmppsId),
+    )
+    return Response(
+      data = response.data,
+      errors = response.errors,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonIntegrationpes/PESPrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonIntegrationpes/PESPrisonerDetails.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonIntegrationpes
+
+data class PESPrisonerDetails(
+  val prisonerNumber: String? = null,
+  val firstName: String,
+  val lastName: String,
+  val prisonId: String? = null,
+  val prisonName: String? = null,
+  val cellLocation: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/POSPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/POSPrisoner.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffender
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Identifiers
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonIntegrationpes.PESPrisonerDetails
 import java.time.LocalDate
 
 data class POSPrisoner(
@@ -17,6 +18,9 @@ data class POSPrisoner(
   val bookingId: String? = null,
   val maritalStatus: String? = null,
   val croNumber: String? = null,
+  val prisonId: String? = null,
+  val prisonName: String? = null,
+  val cellLocation: String? = null,
 ) {
   fun toPerson(): Person =
     Person(
@@ -33,5 +37,15 @@ data class POSPrisoner(
           croNumber = this.croNumber,
         ),
       pncId = this.pncNumber,
+    )
+
+  fun toPESPrisonerDetails(): PESPrisonerDetails =
+    PESPrisonerDetails(
+      prisonerNumber = this.prisonerNumber,
+      firstName = this.firstName,
+      lastName = this.lastName,
+      prisonId = this.prisonId,
+      prisonName = this.prisonName,
+      cellLocation = this.cellLocation,
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPESPrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPESPrisonerDetailsService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonIntegrationpes.PESPrisonerDetails
+
+@Service
+class GetPESPrisonerDetailsService(
+  @Autowired val prisonerSearchGateway: PrisonerOffenderSearchGateway,
+) {
+  fun execute(hmppsId: String): Response<PESPrisonerDetails?> {
+    val prisonResponse = prisonerSearchGateway.getPrisonOffender(hmppsId)
+
+    return Response(
+      data = prisonResponse.data?.toPESPrisonerDetails(),
+      errors = prisonResponse.errors,
+    )
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,6 +50,8 @@ authorisation:
       - "/v1/persons/.*/risk-management-plan"
     ctrlo:
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+    moj.pes:
+      - "/v1/pes/prisoner-details/\\.*+[^/]*$"
     kubernetes-health-check-client:
       - "/health/liveness"
       - "/health/readiness"

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -49,6 +49,7 @@ authorisation:
       - "/v1/persons/.*/person-responsible-officer"
       - "/v1/persons/.*/risk-management-plan"
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+      - "/v1/pes/prisoner-details/\\.*+[^/]*$"
       - "/health"
       - "/health/ping"
       - "/health/readiness"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -56,6 +56,7 @@ authorisation:
       - "/v1/persons/.*/person-responsible-officer"
       - "/v1/persons/.*/risk-management-plan"
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+      - "/v1/pes/prisoner-details/\\.*+[^/]*$"
       - "/health"
       - "/health/ping"
       - "/health/readiness"

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -28,6 +28,8 @@ authorisation:
   consumers:
     ctrlo:
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+    moj.pes:
+      - "/v1/pes/prisoner-details/\\.*+[^/]*$"
     kubernetes-health-check-client:
       - "/health/liveness"
       - "/health/readiness"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,6 +28,8 @@ authorisation:
   consumers:
     ctrlo:
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+    moj.pes:
+      - "/v1/pes/prisoner-details/\\.*+[^/]*$"
     kubernetes-health-check-client:
       - "/health/liveness"
       - "/health/readiness"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -56,6 +56,7 @@ authorisation:
       - "/v1/persons/.*/risks/dynamic"
       - "/v1/persons/.*/reported-adjudications"
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+      - "/v1/pes/prisoner-details/\\.*+[^/]*$"
       - "/v1/persons/.*/adjudications"
       - "/v1/persons/.*/licences/conditions"
       - "/v1/persons/.*/case-notes"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PESPrisonerDetailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/PESPrisonerDetailControllerTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonIntegrationpes.PESPrisonerDetails
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPESPrisonerDetailsService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+
+@WebMvcTest(controllers = [PESPrisonerDetailController::class])
+@ActiveProfiles("test")
+internal class PESPrisonerDetailControllerTest(
+  @Autowired var springMockMvc: MockMvc,
+  @MockBean val getPESPrisonerDetailsService: GetPESPrisonerDetailsService,
+  @MockBean val auditService: AuditService,
+) : DescribeSpec({
+    val hmppsId = "X12345"
+    val path = "/v1/pes/prisoner-details/$hmppsId"
+    val mockMvc = IntegrationAPIMockMvc(springMockMvc)
+
+    describe("GET $path") {
+      beforeTest {
+        Mockito.reset(getPESPrisonerDetailsService)
+        whenever(getPESPrisonerDetailsService.execute(hmppsId)).thenReturn(
+          Response(
+            data = PESPrisonerDetails(prisonerNumber = "ABC123", "Molly", lastName = "Mob", prisonId = "LEI", prisonName = "HMP Leeds", cellLocation = "6-2-006"),
+          ),
+        )
+        Mockito.reset(auditService)
+      }
+
+      it("returns a 200 OK status code") {
+        val result = mockMvc.performAuthorised(path)
+
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+
+      it("gets the prisoner detail for a prisoner with the matching ID") {
+        mockMvc.performAuthorised(path)
+
+        verify(getPESPrisonerDetailsService, VerificationModeFactory.times(1)).execute(hmppsId)
+      }
+
+      it("logs audit") {
+        mockMvc.performAuthorised(path)
+        verify(
+          auditService,
+          VerificationModeFactory.times(1),
+        ).createEvent(
+          "GET_PES_PRISONER_INFORMATION",
+          mapOf("hmppsId" to hmppsId),
+        )
+      }
+
+      it("returns a 500 INTERNAL SERVER ERROR status code when upstream api return expected error") {
+
+        whenever(getPESPrisonerDetailsService.execute(hmppsId)).doThrow(
+          WebClientResponseException(500, "MockError", null, null, null, null),
+        )
+
+        val result = mockMvc.performAuthorised(path)
+        assert(result.response.status == 500)
+        assert(
+          result.response.contentAsString.equals(
+            "{\"status\":500,\"errorCode\":null,\"userMessage\":\"500 MockError\",\"developerMessage\":\"Unable to complete request as an upstream service is not responding\",\"moreInfo\":null}",
+          ),
+        )
+      }
+    }
+  })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisoneroffendersearch/PrisonerTest.kt
@@ -11,6 +11,7 @@ class PrisonerTest : DescribeSpec(
   {
     describe("#toPerson") {
       it("maps one-to-one attributes to person attributes") {
+
         val prisoner =
           POSPrisoner(
             firstName = "First Name",
@@ -41,6 +42,38 @@ class PrisonerTest : DescribeSpec(
         person.identifiers.croNumber.shouldBe(prisoner.croNumber)
         person.identifiers.deliusCrn.shouldBeNull()
         person.pncId.shouldBe(prisoner.pncNumber)
+      }
+    }
+    describe("#toPESPrisonerDetails") {
+      it("maps one-to-one attributes to PESPrisonerDetails attributes") {
+
+        val prisoner =
+          POSPrisoner(
+            firstName = "First Name",
+            lastName = "Last Name",
+            middleNames = "Middle Name",
+            dateOfBirth = LocalDate.parse("2023-03-01"),
+            gender = "Gender",
+            ethnicity = "Ethnicity",
+            prisonerNumber = "prisonerNumber",
+            pncNumber = "pncNumber",
+            croNumber = "croNumber",
+            aliases =
+              listOf(
+                POSPrisonerAlias(firstName = "Alias First Name", lastName = "Alias Last Name"),
+              ),
+            prisonId = "LEI",
+            prisonName = "HMP Leeds",
+            cellLocation = "6-2-006",
+          )
+
+        val pesPrisoner = prisoner.toPESPrisonerDetails()
+        pesPrisoner.prisonerNumber.shouldBe(prisoner.prisonerNumber)
+        pesPrisoner.firstName.shouldBe(prisoner.firstName)
+        pesPrisoner.lastName.shouldBe(prisoner.lastName)
+        pesPrisoner.prisonId.shouldBe(prisoner.prisonId)
+        pesPrisoner.prisonName.shouldBe(prisoner.prisonName)
+        pesPrisoner.cellLocation.shouldBe(prisoner.cellLocation)
       }
     }
   },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPESPrisonerDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPESPrisonerDetailsServiceTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonIntegrationpes.PESPrisonerDetails
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch.POSPrisoner
+
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [GetPESPrisonerDetailsService::class],
+)
+internal class GetPESPrisonerDetailsServiceTest(
+  @MockBean val prisonerSearchGateway: PrisonerOffenderSearchGateway,
+  private val getPESPrisonerDetailsService: GetPESPrisonerDetailsService,
+) : DescribeSpec(
+    {
+      val hmppsId = "X123456"
+      val expectedResult = PESPrisonerDetails(prisonerNumber = "X123456", "Molly", lastName = "Mob", prisonId = "LEI", prisonName = "HMP Leeds", cellLocation = "6-2-006")
+
+      beforeEach {
+        Mockito.reset(prisonerSearchGateway)
+
+        whenever(prisonerSearchGateway.getPrisonOffender(hmppsId)).thenReturn(
+          Response(
+            data = POSPrisoner(prisonerNumber = hmppsId, firstName = "Molly", lastName = "Mob", prisonId = "LEI", prisonName = "HMP Leeds", cellLocation = "6-2-006"),
+          ),
+        )
+      }
+
+      it("Returns a prisoner name record according to the provided HMPPS ID") {
+        val result = getPESPrisonerDetailsService.execute(hmppsId)
+
+        result.shouldBe(Response(data = expectedResult))
+      }
+    },
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/AuthoriseConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/AuthoriseConfigTest.kt
@@ -44,6 +44,7 @@ class AuthoriseConfigTest : DescribeSpec(
           "/v1/persons/.*/person-responsible-officer",
           "/v1/persons/.*/risk-management-plan",
           "/v1/epf/person-details/.*/\\.*+[^/]*${'$'}",
+          "/v1/pes/prisoner-details/.*+[^/]*${'$'}",
           "/health",
           "/health/ping",
           "/health/readiness",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/AuthoriseConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/AuthoriseConfigTest.kt
@@ -44,7 +44,7 @@ class AuthoriseConfigTest : DescribeSpec(
           "/v1/persons/.*/person-responsible-officer",
           "/v1/persons/.*/risk-management-plan",
           "/v1/epf/person-details/.*/\\.*+[^/]*${'$'}",
-          "/v1/pes/prisoner-details/.*+[^/]*${'$'}",
+          "/v1/pes/prisoner-details/\\.*+[^/]*${'$'}",
           "/health",
           "/health/ping",
           "/health/readiness",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PESPrisonerDetailSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/PESPrisonerDetailSmokeTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke
+
+import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIHttpClient
+
+class PESPrisonerDetailSmokeTest : DescribeSpec(
+  {
+    val hmppsId = "X123456"
+    val basePath = "v1/pes/prisoner-details/$hmppsId"
+
+    val httpClient = IntegrationAPIHttpClient()
+
+    it("returns a prisoner detail for a HmppsID") {
+      val response = httpClient.performAuthorised(basePath)
+
+      response.statusCode().shouldBe(HttpStatus.OK.value())
+      response.body().shouldEqualJson(
+        """
+        {
+        "data": {
+          "prisonerNumber": "A1234AA",
+          "firstName": "Robert",
+          "lastName": "Larsen",
+          "prisonId": "MDI",
+          "prisonName": "HMP Leeds",
+          "cellLocation": "A-1-002"
+        },
+        "errors": []
+      }
+      """.removeWhitespaceAndNewlines(),
+      )
+    }
+  },
+)


### PR DESCRIPTION
New endpoint to support the HMPPS Prisoner Education programme, who need to automatically provision new Azure accounts for prisoners as they move into non-Launchpad sites.