### PR TITLE
HmppsAuth Exception and return 502 response when it is handled.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
@@ -49,7 +49,7 @@ class HmppsIntegrationApiExceptionHandler {
 
   @ExceptionHandler(HmppsAuthFailedException::class)
   fun handleAuthenticationFailedException(e: HmppsAuthFailedException): ResponseEntity<ErrorResponse?>? {
-    logAndCapture("Authentication error: {}", e)
+    logAndCapture("Authentication error in HMPPS Auth: {}", e)
     return ResponseEntity
       .status(BAD_GATEWAY)
       .body(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
@@ -6,16 +6,15 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
-import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.AuthenticationFailedException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ConflictFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.HmppsAuthFailedException
 
 @RestControllerAdvice
 class HmppsIntegrationApiExceptionHandler {
@@ -47,14 +46,14 @@ class HmppsIntegrationApiExceptionHandler {
       )
   }
 
-  @ExceptionHandler(AuthenticationFailedException::class)
-  fun handleAuthenticationFailedException(e: AuthenticationFailedException): ResponseEntity<ErrorResponse?>? {
+  @ExceptionHandler(HmppsAuthFailedException::class)
+  fun handleAuthenticationFailedException(e: HmppsAuthFailedException): ResponseEntity<ErrorResponse?>? {
     logAndCapture("Authentication error: {}", e)
     return ResponseEntity
-      .status(FORBIDDEN)
+      .status(INTERNAL_SERVER_ERROR)
       .body(
         ErrorResponse(
-          status = FORBIDDEN,
+          status = INTERNAL_SERVER_ERROR,
           developerMessage = "Authentication error: ${e.message}",
           userMessage = e.message,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
@@ -4,6 +4,7 @@ import io.sentry.Sentry
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_GATEWAY
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
@@ -50,10 +51,10 @@ class HmppsIntegrationApiExceptionHandler {
   fun handleAuthenticationFailedException(e: HmppsAuthFailedException): ResponseEntity<ErrorResponse?>? {
     logAndCapture("Authentication error: {}", e)
     return ResponseEntity
-      .status(INTERNAL_SERVER_ERROR)
+      .status(BAD_GATEWAY)
       .body(
         ErrorResponse(
-          status = INTERNAL_SERVER_ERROR,
+          status = BAD_GATEWAY,
           developerMessage = "Authentication error: ${e.message}",
           userMessage = e.message,
         ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/exception/HmppsAuthFailedException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/exception/HmppsAuthFailedException.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
-@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+@ResponseStatus(HttpStatus.BAD_GATEWAY)
 class HmppsAuthFailedException(
   message: String,
 ) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/exception/HmppsAuthFailedException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/exception/HmppsAuthFailedException.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
-@ResponseStatus(HttpStatus.FORBIDDEN)
-class AuthenticationFailedException(
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+class HmppsAuthFailedException(
   message: String,
 ) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGateway.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.AuthenticationFailedException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.HmppsAuthFailedException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Credentials
 
 @Component
@@ -36,11 +36,11 @@ class HmppsAuthGateway(
 
       JSONParser(response).parseObject()["access_token"].toString()
     } catch (exception: WebClientRequestException) {
-      throw AuthenticationFailedException("Connection to ${exception.uri.authority} failed for $service.")
+      throw HmppsAuthFailedException("Connection to ${exception.uri.authority} failed for $service.")
     } catch (exception: WebClientResponseException.ServiceUnavailable) {
-      throw AuthenticationFailedException("${exception.request?.uri?.authority} is unavailable for $service.")
+      throw HmppsAuthFailedException("${exception.request?.uri?.authority} is unavailable for $service.")
     } catch (exception: WebClientResponseException.Unauthorized) {
-      throw AuthenticationFailedException("Invalid credentials used for $service.")
+      throw HmppsAuthFailedException("Invalid credentials used for $service.")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/HmppsAuthGatewayTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.AuthenticationFailedException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.HmppsAuthFailedException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 
 @ActiveProfiles("test")
@@ -33,7 +33,7 @@ class HmppsAuthGatewayTest(
       hmppsAuthMockServer.stop()
 
       val exception =
-        shouldThrow<AuthenticationFailedException> {
+        shouldThrow<HmppsAuthFailedException> {
           hmppsAuthGateway.getClientToken("NOMIS")
         }
 
@@ -44,7 +44,7 @@ class HmppsAuthGatewayTest(
       hmppsAuthMockServer.stubServiceUnavailableForGetOAuthToken()
 
       val exception =
-        shouldThrow<AuthenticationFailedException> {
+        shouldThrow<HmppsAuthFailedException> {
           hmppsAuthGateway.getClientToken("NOMIS")
         }
 
@@ -55,7 +55,7 @@ class HmppsAuthGatewayTest(
       hmppsAuthMockServer.stubUnauthorizedForGetOAAuthToken()
 
       val exception =
-        shouldThrow<AuthenticationFailedException> {
+        shouldThrow<HmppsAuthFailedException> {
           hmppsAuthGateway.getClientToken("NOMIS")
         }
 


### PR DESCRIPTION
1. This exception is exclusively thrown by the HMPPS Auth gateway, so have named it to match this.
2. There is no solution for the the client when there is an error in HMPPS Auth Gateway, so a 403 response is misleading. 502 better captures the problem