### PR TITLE
HMAI-152 Change bmadley creds to /.* in dev environment 

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -152,13 +152,7 @@ authorisation:
       filters:
     bmadley:
       include:
-        - "/v1/persons"
-        - "/v1/persons/[^/]*$"
-        - "/v1/prison/prisoners/[^/]*$"
-        - "/v1/prison/prisoners"
-        - "/v1/prison/.*/prisoners/[^/]*/balances$"
-        - "/v1/prison/.*/prisoners/.*/accounts/.*/balances"
-        - "/v1/prison/.*/prisoners/.*/accounts/.*/transactions"
+        - "/.*"
       filters:
     serco:
       include:


### PR DESCRIPTION
Changing bmadley creds to "/.*" in the development environment to allow us to investigate which endpoints are affected by the issue that an upstream APIs should return a 400 BAD REQUEST when the gateways throw an exception, but that isn’t handled in all cases. This is being converted into a 500 response with an unhelpful error message.