### PR TITLE
HMAI-121 Create FiltersExtractionFilter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
@@ -1,17 +1,45 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
-import jakarta.servlet.*
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import java.io.IOException
 
-class FiltersExtractionFilter : Filter {
-  @Throws(IOException::class, ServletException::class)
-  override fun doFilter(
-    request: ServletRequest,
-    response: ServletResponse?,
-    chain: FilterChain,
-  ) {
-    request.setAttribute("filters", ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2"))))
-    chain.doFilter(request, response)
+@Component
+@Order(2)
+@EnableConfigurationProperties(AuthorisationConfig::class)
+class FiltersExtractionFilter
+  @Autowired
+  constructor(
+    var authorisationConfig: AuthorisationConfig,
+  ) : Filter {
+    @Throws(IOException::class, ServletException::class)
+    override fun doFilter(
+      request: ServletRequest,
+      response: ServletResponse?,
+      chain: FilterChain,
+    ) {
+      val subjectDistinguishedName = request.getAttribute("clientName") as String?
+      val requestingConsumer: ConsumerConfig? = authorisationConfig.consumers[subjectDistinguishedName]
+
+      if (requestingConsumer == null) {
+        (response as HttpServletResponse).sendError(HttpServletResponse.SC_FORBIDDEN, "TODO")
+        return
+      }
+
+      val requestingConsumersFilters: ConsumerFilters? = requestingConsumer.filters
+
+      request.setAttribute("filters", requestingConsumersFilters)
+      chain.doFilter(request, response)
+    }
   }
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
-import jakarta.servlet.*
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
@@ -1,10 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
-import jakarta.servlet.Filter
-import jakarta.servlet.FilterChain
-import jakarta.servlet.ServletException
-import jakarta.servlet.ServletRequest
-import jakarta.servlet.ServletResponse
+import jakarta.servlet.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import java.io.IOException
 
 class FiltersExtractionFilter : Filter {
@@ -14,6 +11,7 @@ class FiltersExtractionFilter : Filter {
     response: ServletResponse?,
     chain: FilterChain,
   ) {
+    request.setAttribute("filters", ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2"))))
     chain.doFilter(request, response)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import java.io.IOException
+
+class FiltersExtractionFilter : Filter {
+  @Throws(IOException::class, ServletException::class)
+  override fun doFilter(
+    request: ServletRequest,
+    response: ServletResponse?,
+    chain: FilterChain,
+  ) {
+    chain.doFilter(request, response)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
@@ -1,10 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
-import jakarta.servlet.Filter
-import jakarta.servlet.FilterChain
-import jakarta.servlet.ServletException
-import jakarta.servlet.ServletRequest
-import jakarta.servlet.ServletResponse
+import jakarta.servlet.*
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -26,18 +22,18 @@ class FiltersExtractionFilter
     @Throws(IOException::class, ServletException::class)
     override fun doFilter(
       request: ServletRequest,
-      response: ServletResponse?,
+      response: ServletResponse,
       chain: FilterChain,
     ) {
       val subjectDistinguishedName = request.getAttribute("clientName") as String?
-      val requestingConsumer: ConsumerConfig? = authorisationConfig.consumers[subjectDistinguishedName]
+      val consumerConfig: ConsumerConfig? = authorisationConfig.consumers[subjectDistinguishedName]
 
-      if (requestingConsumer == null) {
+      if (consumerConfig == null) {
         (response as HttpServletResponse).sendError(HttpServletResponse.SC_FORBIDDEN, "TODO")
         return
       }
 
-      val requestingConsumersFilters: ConsumerFilters? = requestingConsumer.filters
+      val requestingConsumersFilters: ConsumerFilters? = consumerConfig.filters
 
       request.setAttribute("filters", requestingConsumersFilters)
       chain.doFilter(request, response)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilter.kt
@@ -33,7 +33,7 @@ class FiltersExtractionFilter
       val consumerConfig: ConsumerConfig? = authorisationConfig.consumers[subjectDistinguishedName]
 
       if (consumerConfig == null) {
-        (response as HttpServletResponse).sendError(HttpServletResponse.SC_FORBIDDEN, "TODO")
+        (response as HttpServletResponse).sendError(HttpServletResponse.SC_FORBIDDEN, "No consumer authorisation config found for $subjectDistinguishedName")
         return
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -1,12 +1,12 @@
-@file:Suppress("ktlint:standard:no-wildcard-imports")
-
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.*
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -30,6 +30,8 @@ class FiltersExtractionFilterTest {
     val mockResponse = mock(HttpServletResponse::class.java)
     val mockChain = mock(FilterChain::class.java)
 
+    authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(emptyMap())))
+
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
 
@@ -43,13 +45,14 @@ class FiltersExtractionFilterTest {
     val mockRequest = mock(HttpServletRequest::class.java)
     whenever(mockRequest.getAttribute("clientName")).thenReturn("consumer-name")
 
+    val mockResponse = mock(HttpServletResponse::class.java)
     val mockChain = mock(FilterChain::class.java)
 
     val expectedFilters = ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2")))
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = expectedFilters))
 
     // Act
-    filtersExtractionFilter.doFilter(mockRequest, null, mockChain)
+    filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
 
     // Assert
     verify(mockRequest, times(1)).setAttribute("filters", expectedFilters)
@@ -61,13 +64,14 @@ class FiltersExtractionFilterTest {
     val mockRequest = mock(HttpServletRequest::class.java)
     whenever(mockRequest.getAttribute("clientName")).thenReturn("invalid-consumer-name")
 
+    val mockResponse = mock(HttpServletResponse::class.java)
     val mockChain = mock(FilterChain::class.java)
 
     val expectedFilters = ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2")))
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = expectedFilters))
 
     // Act
-    filtersExtractionFilter.doFilter(mockRequest, null, mockChain)
+    filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
 
     // Assert
     verify(mockRequest, times(0)).setAttribute("filters", expectedFilters)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -6,8 +6,6 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Test
-import org.mockito.InjectMocks
-import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
@@ -15,10 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 class FiltersExtractionFilterTest {
-  @Mock
   private var authorisationConfig: AuthorisationConfig = AuthorisationConfig()
-
-  @InjectMocks
   private var filtersExtractionFilter: FiltersExtractionFilter = FiltersExtractionFilter(authorisationConfig)
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -4,9 +4,10 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.*
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 class FiltersExtractionFilterTest {
   @Test
@@ -23,5 +24,24 @@ class FiltersExtractionFilterTest {
 
     // Assert
     verify(mockChain, times(1)).doFilter(mockRequest, mockResponse)
+  }
+
+  @Test
+  fun `can get filters attribute from the test`() {
+    // Arrange
+    val mockRequest = mock(HttpServletRequest::class.java)
+    val mockChain = mock(FilterChain::class.java)
+
+    val filter = FiltersExtractionFilter()
+
+    val authorisationConfig = AuthorisationConfig()
+    val expectedFilters = ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2")))
+    authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = expectedFilters))
+
+    // Act
+    filter.doFilter(mockRequest,  null, mockChain)
+
+    // Assert
+    verify(mockRequest, times(1)).setAttribute("filters", expectedFilters)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -1,26 +1,37 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
 import org.mockito.Mockito.*
+import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 class FiltersExtractionFilterTest {
+  @Mock
+  private var authorisationConfig: AuthorisationConfig = AuthorisationConfig()
+
+  @InjectMocks
+  private var filtersExtractionFilter: FiltersExtractionFilter = FiltersExtractionFilter(authorisationConfig)
+
   @Test
   fun `calls the onward chain`() {
     // Arrange
     val mockRequest = mock(HttpServletRequest::class.java)
+    whenever(mockRequest.getAttribute("clientName")).thenReturn("consumer-name")
+
     val mockResponse = mock(HttpServletResponse::class.java)
     val mockChain = mock(FilterChain::class.java)
 
-    val filter = FiltersExtractionFilter()
-
     // Act
-    filter.doFilter(mockRequest, mockResponse, mockChain)
+    filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
 
     // Assert
     verify(mockChain, times(1)).doFilter(mockRequest, mockResponse)
@@ -30,18 +41,35 @@ class FiltersExtractionFilterTest {
   fun `can get filters attribute from the test`() {
     // Arrange
     val mockRequest = mock(HttpServletRequest::class.java)
+    whenever(mockRequest.getAttribute("clientName")).thenReturn("consumer-name")
+
     val mockChain = mock(FilterChain::class.java)
 
-    val filter = FiltersExtractionFilter()
-
-    val authorisationConfig = AuthorisationConfig()
     val expectedFilters = ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2")))
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = expectedFilters))
 
     // Act
-    filter.doFilter(mockRequest,  null, mockChain)
+    filtersExtractionFilter.doFilter(mockRequest, null, mockChain)
 
     // Assert
     verify(mockRequest, times(1)).setAttribute("filters", expectedFilters)
+  }
+
+  @Test
+  fun `tolerates when no consumer config values matched with clientName`() {
+    // Arrange
+    val mockRequest = mock(HttpServletRequest::class.java)
+    whenever(mockRequest.getAttribute("clientName")).thenReturn("invalid-consumer-name")
+
+    val mockChain = mock(FilterChain::class.java)
+
+    val expectedFilters = ConsumerFilters(mapOf("example-filter" to listOf("filter-1", "filter-2")))
+    authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = expectedFilters))
+
+    // Act
+    filtersExtractionFilter.doFilter(mockRequest, null, mockChain)
+
+    // Assert
+    verify(mockRequest, times(0)).setAttribute("filters", expectedFilters)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+class FiltersExtractionFilterTest {
+  @Test
+  fun `calls the onward chain`() {
+    // Arrange
+    val mockRequest = mock(HttpServletRequest::class.java)
+    val mockResponse = mock(HttpServletResponse::class.java)
+    val mockChain = mock(FilterChain::class.java)
+
+    val filter = FiltersExtractionFilter()
+
+    // Act
+    filter.doFilter(mockRequest, mockResponse, mockChain)
+
+    // Assert
+    verify(mockChain, times(1)).doFilter(mockRequest, mockResponse)
+  }
+}


### PR DESCRIPTION
In order to let API endpoints have access to the filters from the authorisation config, provide an extraction filter that adds these to the request object. These should be accessible with the [RequestAttribute](https://docs.spring.io/spring-framework/reference/web/webflux/controller/ann-methods/requestattrib.html) annotation.