### PR TITLE
Replace status with new status supplied by prism

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PLPIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PLPIntegrationTest.kt
@@ -15,7 +15,7 @@ class PLPIntegrationTest : IntegrationTestBase() {
           """
            {"data": {
             "deadlineDate":"2019-08-24",
-            "status":"SCHEDULED",
+            "status":"PENDING_INITIAL_SCREENING_AND_ASSESSMENTS_FROM_CURIOUS",
             "calculationRule": "NEW_PRISON_ADMISSION",
             "nomisNumber": "A1234BC",
             "systemUpdatedBy":"Alex Smith",


### PR DESCRIPTION
This has been caused by a change in education and work: https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/commit/29f29253fb2731f0d37303e3f54a197749c5a965#diff-f1d1f3634d02424dce3d2b27d85f73f1c357834d7fcf9f323c81853dc7279a2aR3269