### PR TITLE
HMAI-169 Handling empty response from Ndelius MappaDetails endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailController.kt
@@ -44,6 +44,7 @@ class MappaDetailController(
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
     }
+
     auditService.createEvent("GET_MAPPA_DETAIL", mapOf("hmppsId" to hmppsId))
     return DataResponse(response.data)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailController.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.ValidationException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -43,6 +44,10 @@ class MappaDetailController(
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
+    }
+
+    if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
+      throw ValidationException("Invalid HMPPS ID: $hmppsId")
     }
 
     auditService.createEvent("GET_MAPPA_DETAIL", mapOf("hmppsId" to hmppsId))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/MappaDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/MappaDetail.kt
@@ -17,4 +17,6 @@ data class MappaDetail(
   val reviewDate: String? = null,
   @Schema(example = "Mappa Detail for X00001")
   val notes: String? = null,
-)
+) {
+  fun isNotPopulated(): Boolean = level == null && levelDescription == null && category == null && categoryDescription == null && startDate == null && reviewDate == null && notes == null
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/MappaDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/MappaDetail.kt
@@ -17,6 +17,4 @@ data class MappaDetail(
   val reviewDate: String? = null,
   @Schema(example = "Mappa Detail for X00001")
   val notes: String? = null,
-) {
-  fun isNotPopulated(): Boolean = level == null && levelDescription == null && category == null && categoryDescription == null && startDate == null && reviewDate == null && notes == null
-}
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetMappaDetailForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetMappaDetailForPersonService.kt
@@ -30,7 +30,8 @@ class GetMappaDetailForPersonService(
       nDeliusMappaDetailResponse = nDeliusGateway.getMappaDetailForPerson(id = deliusCrn)
 
       if (nDeliusMappaDetailResponse.data != null) {
-        if (nDeliusMappaDetailResponse.data!!.isNotPopulated()) {
+        val mappaDetail = nDeliusMappaDetailResponse.data!!
+        if (isNotPopulated(mappaDetail)) {
           nDeliusMappaDetailResponse.errors = listOf(UpstreamApiError(causedBy = UpstreamApi.NDELIUS, type = UpstreamApiError.Type.ENTITY_NOT_FOUND))
         }
       }
@@ -41,4 +42,6 @@ class GetMappaDetailForPersonService(
       errors = nDeliusMappaDetailResponse.errors,
     )
   }
+
+  private fun isNotPopulated(ndeliusMappaData: MappaDetail?): Boolean = ndeliusMappaData?.level == null && ndeliusMappaData?.levelDescription == null && ndeliusMappaData?.category == null && ndeliusMappaData?.categoryDescription == null && ndeliusMappaData?.startDate == null && ndeliusMappaData?.reviewDate == null && ndeliusMappaData?.notes == null
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetMappaDetailForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetMappaDetailForPersonService.kt
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.MappaDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 
 @Service
 class GetMappaDetailForPersonService(
@@ -14,11 +16,24 @@ class GetMappaDetailForPersonService(
   fun execute(hmppsId: String): Response<MappaDetail?> {
     val personResponse = getPersonService.execute(hmppsId = hmppsId)
 
+    if (personResponse.errors.isNotEmpty()) {
+      return Response(
+        data = null,
+        errors = personResponse.errors,
+      )
+    }
+
     val deliusCrn = personResponse.data?.identifiers?.deliusCrn
     var nDeliusMappaDetailResponse: Response<MappaDetail?> = Response(data = MappaDetail())
 
     if (deliusCrn != null) {
       nDeliusMappaDetailResponse = nDeliusGateway.getMappaDetailForPerson(id = deliusCrn)
+
+      if (nDeliusMappaDetailResponse.data != null) {
+        if (nDeliusMappaDetailResponse.data!!.isNotPopulated()) {
+          nDeliusMappaDetailResponse.errors = listOf(UpstreamApiError(causedBy = UpstreamApi.NDELIUS, type = UpstreamApiError.Type.ENTITY_NOT_FOUND))
+        }
+      }
     }
 
     return Response(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -54,21 +54,22 @@ class BalancesControllerTest(
         balance = AccountBalance(accountCode = "spends", amount = 201),
       )
 
-    it("gets the balances for a person with the matching ID") {
-      mockMvc.performAuthorised(balancesPath)
+    describe("all balances tests") {
+      it("gets the balances for a person with the matching ID") {
+        mockMvc.performAuthorised(balancesPath)
 
-      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, filters = null)
-    }
+        verify(getBalancesForPersonService, VerificationModeFactory.times(1)).execute(prisonId, hmppsId, filters = null)
+      }
 
-    it("returns the correct balances data") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
-        Response(
-          data = balance,
-        ),
-      )
-      val result = mockMvc.performAuthorised(balancesPath)
-      result.response.contentAsString.shouldContain(
-        """
+      it("returns the correct balances data") {
+        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
+          Response(
+            data = balance,
+          ),
+        )
+        val result = mockMvc.performAuthorised(balancesPath)
+        result.response.contentAsString.shouldContain(
+          """
           "data": {
             "balances": [
               {
@@ -86,96 +87,96 @@ class BalancesControllerTest(
             ]
           }
         """.removeWhitespaceAndNewlines(),
-      )
-    }
+        )
+      }
 
-    it("calls the API with the correct filters") {
-      mockMvc.performAuthorisedWithCN(balancesPath, "limited-prisons")
-      verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf("XYZ")))
-    }
+      it("calls the balances endpoint with the correct filters") {
+        mockMvc.performAuthorisedWithCN(balancesPath, "limited-prisons")
+        verify(getBalancesForPersonService, times(1)).execute(prisonId, hmppsId, filters = ConsumerFilters(prisons = listOf("XYZ")))
+      }
 
-    it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
-        Response(
-          data = null,
-          errors =
-            listOf(
-              UpstreamApiError(
-                causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
-                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+      it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
+        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, null)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
               ),
-            ),
-        ),
-      )
+          ),
+        )
 
-      val result = mockMvc.performAuthorised(balancesPath)
+        val result = mockMvc.performAuthorised(balancesPath)
 
-      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-    }
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
 
-    it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
-        Response(
-          data = null,
-          errors =
-            listOf(
-              UpstreamApiError(
-                causedBy = UpstreamApi.NOMIS,
-                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+      it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
+        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  causedBy = UpstreamApi.NOMIS,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
               ),
-            ),
-        ),
-      )
+          ),
+        )
 
-      val result = mockMvc.performAuthorised(balancesPath)
+        val result = mockMvc.performAuthorised(balancesPath)
 
-      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-    }
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
 
-    it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
-        Response(
-          data = null,
-          errors =
-            listOf(
-              UpstreamApiError(
-                type = UpstreamApiError.Type.BAD_REQUEST,
-                causedBy = UpstreamApi.NOMIS,
+      it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
+        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  type = UpstreamApiError.Type.BAD_REQUEST,
+                  causedBy = UpstreamApi.NOMIS,
+                ),
               ),
-            ),
-        ),
-      )
+          ),
+        )
 
-      val result = mockMvc.performAuthorised(balancesPath)
+        val result = mockMvc.performAuthorised(balancesPath)
 
-      result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
-    }
+        result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
+      }
 
-    it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenThrow(
-        IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
-      )
+      it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
+        whenever(getBalancesForPersonService.execute(prisonId, hmppsId, filters = null)).thenThrow(
+          IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
+        )
 
-      val result = mockMvc.performAuthorised(balancesPath)
+        val result = mockMvc.performAuthorised(balancesPath)
 
-      result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
-    }
+        result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
+      }
 
-    it("gets the balance for the relevant account code for a person with the matching ID") {
-      mockMvc.performAuthorised(accountCodePath)
+      it("gets the balance for the relevant account code for a person with the matching ID") {
+        mockMvc.performAuthorised(accountCodePath)
 
-      verify(getBalancesForPersonService, VerificationModeFactory.times(1)).getBalance(prisonId, hmppsId, accountCode, null)
-    }
+        verify(getBalancesForPersonService, VerificationModeFactory.times(1)).getBalance(prisonId, hmppsId, accountCode, null)
+      }
 
-    it("returns the correct balance data when given an account code") {
-      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
-        Response(
-          data = singleBalance,
-        ),
-      )
-      val result = mockMvc.performAuthorised(accountCodePath)
-      result.response.contentAsString.shouldContain(
-        """
+      it("returns the correct balance data when given an account code") {
+        whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+          Response(
+            data = singleBalance,
+          ),
+        )
+        val result = mockMvc.performAuthorised(accountCodePath)
+        result.response.contentAsString.shouldContain(
+          """
           "data": {
             "balance":
               {
@@ -185,78 +186,82 @@ class BalancesControllerTest(
 
           }
         """.removeWhitespaceAndNewlines(),
-      )
+        )
+      }
     }
 
-    it("calls the API with the correct filters") {
-      mockMvc.performAuthorisedWithCN(accountCodePath, "limited-prisons")
-      verify(getBalancesForPersonService, times(1)).getBalance(prisonId, hmppsId, accountCode, filters = ConsumerFilters(prisons = listOf("XYZ")))
-    }
+    describe("account code balance tests") {
 
-    it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
-      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode)).thenReturn(
-        Response(
-          data = null,
-          errors =
-            listOf(
-              UpstreamApiError(
-                causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
-                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+      it("calls the account code balances endpoint with the correct filters") {
+        mockMvc.performAuthorisedWithCN(accountCodePath, "limited-prisons")
+        verify(getBalancesForPersonService, times(1)).getBalance(prisonId, hmppsId, accountCode, filters = ConsumerFilters(prisons = listOf("XYZ")))
+      }
+
+      it("returns a 404 NOT FOUND status code when person isn't found in probation offender search") {
+        whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  causedBy = UpstreamApi.PROBATION_OFFENDER_SEARCH,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
               ),
-            ),
-        ),
-      )
+          ),
+        )
 
-      val result = mockMvc.performAuthorised(accountCodePath)
+        val result = mockMvc.performAuthorised(accountCodePath)
 
-      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-    }
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
 
-    it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
-      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
-        Response(
-          data = null,
-          errors =
-            listOf(
-              UpstreamApiError(
-                causedBy = UpstreamApi.NOMIS,
-                type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+      it("returns a 404 NOT FOUND status code when person isn't found in Nomis") {
+        whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  causedBy = UpstreamApi.NOMIS,
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                ),
               ),
-            ),
-        ),
-      )
+          ),
+        )
 
-      val result = mockMvc.performAuthorised(accountCodePath)
+        val result = mockMvc.performAuthorised(accountCodePath)
 
-      result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
-    }
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+      }
 
-    it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
-        Response(
-          data = null,
-          errors =
-            listOf(
-              UpstreamApiError(
-                type = UpstreamApiError.Type.BAD_REQUEST,
-                causedBy = UpstreamApi.NOMIS,
+      it("returns a 400 BAD REQUEST status code when account isn't found in the upstream API") {
+        whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  type = UpstreamApiError.Type.BAD_REQUEST,
+                  causedBy = UpstreamApi.NOMIS,
+                ),
               ),
-            ),
-        ),
-      )
+          ),
+        )
 
-      val result = mockMvc.performAuthorised(accountCodePath)
+        val result = mockMvc.performAuthorised(accountCodePath)
 
-      result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
-    }
+        result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
+      }
 
-    it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
-      whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenThrow(
-        IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
-      )
+      it("returns a 500 INTERNAL SERVER ERROR status code when balance isn't found in the upstream API") {
+        whenever(getBalancesForPersonService.getBalance(prisonId, hmppsId, accountCode, filters = null)).thenThrow(
+          IllegalStateException("Error occurred while trying to get accounts for person with id: $hmppsId"),
+        )
 
-      val result = mockMvc.performAuthorised(accountCodePath)
+        val result = mockMvc.performAuthorised(accountCodePath)
 
-      result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        result.response.status.shouldBe(HttpStatus.INTERNAL_SERVER_ERROR.value())
+      }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailControllerTest.kt
@@ -113,6 +113,44 @@ internal class MappaDetailControllerTest(
 
           result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
         }
+
+        it("returns a 404 NOT FOUND status code when mappadetails response is empty") {
+          whenever(getMappaDetailForPersonService.execute(hmppsId)).thenReturn(
+            Response(
+              data = MappaDetail(),
+              errors =
+                listOf(
+                  UpstreamApiError(
+                    causedBy = UpstreamApi.NDELIUS,
+                    type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                  ),
+                ),
+            ),
+          )
+
+          val result = mockMvc.performAuthorised(path)
+
+          result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
+        }
+
+        it("returns a 400 NOT FOUND status code when person isn't found") {
+          whenever(getMappaDetailForPersonService.execute(hmppsId)).thenReturn(
+            Response(
+              data = null,
+              errors =
+                listOf(
+                  UpstreamApiError(
+                    causedBy = UpstreamApi.NOMIS,
+                    type = UpstreamApiError.Type.BAD_REQUEST,
+                  ),
+                ),
+            ),
+          )
+
+          val result = mockMvc.performAuthorised(path)
+
+          result.response.status.shouldBe(HttpStatus.BAD_REQUEST.value())
+        }
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetMappaDetailForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetMappaDetailForPersonServiceTest.kt
@@ -79,6 +79,32 @@ internal class GetMappaDetailForPersonServiceTest(
         verify(getPersonService, VerificationModeFactory.times(1)).execute(hmppsId = hmppsId)
       }
 
+      it("returns a 404 when Mappa Detail is null") {
+        whenever(nDeliusGateway.getMappaDetailForPerson(id = deliusCrn)).thenReturn(
+          Response(
+            data =
+              MappaDetail(
+                level = null,
+                levelDescription = null,
+                category = null,
+                categoryDescription = null,
+                startDate = null,
+                reviewDate = null,
+                notes = null,
+              ),
+          ),
+        )
+        val result = getMappaDetailForPersonService.execute(hmppsId)
+        result.errors.shouldBe(
+          listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NDELIUS,
+              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+            ),
+          ),
+        )
+      }
+
       describe("when an upstream API returns an error when looking up a person from a Hmpps ID") {
         beforeEach {
           whenever(getPersonService.execute(hmppsId = hmppsId)).thenReturn(


### PR DESCRIPTION
Currently we return a 500 when we get a miss against ndelius, we should return a 404