### PR TITLE
HMAI 99 - Implement GET /v1/prison/{prisonId}/prisoners/{hmppsId}/balances/{accountCode}

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
@@ -52,7 +52,7 @@ class BalancesController(
     }
 
     if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
-      throw ValidationException("Either invalid HMPPS ID: $hmppsId at or incorrect prison: $prisonId")
+      throw ValidationException("Either invalid HMPPS ID: $hmppsId or incorrect prison: $prisonId")
     }
 
     auditService.createEvent("GET_BALANCES_FOR_PERSON", mapOf("hmppsId" to hmppsId, "prisonId" to prisonId))
@@ -84,6 +84,10 @@ class BalancesController(
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
+    }
+
+    if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
+      throw ValidationException("Either invalid HMPPS ID: $hmppsId, invalid Account Code: $accountCode or incorrect prison: $prisonId")
     }
 
     return DataResponse(response.data)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
@@ -81,6 +81,11 @@ class BalancesController(
     @RequestAttribute filters: ConsumerFilters?,
   ): DataResponse<Balances?> {
     val response = getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = filters)
+
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not find person with id: $hmppsId")
+    }
+
     return DataResponse(response.data)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
@@ -45,7 +45,7 @@ class BalancesController(
     @PathVariable prisonId: String,
     @RequestAttribute filters: ConsumerFilters?,
   ): DataResponse<Balances?> {
-    val response = getBalancesForPersonService.execute(prisonId, hmppsId, filters)
+    val response = getBalancesForPersonService.execute(prisonId, hmppsId, filters = filters)
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
@@ -58,4 +58,29 @@ class BalancesController(
     auditService.createEvent("GET_BALANCES_FOR_PERSON", mapOf("hmppsId" to hmppsId, "prisonId" to prisonId))
     return DataResponse(response.data)
   }
+
+  @GetMapping("/{accountCode}")
+  @Operation(
+    summary = "Returns a specific account for a prisoner that they have at a prison, based on the account code provided.",
+    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
+    responses = [
+      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully found a prisoner's account."),
+      ApiResponse(
+        responseCode = "400",
+        description = "The HMPPS ID provided has an invalid format or the prisoner does hot have accounts at the specified prison.",
+        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
+      ),
+      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
+      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
+    ],
+  )
+  fun getBalanceForPerson(
+    @PathVariable hmppsId: String,
+    @PathVariable prisonId: String,
+    @PathVariable accountCode: String,
+    @RequestAttribute filters: ConsumerFilters?,
+  ): DataResponse<Balances?> {
+    val response = getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = filters)
+    return DataResponse(response.data)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
@@ -67,7 +67,7 @@ class BalancesController(
       ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully found a prisoner's account."),
       ApiResponse(
         responseCode = "400",
-        description = "The HMPPS ID provided has an invalid format or the prisoner does hot have accounts at the specified prison.",
+        description = "The HMPPS ID provided has an invalid format, the account code is not one of the allowable accounts or the prisoner does hot have accounts at the specified prison.",
         content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
       ),
       ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
@@ -90,6 +90,7 @@ class BalancesController(
       throw ValidationException("Either invalid HMPPS ID: $hmppsId, invalid Account Code: $accountCode or incorrect prison: $prisonId")
     }
 
+    auditService.createEvent("GET_BALANCE_FOR_PERSON", mapOf("hmppsId" to hmppsId, "accountCode" to accountCode, "prisonId" to prisonId))
     return DataResponse(response.data)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesController.kt
@@ -80,7 +80,7 @@ class BalancesController(
     @PathVariable accountCode: String,
     @RequestAttribute filters: ConsumerFilters?,
   ): DataResponse<Balances?> {
-    val response = getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = filters)
+    val response = getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = filters)
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
@@ -75,7 +75,7 @@ class GetBalancesForPersonService(
   fun getBalance(
     prisonId: String,
     hmppsId: String,
-    accountCode: String? = null,
+    accountCode: String,
     filters: ConsumerFilters? = null,
   ): Response<Balances?> {
     if (!listOf("spends", "savings", "cash").any { it == accountCode }) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
@@ -18,7 +18,6 @@ class GetBalancesForPersonService(
   fun execute(
     prisonId: String,
     hmppsId: String,
-    accountCode: String? = null, // TODO: Remove this
     filters: ConsumerFilters? = null,
   ): Response<Balances?> {
     if (
@@ -86,7 +85,7 @@ class GetBalancesForPersonService(
       )
     }
 
-    val response = execute(prisonId, hmppsId, accountCode, filters)
+    val response = execute(prisonId, hmppsId, filters)
 
     if (response.errors.isNotEmpty()) {
       return Response(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
@@ -18,6 +18,7 @@ class GetBalancesForPersonService(
   fun execute(
     prisonId: String,
     hmppsId: String,
+    accountCode: String? = null,
     filters: ConsumerFilters? = null,
   ): Response<Balances?> {
     if (
@@ -45,6 +46,20 @@ class GetBalancesForPersonService(
       return Response(
         data = null,
         errors = nomisAccounts.errors,
+      )
+    }
+
+    if (accountCode != null) {
+      val balance =
+        Balances(
+          balances =
+            listOf(
+              AccountBalance(accountCode = accountCode, amount = 100),
+            ),
+        )
+      return Response(
+        data = balance,
+        errors = emptyList(),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonService.kt
@@ -78,7 +78,7 @@ class GetBalancesForPersonService(
     accountCode: String? = null,
     filters: ConsumerFilters? = null,
   ): Response<Balances?> {
-    if (!listOf("spends", "savings", "cash").any { it.equals(accountCode) }) {
+    if (!listOf("spends", "savings", "cash").any { it == accountCode }) {
       return Response(
         data = null,
         errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.NOMIS)),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -129,6 +129,7 @@ authorisation:
         - "/v1/prison/prisoners/[^/]*$"
         - "/v1/prison/prisoners"
         - "/v1/prison/.*/prisoners/.*/balances$"
+        - "/v1/prison/.*/prisoners/.*/balances/[^/]*$"
       filters:
     kilco:
       include:
@@ -137,6 +138,7 @@ authorisation:
         - "/v1/prison/prisoners"
         - "/v1/prison/prisoners/[^/]*$"
         - "/v1/prison/.*/prisoners/.*/balances$"
+        - "/v1/prison/.*/prisoners/.*/balances/[^/]*$"
       filters:
     meganexus:
       include:
@@ -153,6 +155,7 @@ authorisation:
         - "/v1/prison/prisoners/[^/]*$"
         - "/v1/prison/prisoners"
         - "/v1/prison/.*/prisoners/.*/balances$"
+        - "/v1/prison/.*/prisoners/.*/balances/[^/]*$"
       filters:
     serco:
       include:

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -85,6 +85,7 @@ authorisation:
         - "/v1/prison/prisoners/[^/]*$"
         - "/v1/prison/prisoners"
         - "/v1/prison/.*/prisoners/.*/balances$"
+        - "/v1/prison/.*/prisoners/.*/balances/[^/]*$"
       filters:
     config-test:
       include:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -87,6 +87,7 @@ authorisation:
         - "/v1/prison/prisoners/[^/]*$"
         - "/v1/prison/prisoners"
         - "/v1/prison/.*/prisoners/.*/balances$"
+        - "/v1/prison/.*/prisoners/.*/balances/[^/]*$"
     config-test:
       include:
         - "/v1/config/authorisation"
@@ -96,6 +97,7 @@ authorisation:
     limited-prisons:
       include:
         - "/v1/prison/.*/prisoners/.*/balances$"
+        - "/v1/prison/.*/prisoners/.*/balances/[^/]*$"
       filters:
         prisons:
           - XYZ

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -170,77 +170,69 @@ class BalancesControllerTest(
       verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, accountCode, null)
     }
 
-//    it("returns the correct balances data") {
-//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(
-//            Response(
-//                data = balance,
-//            ),
-//        )
-//        val result = mockMvc.performAuthorised(balancesPath)
-//        result.response.contentAsString.shouldContain(
-//            """
-//          "data": {
-//            "balances": [
-//              {
-//                "accountCode": "spends",
-//                "amount": 101
-//              },
-//              {
-//                "accountCode": "savings",
-//                "amount": 102
-//              },
-//              {
-//                "accountCode": "cash",
-//                "amount": 103
-//              }
-//            ]
-//          }
-//        """.removeWhitespaceAndNewlines(),
-//        )
-//    }
-//
-//    it("calls the API with the correct filters") {
-//        mockMvc.performAuthorisedWithCN(balancesPath, "limited-prisons")
-//        verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf("XYZ")))
-//    }
-//
-//    it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
-//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
-//            Response(
-//                data = null,
-//                errors =
-//                    listOf(
-//                        UpstreamApiError(
-//                            causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
-//                            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-//                        ),
-//                    ),
-//            ),
-//        )
-//
-//        val result = mockMvc.performAuthorised(balancesPath)
-//
-//        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-//    }
-//
-//    it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
-//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(
-//            Response(
-//                data = null,
-//                errors =
-//                    listOf(
-//                        UpstreamApiError(
-//                            causedBy = UpstreamApi.NOMIS,
-//                            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-//                        ),
-//                    ),
-//            ),
-//        )
-//
-//        val result = mockMvc.performAuthorised(balancesPath)
-//
-//        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-//    }
+    it("returns the correct balance data when given an account code") {
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+        Response(
+          data = singleBalance,
+        ),
+      )
+      val result = mockMvc.performAuthorised(accountCodePath)
+      result.response.contentAsString.shouldContain(
+        """
+          "data": {
+            "balances": [
+              {
+                "accountCode": "spends",
+                "amount": 201
+              }
+            ]
+          }
+        """.removeWhitespaceAndNewlines(),
+      )
+    }
+
+    it("calls the API with the correct filters") {
+      mockMvc.performAuthorisedWithCN(accountCodePath, "limited-prisons")
+      verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, accountCode, filters = ConsumerFilters(prisons = listOf("XYZ")))
+    }
+
+    it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode)).thenReturn(
+        Response(
+          data = null,
+          errors =
+            listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+        ),
+      )
+
+      val result = mockMvc.performAuthorised(accountCodePath)
+
+      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+    }
+
+    it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+        Response(
+          data = null,
+          errors =
+            listOf(
+              UpstreamApiError(
+                causedBy = UpstreamApi.NOMIS,
+                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+              ),
+            ),
+        ),
+      )
+
+      val result = mockMvc.performAuthorised(accountCodePath)
+
+      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+    }
 //
 //    it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
 //        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -87,7 +87,7 @@ class BalancesControllerTest(
 
     it("calls the API with the correct filters") {
       mockMvc.performAuthorisedWithCN(basePath, "limited-prisons")
-      verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, ConsumerFilters(prisons = listOf("XYZ")))
+      verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf("XYZ")))
     }
 
     it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -36,10 +35,11 @@ class BalancesControllerTest(
 ) : DescribeSpec({
     val hmppsId = "200313116M"
     val prisonId = "ABC"
+    val accountCode = "spends"
 
-    val basePath = "/v1/prison/$prisonId/prisoners/$hmppsId/balances"
+    val balancesPath = "/v1/prison/$prisonId/prisoners/$hmppsId/balances"
+    val accountCodePath = "/v1/prison/$prisonId/prisoners/$hmppsId/balances/$accountCode"
     val mockMvc = IntegrationAPIMockMvc(springMockMvc)
-    val objectMapper = ObjectMapper()
     val balance =
       Balances(
         balances =
@@ -49,20 +49,27 @@ class BalancesControllerTest(
             AccountBalance(accountCode = "cash", amount = 103),
           ),
       )
+    val singleBalance =
+      Balances(
+        balances =
+          listOf(
+            AccountBalance(accountCode = "spends", amount = 201),
+          ),
+      )
 
     it("gets the balances for a person with the matching ID") {
-      mockMvc.performAuthorised(basePath)
+      mockMvc.performAuthorised(balancesPath)
 
-      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, null)
+      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, filters = null)
     }
 
     it("returns the correct balances data") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
         Response(
           data = balance,
         ),
       )
-      val result = mockMvc.performAuthorised(basePath)
+      val result = mockMvc.performAuthorised(balancesPath)
       result.response.contentAsString.shouldContain(
         """
           "data": {
@@ -86,7 +93,7 @@ class BalancesControllerTest(
     }
 
     it("calls the API with the correct filters") {
-      mockMvc.performAuthorisedWithCN(basePath, "limited-prisons")
+      mockMvc.performAuthorisedWithCN(balancesPath, "limited-prisons")
       verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf("XYZ")))
     }
 
@@ -104,13 +111,13 @@ class BalancesControllerTest(
         ),
       )
 
-      val result = mockMvc.performAuthorised(basePath)
+      val result = mockMvc.performAuthorised(balancesPath)
 
       result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
     }
 
     it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
         Response(
           data = null,
           errors =
@@ -123,13 +130,13 @@ class BalancesControllerTest(
         ),
       )
 
-      val result = mockMvc.performAuthorised(basePath)
+      val result = mockMvc.performAuthorised(balancesPath)
 
       result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
     }
 
     it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
         Response(
           data = null,
           errors =
@@ -142,18 +149,125 @@ class BalancesControllerTest(
         ),
       )
 
-      val result = mockMvc.performAuthorised(basePath)
+      val result = mockMvc.performAuthorised(balancesPath)
 
       result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
     }
 
     it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenThrow(
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenThrow(
         IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
       )
 
-      val result = mockMvc.performAuthorised(basePath)
+      val result = mockMvc.performAuthorised(balancesPath)
 
       result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
     }
+
+    it("gets the balance for the relevant account code for a person with the matching ID") {
+      mockMvc.performAuthorised(accountCodePath)
+
+      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, accountCode, null)
+    }
+
+//    it("returns the correct balances data") {
+//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(
+//            Response(
+//                data = balance,
+//            ),
+//        )
+//        val result = mockMvc.performAuthorised(balancesPath)
+//        result.response.contentAsString.shouldContain(
+//            """
+//          "data": {
+//            "balances": [
+//              {
+//                "accountCode": "spends",
+//                "amount": 101
+//              },
+//              {
+//                "accountCode": "savings",
+//                "amount": 102
+//              },
+//              {
+//                "accountCode": "cash",
+//                "amount": 103
+//              }
+//            ]
+//          }
+//        """.removeWhitespaceAndNewlines(),
+//        )
+//    }
+//
+//    it("calls the API with the correct filters") {
+//        mockMvc.performAuthorisedWithCN(balancesPath, "limited-prisons")
+//        verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf("XYZ")))
+//    }
+//
+//    it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
+//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
+//            Response(
+//                data = null,
+//                errors =
+//                    listOf(
+//                        UpstreamApiError(
+//                            causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+//                            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+//                        ),
+//                    ),
+//            ),
+//        )
+//
+//        val result = mockMvc.performAuthorised(balancesPath)
+//
+//        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+//    }
+//
+//    it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
+//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(
+//            Response(
+//                data = null,
+//                errors =
+//                    listOf(
+//                        UpstreamApiError(
+//                            causedBy = UpstreamApi.NOMIS,
+//                            type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+//                        ),
+//                    ),
+//            ),
+//        )
+//
+//        val result = mockMvc.performAuthorised(balancesPath)
+//
+//        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+//    }
+//
+//    it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
+//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(
+//            Response(
+//                data = null,
+//                errors =
+//                    listOf(
+//                        UpstreamApiError(
+//                            type = UpstreamApiError.Type.BAD_REQUEST,
+//                            causedBy = UpstreamApi.NOMIS,
+//                        ),
+//                    ),
+//            ),
+//        )
+//
+//        val result = mockMvc.performAuthorised(balancesPath)
+//
+//        result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
+//    }
+//
+//    it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
+//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenThrow(
+//            IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
+//        )
+//
+//        val result = mockMvc.performAuthorised(balancesPath)
+//
+//        result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
+//    }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -252,14 +252,14 @@ class BalancesControllerTest(
 
       result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
     }
-//
-//    it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
-//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenThrow(
-//            IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
-//        )
-//
-//        val result = mockMvc.performAuthorised(balancesPath)
-//
-//        result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
-//    }
+
+    it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenThrow(
+        IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
+      )
+
+      val result = mockMvc.performAuthorised(accountCodePath)
+
+      result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
+    }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -233,25 +233,25 @@ class BalancesControllerTest(
 
       result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
     }
-//
-//    it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
-//        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenReturn(
-//            Response(
-//                data = null,
-//                errors =
-//                    listOf(
-//                        UpstreamApiError(
-//                            type = UpstreamApiError.Type.BAD_REQUEST,
-//                            causedBy = UpstreamApi.NOMIS,
-//                        ),
-//                    ),
-//            ),
-//        )
-//
-//        val result = mockMvc.performAuthorised(balancesPath)
-//
-//        result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
-//    }
+
+    it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
+      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+        Response(
+          data = null,
+          errors =
+            listOf(
+              UpstreamApiError(
+                type = UpstreamApiError.Type.BAD_REQUEST,
+                causedBy = UpstreamApi.NOMIS,
+              ),
+            ),
+        ),
+      )
+
+      val result = mockMvc.performAuthorised(accountCodePath)
+
+      result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
+    }
 //
 //    it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
 //        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters=null)).thenThrow(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -167,11 +167,11 @@ class BalancesControllerTest(
     it("gets the balance for the relevant account code for a person with the matching ID") {
       mockMvc.performAuthorised(accountCodePath)
 
-      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, accountCode, null)
+      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).getBalance(prisonId, hmppsId, accountCode, null)
     }
 
     it("returns the correct balance data when given an account code") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
         Response(
           data = singleBalance,
         ),
@@ -193,11 +193,11 @@ class BalancesControllerTest(
 
     it("calls the API with the correct filters") {
       mockMvc.performAuthorisedWithCN(accountCodePath, "limited-prisons")
-      verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, accountCode, filters = ConsumerFilters(prisons = listOf("XYZ")))
+      verify(getBalancesForPersonService, times(1)).getBalance(prisonId, hmppsId, accountCode, filters = ConsumerFilters(prisons = listOf("XYZ")))
     }
 
     it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode)).thenReturn(
+      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode)).thenReturn(
         Response(
           data = null,
           errors =
@@ -216,7 +216,7 @@ class BalancesControllerTest(
     }
 
     it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
         Response(
           data = null,
           errors =
@@ -235,7 +235,7 @@ class BalancesControllerTest(
     }
 
     it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
         Response(
           data = null,
           errors =
@@ -254,7 +254,7 @@ class BalancesControllerTest(
     }
 
     it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, accountCode, filters = null)).thenThrow(
+      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenThrow(
         IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/BalanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/BalanceIntegrationTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.prison
 
 import org.junit.jupiter.api.Test
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
@@ -9,11 +8,13 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationT
 class BalanceIntegrationTest : IntegrationTestBase() {
   private final val hmppsId = "G2996UX"
   private final val prisonId = "ABC"
-  private final val basePrisonPath = "/v1/prison/$prisonId/prisoners/$hmppsId/balances"
+  private final val accountCode = "savings"
+  private final val balancePrisonPath = "/v1/prison/$prisonId/prisoners/$hmppsId/balances"
+  private final val accountCodePrisonPath = "/v1/prison/$prisonId/prisoners/$hmppsId/balances/$accountCode"
 
   @Test
   fun `return a list of a prisoner's balances`() {
-    callApi(basePrisonPath)
+    callApi(balancePrisonPath)
       .andExpect(status().isOk)
       .andExpect(
         content().json(
@@ -32,6 +33,28 @@ class BalanceIntegrationTest : IntegrationTestBase() {
               {
                 "accountCode": "cash",
                 "amount": 13565
+              }
+            ]
+          }
+        }
+      """,
+        ),
+      )
+  }
+
+  @Test
+  fun `return a single balance for a prisoner given an account code`() {
+    callApi(accountCodePrisonPath)
+      .andExpect(status().isOk)
+      .andExpect(
+        content().json(
+          """
+        {
+          "data": {
+            "balances": [
+              {
+                "accountCode": "savings",
+                "amount": 12344
               }
             ]
           }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
@@ -194,6 +194,4 @@ internal class GetBalancesForPersonServiceTest(
       result.data.shouldBe(null)
       result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.NOMIS, UpstreamApiError.Type.ENTITY_NOT_FOUND, "Not found")))
     }
-    // returns 500 if account not allowed
-    // prison filter still works
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
@@ -174,14 +174,14 @@ internal class GetBalancesForPersonServiceTest(
     }
 
     it("returns a balance when given a valid account code") {
-      val result = getBalancesForPersonService.execute(prisonId = prisonId, hmppsId = hmppsId, accountCode = accountCode)
+      val result = getBalancesForPersonService.getBalance(prisonId = prisonId, hmppsId = hmppsId, accountCode = accountCode)
 
       result.data.shouldBe(singleBalance)
     }
 
     it("returns an error when given an invalid account code") {
       val wrongAccountCode = "invalid_account_code"
-      val result = getBalancesForPersonService.execute(prisonId = prisonId, hmppsId = hmppsId, accountCode = wrongAccountCode)
+      val result = getBalancesForPersonService.getBalance(prisonId = prisonId, hmppsId = hmppsId, accountCode = wrongAccountCode)
 
       result.data.shouldBe(null)
       result.errors.shouldBe(listOf(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.NOMIS)))
@@ -189,7 +189,7 @@ internal class GetBalancesForPersonServiceTest(
 
     it("returns null when balance is requested from an unapproved prison") {
       val wrongPrisonId = "XYZ"
-      val result = getBalancesForPersonService.execute(wrongPrisonId, hmppsId, accountCode, ConsumerFilters(prisons = listOf("ABC")))
+      val result = getBalancesForPersonService.getBalance(wrongPrisonId, hmppsId, accountCode, ConsumerFilters(prisons = listOf("ABC")))
 
       result.data.shouldBe(null)
       result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.NOMIS, UpstreamApiError.Type.ENTITY_NOT_FOUND, "Not found")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
@@ -35,8 +35,7 @@ internal class GetBalancesForPersonServiceTest(
     val nomisSpends = 101
     val nomisSavings = 102
     val nomisCash = 103
-    val accountCode = "testAccount"
-    val testAccountAmount = 100
+    val accountCode = "spends"
 
     beforeEach {
       Mockito.reset(getPersonService)
@@ -70,7 +69,7 @@ internal class GetBalancesForPersonServiceTest(
       Balances(
         balances =
           listOf(
-            AccountBalance(accountCode = accountCode, amount = testAccountAmount),
+            AccountBalance(accountCode = accountCode, amount = nomisSpends),
           ),
       )
 
@@ -174,13 +173,20 @@ internal class GetBalancesForPersonServiceTest(
       result.data.shouldBe(balance)
     }
 
-    it("returns a single balance when given an account code") {
+    it("returns a balance when given a valid account code") {
       val result = getBalancesForPersonService.execute(prisonId = prisonId, hmppsId = hmppsId, accountCode = accountCode)
 
       result.data.shouldBe(singleBalance)
     }
 
-    // returns 400 if not an allowable account code
+    it("returns an error when given an invalid account code") {
+      val wrongAccountCode = "invalid_account_code"
+      val result = getBalancesForPersonService.execute(prisonId = prisonId, hmppsId = hmppsId, accountCode = wrongAccountCode)
+
+      result.data.shouldBe(null)
+      result.errors.shouldBe(listOf(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.NOMIS)))
+    }
+
     // returns 500 if account not allowed
     // prison filter still works
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
@@ -187,6 +187,13 @@ internal class GetBalancesForPersonServiceTest(
       result.errors.shouldBe(listOf(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.NOMIS)))
     }
 
+    it("returns null when balance is requested from an unapproved prison") {
+      val wrongPrisonId = "XYZ"
+      val result = getBalancesForPersonService.execute(wrongPrisonId, hmppsId, accountCode, ConsumerFilters(prisons = listOf("ABC")))
+
+      result.data.shouldBe(null)
+      result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.NOMIS, UpstreamApiError.Type.ENTITY_NOT_FOUND, "Not found")))
+    }
     // returns 500 if account not allowed
     // prison filter still works
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetBalancesForPersonServiceTest.kt
@@ -55,7 +55,7 @@ internal class GetBalancesForPersonServiceTest(
         ),
       )
     }
-    val balance =
+    val balances =
       Balances(
         balances =
           listOf(
@@ -88,7 +88,7 @@ internal class GetBalancesForPersonServiceTest(
     it("returns a person's account balances given a Hmpps ID") {
       val result = getBalancesForPersonService.execute(prisonId, hmppsId)
 
-      result.data.shouldBe(balance)
+      result.data.shouldBe(balances)
     }
 
     it("records upstream API errors") {
@@ -170,7 +170,7 @@ internal class GetBalancesForPersonServiceTest(
     it("returns balances when requested from an approved prison") {
       val result = getBalancesForPersonService.execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf(prisonId)))
 
-      result.data.shouldBe(balance)
+      result.data.shouldBe(balances)
     }
 
     it("returns a balance when given a valid account code") {


### PR DESCRIPTION
Addition of an endpoint to get a singular balance for a person. This relies on the same gateway call and service as the /v1/prison/{prisonId}/prisoners/{hmppsId}/balances endpoint thanks to some additional logic on the service layer to handle the account code being provided.