### PR TITLE
Add second script to zip consumer's credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ __pycache__/
 *.key
 *.csr
 *.pem
+*.enc
 
 # Localstack
 localstack/cache

--- a/docs/guides/setting-up-a-new-consumer.md
+++ b/docs/guides/setting-up-a-new-consumer.md
@@ -124,6 +124,12 @@ tar cvfz hmpps-integration-api-preprod.tar.gz preprod/preprod-client.key preprod
 openssl enc -aes-256-cbc -pbkdf2 -iter 310000 -md sha256 -salt -in hmpps-integration-api-preprod.tar.gz -out hmpps-integration-api-preprod.tar.gz.enc -pass file:./symmetric.key
 ```
 
+### Alternatively
+
+If the client's public key is named `hmpps-integration-api-cred-exchange-public-key.pem`, change directory into the `scripts/client_certificates` directory and run the `zip.sh` command. This should complete the above steps.
+
+### Accessing the credentials
+
 We can now send the **encrypted** symmetric key (`symmetric.key.enc`) and **encrypted** access credentials (`hmpps-integration-api-preprod.tar.gz.enc`) to the client via email. The client may now decrypt the symmetric key using their private key and subsequently the access credentials using the symmetric key
 
 ```Bash

--- a/scripts/client_certificates/zip.sh
+++ b/scripts/client_certificates/zip.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+read_certificate_arguments() {
+  echo "Environment: (dev, preprod or prod)"
+  read environment
+  echo "Client identifier (no spaces, lowercase) that will be used for authorisation: e.g. mapps"
+  read client
+}
+
+get_api_key() {
+  api_key=`kubectl -n hmpps-integration-api-dev get secrets consumer-api-keys -o json | jq -r .data.$client | base64 -d`
+  echo -n $api_key > $environment-$client-api-key
+}
+
+generate_symmetric_key() {
+  # Create a symmetric key
+  head /dev/urandom | sha256sum > symmetric.key
+  # Encrypt with client's public key
+  openssl pkeyutl -encrypt -pubin -inkey hmpps-integration-api-cred-exchange-public-key.pem -in symmetric.key -out symmetric.key.enc
+}
+
+zip_files() {
+  # Create a tarball of the access credentials
+  tar cvfz hmpps-integration-api-$environment.tar.gz $environment-$client-api-key $environment-$client-client.key $environment-$client-client.pem
+  # Encrypt using symmetric key
+  openssl enc -aes-256-cbc -pbkdf2 -iter 310000 -md sha256 -salt -in hmpps-integration-api-$environment.tar.gz -out hmpps-integration-api-$environment.tar.gz.enc -pass file:./symmetric.key
+}
+
+main() {
+  read_certificate_arguments
+  get_api_key
+  generate_symmetric_key
+  zip_files
+}
+
+main

--- a/scripts/client_certificates/zip.sh
+++ b/scripts/client_certificates/zip.sh
@@ -9,7 +9,7 @@ read_certificate_arguments() {
 }
 
 get_api_key() {
-  api_key=`kubectl -n hmpps-integration-api-dev get secrets consumer-api-keys -o json | jq -r .data.$client | base64 -d`
+  api_key=`kubectl -n hmpps-integration-api-$environment get secrets consumer-api-keys -o json | jq -r .data.$client | base64 -d`
   echo -n $api_key > $environment-$client-api-key
 }
 


### PR DESCRIPTION
Add a second script to zip and encrypt consumer's credentials. If this goes well, then I will combine the two scripts to be a single command that can be run after necessary prep (API Key generated, Public Key from consumer, consumer config set up) has been completed.