### PR TITLE
Return 404 response in prison/prisoners/{hmppsId} if probation search cannot find HMPPS ID.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
@@ -49,8 +49,11 @@ class PrisonController(
   ): DataResponse<Person?> {
     val response = getPersonService.getPrisoner(hmppsId)
 
-    if (response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH)) {
+    if (response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH)) {
       throw EntityNotFoundException("Could not find person with hmppsId: $hmppsId")
+    }
+    if (response.hasErrorCausedBy(ENTITY_NOT_FOUND, causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH)) {
+      throw EntityNotFoundException("Could not find prisoner with hmppsId: $hmppsId")
     }
 
     auditService.createEvent("GET_PERSON_DETAILS", mapOf("hmppsId" to hmppsId))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonControllerTest.kt
@@ -154,6 +154,26 @@ internal class PrisonControllerTest(
         result.response.status.shouldBe(404)
       }
 
+      it("returns 404 when NOMIS number is not found") {
+        whenever(getPersonService.getPrisoner(hmppsId)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  type = ENTITY_NOT_FOUND,
+                  causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+                  description = "NOMIS number not found",
+                ),
+              ),
+          ),
+        )
+
+        val result = mockMvc.performAuthorised("$basePath/prisoners/$hmppsId")
+
+        result.response.status.shouldBe(404)
+      }
+
       it("returns 500 when prison/prisoners throws an unexpected error") {
 
         whenever(getPrisonersService.execute("Barry", "Allen", "2023-03-01")).thenThrow(RuntimeException("Service error"))


### PR DESCRIPTION
A GET to /v1/prison/prisoners/<invalid id> was returning `{"data":null}` with a 200 code, as we were not picking up on the 404 from the probation API