### PR TITLE
updated existing method

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetHmppsIdService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetHmppsIdService.kt
@@ -11,10 +11,16 @@ class GetHmppsIdService(
   @Autowired val getPersonService: GetPersonService,
 ) {
   fun execute(hmppsId: String): Response<HmppsId?> {
-    val personResponse = getPersonService.execute(hmppsId = hmppsId)
+    val personResponse = getPersonService.execute(hmppsId)
+
+    val hmppsIdToReturn =
+      personResponse.data?.hmppsId ?: run {
+        // Attempt to look up the person in NOMIS if not found in the probation offender search
+        getPersonService.getPersonFromNomis(hmppsId).data?.prisonerNumber
+      }
 
     return Response(
-      data = HmppsId(hmppsId = personResponse.data?.hmppsId),
+      data = HmppsId(hmppsIdToReturn),
       errors = personResponse.errors,
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -103,4 +103,6 @@ class GetPersonService(
       errors = (prisonResponse?.errors ?: emptyList()) + probationResponse.errors,
     )
   }
+
+  fun getPersonFromNomis(nomisNumber: String) = prisonerOffenderSearchGateway.getPrisonOffender(nomisNumber)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/HmppsIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/HmppsIdIntegrationTest.kt
@@ -45,6 +45,19 @@ class HmppsIdIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `gets the nomis Id for a HMPPSID where the id is a NOMIS id AND is not in delius`() {
+    callApi("/v1/hmpps/id/$nomsIdNotInDelius/nomis-number")
+      .andExpect(status().isOk)
+      .andExpect(
+        content().json(
+          """
+        {"data":{"nomisNumber":"A1234AA"}}
+      """,
+        ),
+      )
+  }
+
+  @Test
   fun `gets the nomis Id for a HMPPSID where the id is invalid`() {
     callApi("/v1/hmpps/id/invalidId/nomis-number")
       .andExpect(status().is4xxClientError)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
@@ -28,6 +28,7 @@ abstract class IntegrationTestBase {
   final val pnc = URLEncoder.encode("2004/13116M", StandardCharsets.UTF_8)
   final val nomsId = "G2996UX"
   final val crn = "AB123123"
+  final val nomsIdNotInDelius = "A1234AA"
 
   companion object {
     private val hmppsAuthMockServer = HmppsAuthMockServer()


### PR DESCRIPTION
This looks weird but...

Sometimes the hmppsId will be a crn and sometimes it will be a noms number. 

If the crn exists then it will be the crn but if no crn exists then it will be a noms number. 

However... it is possible for the hmppsid to change without the downstream service being aware. So they should always essentially verify that the hmppsId is correct - that's what this api method does. The end client is essentially verifying that the hmppsId is the one they have and if not it will give them the correct one. 

hope that makes sense. 