### PR TITLE
PES - add hmpps id endpoint for a given nomis number

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdController.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsId
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetHmppsIdService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+
+@RestController
+@RequestMapping("/v1/hmpps-id")
+class HmppsIdController(
+  @Autowired val getHmppsIdService: GetHmppsIdService,
+  @Autowired val auditService: AuditService,
+) {
+  @GetMapping("nomis-number/{encodedNomisNumber}")
+  fun getHmppsIdByNomisNumber(
+    @PathVariable encodedNomisNumber: String,
+  ): Map<String, HmppsId?> {
+    val nomisNumber = encodedNomisNumber.decodeUrlCharacters()
+
+    val response = getHmppsIdService.execute(nomisNumber)
+
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not find HMPPS ID for nomis number: $nomisNumber")
+    }
+
+    auditService.createEvent("GET_HMPPS_ID_BY_NOMIS_NUMBER", mapOf("nomisNumber" to nomisNumber))
+
+    return mapOf("data" to response.data)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ProbationOffenderSearchGateway.kt
@@ -27,6 +27,8 @@ class ProbationOffenderSearchGateway(
     val queryField =
       if (isPncNumber(id)) {
         "pncNumber"
+      } else if (isNomsNumber(id)) {
+        "nomsNumber"
       } else {
         "crn"
       }
@@ -149,5 +151,9 @@ class ProbationOffenderSearchGateway(
 
   private fun isPncNumber(id: String?): Boolean {
     return id?.matches(Regex("^[0-9]+/[0-9A-Za-z]+$")) == true
+  }
+
+  private fun isNomsNumber(id: String?): Boolean {
+    return id?.matches(Regex("^[A-Z]\\d{4}[A-Z]{2}+$")) == true
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/HmppsId.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/HmppsId.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
+
+data class HmppsId(
+  val hmppsId: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/Offender.kt
@@ -33,7 +33,7 @@ data class Offender(
           deliusCrn = otherIds.crn,
         ),
       pncId = otherIds.pncNumber,
-      hmppsId = otherIds.crn,
+      hmppsId = if (otherIds.crn?.isNotEmpty() == true) otherIds.crn else otherIds.nomsNumber,
       contactDetails = this.contactDetails?.toContactDetails(),
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetHmppsIdService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetHmppsIdService.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsId
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+
+@Service
+class GetHmppsIdService(
+  @Autowired val getPersonService: GetPersonService,
+) {
+  fun execute(hmppsId: String): Response<HmppsId?> {
+    val personResponse = getPersonService.execute(hmppsId = hmppsId)
+
+    return Response(
+      data = HmppsId(hmppsId = personResponse.data?.hmppsId),
+      errors = personResponse.errors,
+    )
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -52,6 +52,7 @@ authorisation:
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
     moj-pes:
       - "/v1/persons/.*/name"
+      - "/v1/hmpps-id/nomis-number/\\.*+[^/]*$"
     kubernetes-health-check-client:
       - "/health/liveness"
       - "/health/readiness"

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -51,6 +51,7 @@ authorisation:
       - "/v1/persons/.*/person-responsible-officer"
       - "/v1/persons/.*/risk-management-plan"
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+      - "/v1/hmpps-id/nomis-number/\\.*+[^/]*$"
       - "/health"
       - "/health/ping"
       - "/health/readiness"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -58,6 +58,7 @@ authorisation:
       - "/v1/persons/.*/status-information"
       - "/v1/persons/.*/risk-management-plan"
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
+      - "/v1/hmpps-id/nomis-number/\\.*+[^/]*$"
       - "/health"
       - "/health/ping"
       - "/health/readiness"

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -30,6 +30,7 @@ authorisation:
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
     moj-pes:
       - "/v1/persons/.*/name"
+      - "/v1/hmpps-id/nomis-number/\\.*+[^/]*$"
     kubernetes-health-check-client:
       - "/health/liveness"
       - "/health/readiness"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -30,6 +30,7 @@ authorisation:
       - "/v1/epf/person-details/.*/\\.*+[^/]*$"
     moj-pes:
       - "/v1/persons/.*/name"
+      - "/v1/hmpps-id/nomis-number/\\.*+[^/]*$"
     kubernetes-health-check-client:
       - "/health/liveness"
       - "/health/readiness"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -66,6 +66,7 @@ authorisation:
       - "/v1/persons/.*/risks/categories"
       - "/v1/persons/.*/risk-management-plan"
       - "/v1/persons/.*/status-information"
+      - "/v1/hmpps-id/nomis-number/\\.*+[^/]*$"
       - "/health"
       - "/health/ping"
       - "/health/readiness"
@@ -73,4 +74,3 @@ authorisation:
       - "/info"
     config-test:
       - "/v1/config/authorisation"
-

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdControllerTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsId
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetHmppsIdService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+
+@WebMvcTest(controllers = [HmppsIdController::class])
+@ActiveProfiles("test")
+internal class HmppsIdControllerTest(
+  @Autowired var springMockMvc: MockMvc,
+  @MockBean val getHmppsIdService: GetHmppsIdService,
+  @MockBean val auditService: AuditService,
+) : DescribeSpec({
+    val nomisNumber = "A1234AA"
+    val path = "/v1/hmpps-id/nomis-number/$nomisNumber"
+    val mockMvc = IntegrationAPIMockMvc(springMockMvc)
+
+    describe("GET $path") {
+      beforeTest {
+        Mockito.reset(getHmppsIdService)
+        whenever(getHmppsIdService.execute(nomisNumber)).thenReturn(
+          Response(
+            data = HmppsId(hmppsId = nomisNumber),
+          ),
+        )
+        Mockito.reset(auditService)
+      }
+
+      it("returns a 200 OK status code") {
+        val result = mockMvc.performAuthorised(path)
+
+        result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+
+      it("gets the person detail for a person with the matching ID") {
+        mockMvc.performAuthorised(path)
+
+        verify(getHmppsIdService, VerificationModeFactory.times(1)).execute(nomisNumber)
+      }
+
+      it("logs audit") {
+        mockMvc.performAuthorised(path)
+        verify(
+          auditService,
+          VerificationModeFactory.times(1),
+        ).createEvent(
+          "GET_HMPPS_ID_BY_NOMIS_NUMBER",
+          mapOf("nomisNumber" to nomisNumber),
+        )
+      }
+
+      it("returns a 500 INTERNAL SERVER ERROR status code when upstream api return expected error") {
+
+        whenever(getHmppsIdService.execute(nomisNumber)).doThrow(
+          WebClientResponseException(500, "MockError", null, null, null, null),
+        )
+
+        val result = mockMvc.performAuthorised(path)
+        assert(result.response.status == 500)
+        assert(
+          result.response.contentAsString.equals(
+            "{\"status\":500,\"errorCode\":null,\"userMessage\":\"500 MockError\",\"developerMessage\":\"Unable to complete request as an upstream service is not responding\",\"moreInfo\":null}",
+          ),
+        )
+      }
+    }
+  })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -413,5 +413,30 @@ class ProbationOffenderSearchGatewayTest(
           probationOffenderSearchGateway.getPerson(hmppsId)
         }
       }
+
+      describe("when a Nomis number is used to make requests") {
+        val hmppsId = "A7777ZZ"
+
+        it("calls the Probation API service with a Nomis number") {
+          probationOffenderSearchApiMockServer.stubPostOffenderSearch(
+            "{\"nomsNumber\": \"$hmppsId\"}",
+            """
+          [
+           {
+            "firstName": "Jonathan",
+            "surname": "Bravo",
+            "dateOfBirth": "1970-02-07",
+            "offenderAliases": []
+          }
+        ]
+        """,
+          )
+
+          val response = probationOffenderSearchGateway.getPerson(hmppsId)
+
+          response.data?.firstName.shouldBe("Jonathan")
+          response.data?.lastName.shouldBe("Bravo")
+        }
+      }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/fixtures/GetOffendersResponse.json
@@ -8,7 +8,8 @@
     "gender": "Male",
     "otherIds": {
       "crn": "X595043",
-      "pncNumber": "2018/0123456X"
+      "pncNumber": "2018/0123456X",
+      "nomsNumber": "A7777ZZ"
     },
     "contactDetails": {
       "phoneNumbers": [],

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/probationoffendersearch/OffenderTest.kt
@@ -60,6 +60,43 @@ class OffenderTest : DescribeSpec(
 
         person.middleName.shouldBeEmpty()
       }
+
+      it("returns crn as HMPPS ID when crn is returned") {
+        val prisoner =
+          Offender(
+            firstName = "First Name",
+            surname = "Surname",
+            otherIds =
+              OtherIds(
+                pncNumber = "pncNumber",
+                nomsNumber = "nomsNumber",
+                croNumber = "croNumber",
+                crn = "crnNumber",
+              ),
+          )
+
+        val person = prisoner.toPerson()
+
+        person.hmppsId.shouldBe("crnNumber")
+      }
+
+      it("returns nomsNumber as HMPPS ID when no crn") {
+        val prisoner =
+          Offender(
+            firstName = "First Name",
+            surname = "Surname",
+            otherIds =
+              OtherIds(
+                pncNumber = "pncNumber",
+                nomsNumber = "nomsNumber",
+                croNumber = "croNumber",
+              ),
+          )
+
+        val person = prisoner.toPerson()
+
+        person.hmppsId.shouldBe("nomsNumber")
+      }
     }
   },
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetHmppsIdServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetHmppsIdServiceTest.kt
@@ -1,0 +1,43 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ContextConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsId
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Identifiers
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Person
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+
+@ContextConfiguration(
+  initializers = [ConfigDataApplicationContextInitializer::class],
+  classes = [GetHmppsIdService::class],
+)
+internal class GetHmppsIdServiceTest(
+  @MockBean val getPersonService: GetPersonService,
+  private val getHmppsIdService: GetHmppsIdService,
+) : DescribeSpec(
+    {
+      val id = "A7777ZZ"
+      val hmppsId = HmppsId(hmppsId = id)
+
+      beforeEach {
+        Mockito.reset(getPersonService)
+
+        whenever(getPersonService.execute(id)).thenReturn(
+          Response(
+            data = Person(firstName = "Qui-gon", lastName = "Jin", hmppsId = id, identifiers = Identifiers(nomisNumber = id)),
+          ),
+        )
+      }
+
+      it("Returns a hmpps id for the given id") {
+        val result = getHmppsIdService.execute(id)
+
+        result.shouldBe(Response(data = hmppsId))
+      }
+    },
+  )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/AuthoriseConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/AuthoriseConfigTest.kt
@@ -46,6 +46,7 @@ class AuthoriseConfigTest : DescribeSpec(
           "/v1/persons/.*/person-responsible-officer",
           "/v1/persons/.*/risk-management-plan",
           "/v1/epf/person-details/.*/\\.*+[^/]*${'$'}",
+          "/v1/hmpps-id/nomis-number/\\.*+[^/]*${'$'}",
           "/health",
           "/health/ping",
           "/health/readiness",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
@@ -114,6 +114,84 @@ class PersonSmokeTest : DescribeSpec(
       )
     }
 
+    it("returns a person from Probation Offender Search when nomis number provided as HMPPS ID") {
+      val nomsHmppsId = "A1234AA"
+      val encodedNomsHmppsId = URLEncoder.encode(nomsHmppsId, StandardCharsets.UTF_8)
+
+      val response = httpClient.performAuthorised("$basePath/$encodedNomsHmppsId")
+
+      response.body().shouldBe(
+        """
+        {
+            "data": {
+                "prisonerOffenderSearch": {
+                    "firstName": "Robert",
+                    "lastName": "Larsen",
+                    "middleName": "John James",
+                    "dateOfBirth": "1975-04-02",
+                    "gender": "Female",
+                    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+                    "aliases": [
+                        {
+                            "firstName": "Robert",
+                            "lastName": "Lorsen",
+                            "middleName": "Trevor",
+                            "dateOfBirth": "1975-04-02",
+                            "gender": "Male",
+                            "ethnicity": "White : Irish"
+                        }
+                    ],
+                    "identifiers": {
+                        "nomisNumber": "A1234AA",
+                        "croNumber": "29906/12J",
+                        "deliusCrn": null
+                    },
+                    "pncId": "12/394773H",
+                    "hmppsId": null,
+                    "contactDetails": null
+                },
+                "probationOffenderSearch": {
+                    "firstName": "string",
+                    "lastName": "string",
+                    "middleName": "string",
+                    "dateOfBirth": "2019-08-24",
+                    "gender": "string",
+                    "ethnicity": "string",
+                    "aliases": [
+                        {
+                            "firstName": "string",
+                            "lastName": "string",
+                            "middleName": "string",
+                            "dateOfBirth": "2019-08-24",
+                            "gender": "string",
+                            "ethnicity": null
+                        }
+                    ],
+                    "identifiers": {
+                        "nomisNumber": "G5555TT",
+                        "croNumber": "123456/24A",
+                        "deliusCrn": "A123456"
+                    },
+                    "pncId": "2012/0052494Q",
+                    "hmppsId": "A123456",
+                    "contactDetails": {
+                        "phoneNumbers": [
+                            {
+                                "number": "string",
+                                "type": "TELEPHONE"
+                            }
+                        ],
+                        "emails": [
+                            "string"
+                        ]
+                    }
+                }
+            }
+        }
+    """.removeWhitespaceAndNewlines(),
+      )
+    }
+
     it("returns image metadata for a person") {
       val response = httpClient.performAuthorised("$basePath/$encodedHmppsId/images")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/smoke/person/PersonSmokeTest.kt
@@ -178,7 +178,7 @@ class PersonSmokeTest : DescribeSpec(
                         "phoneNumbers": [
                             {
                                 "number": "string",
-                                "type": "TELEPHONE"
+                                "type": "string"
                             }
                         ],
                         "emails": [


### PR DESCRIPTION
Add endpoint to retrieve HMPPS ID given a nomis number. Until the HMPPS core person work is finialised this endpoint will return the crn in most cases but could also return the nomis number where no crn exists for a person.