### PR TITLE
HMAI-100- Gateway level error handling - Implement GET /v1/prison/{prisonId}/prisoners/{hmppsId}/balances

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAccountsForPersonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/nomis/GetAccountsForPersonTest.kt
@@ -82,5 +82,27 @@ class GetAccountsForPersonTest(
           response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
           response.errors.first().type.shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
         }
+
+//          it("returns null when 400 Bad Request is returned") {
+//              nomisApiMockServer.stubNomisApiResponse(
+//                  accountsPath,
+//                  "",
+//                  HttpStatus.BAD_REQUEST,
+//              )
+//              val response =
+//                  shouldThrow<WebClientResponseException> {
+//                      nomisGateway.getAccountsForPerson(prisonId, nomisNumber)
+//                  }
+//              response.statusCode.shouldBe(HttpStatus.BAD_REQUEST)
+//          }
+        it("returns an error when 400 Bad Request is returned because of invalid ID") {
+          nomisApiMockServer.stubNomisApiResponse(accountsPath, "", HttpStatus.BAD_REQUEST)
+
+          val response = nomisGateway.getAccountsForPerson(prisonId, nomisNumber)
+
+          response.errors.shouldHaveSize(1)
+          response.errors.first().causedBy.shouldBe(UpstreamApi.NOMIS)
+          response.errors.first().type.shouldBe(UpstreamApiError.Type.BAD_REQUEST)
+        }
       },
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -361,9 +361,6 @@ class ProbationOffenderSearchGatewayTest(
           response.statusCode.shouldBe(HttpStatus.BAD_REQUEST)
         }
 
-        // 1. Change their gateway tests to pass (but will we have still broken the endpoints)
-        // 2. Change our code to catch the exception instead
-
         it("returns null when no offenders are returned") {
           probationOffenderSearchApiMockServer.stubPostOffenderSearch(
             "{\"pncNumber\": \"$hmppsId\"}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/probationoffendersearch/ProbationOffenderSearchGatewayTest.kt
@@ -361,6 +361,9 @@ class ProbationOffenderSearchGatewayTest(
           response.statusCode.shouldBe(HttpStatus.BAD_REQUEST)
         }
 
+        // 1. Change their gateway tests to pass (but will we have still broken the endpoints)
+        // 2. Change our code to catch the exception instead
+
         it("returns null when no offenders are returned") {
           probationOffenderSearchApiMockServer.stubPostOffenderSearch(
             "{\"pncNumber\": \"$hmppsId\"}",


### PR DESCRIPTION
Add in fix for the 400 error handling on the getAccountsForPerson in the nomis gateway 