### PR TITLE
HMAI-202 Remove redundant request body from transaction endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/OpenAPIConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/OpenAPIConfig.kt
@@ -14,7 +14,6 @@ import org.springdoc.core.customizers.GlobalOpenApiCustomizer
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.TransactionRequest
 
 @OpenAPIDefinition(
   info =
@@ -85,17 +84,6 @@ class OpenAPIConfig {
                 "status" to Schema<Int>().type("number").example(409),
                 "userMessage" to Schema<String>().type("string").example("Conflict"),
                 "developerMessage" to Schema<String>().type("string").example("Duplicate post - The client_unique_ref has been used before"),
-              ),
-            ),
-          ).addSchemas(
-            "TransactionRequest",
-            Schema<TransactionRequest>().description("A request to create a transaction").properties(
-              mapOf(
-                "type" to Schema<String>().type("string").example("CART"),
-                "description" to Schema<String>().type("string").example("A description of the transaction"),
-                "amount" to Schema<Int>().type("number").example(1000),
-                "clientTransactionId" to Schema<String>().type("string").example("123456"),
-                "clientUniqueRef" to Schema<String>().type("string").example("123456"),
               ),
             ),
           )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/TransactionsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/TransactionsController.kt
@@ -33,7 +33,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.PostTransaction
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.PostTransactionTransferForPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 import java.time.LocalDate
-import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 
 @RestController
 @RequestMapping("/v1/prison/{prisonId}/prisoners/{hmppsId}")
@@ -180,17 +179,6 @@ class TransactionsController(
   @Operation(
     summary = "Post a transaction.",
     description = "<a href=\"#schema-transactionrequest\">Request body</a><br><br><b>Applicable filters</b>: <ul><li>prisons</li></ul>",
-    requestBody =
-      SwaggerRequestBody(
-        description = "The transaction request body.",
-        required = true,
-        content = [
-          Content(
-            schema =
-              Schema(ref = "#/components/schemas/TransactionRequest"),
-          ),
-        ],
-      ),
     responses = [
       ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully created a transaction."),
       ApiResponse(


### PR DESCRIPTION
Now we have implemented the JS solution, we can remove these redundant request body and schema from the transaction controller and openApiConfig.