### PR TITLE
Experiment with suspending controller methods

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
   }
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.10.1")
   testImplementation("io.kotest:kotest-assertions-json-jvm:5.9.1")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")
   testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdController.kt
@@ -37,7 +37,7 @@ class HmppsIdController(
       ApiResponse(responseCode = "400", description = "Invalid hmppsId."),
     ],
   )
-  fun getHmppsIdByNomisNumber(
+  suspend fun getHmppsIdByNomisNumber(
     @PathVariable nomisNumber: String,
     @RequestAttribute filters: ConsumerFilters?,
   ): DataResponse<HmppsId?> {
@@ -67,7 +67,7 @@ class HmppsIdController(
       ApiResponse(responseCode = "400", description = "Invalid hmppsId."),
     ],
   )
-  fun getNomisNumberByHMPPSID(
+  suspend fun getNomisNumberByHMPPSID(
     @PathVariable hmppsId: String,
   ): DataResponse<NomisNumber?> {
     val response = getHmppsIdService.getNomisNumber(hmppsId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/IntegrationAPIWebClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/IntegrationAPIWebClient.kt
@@ -1,0 +1,68 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+
+class IntegrationAPIWebClient(
+  @Autowired val client: WebTestClient,
+) {
+  fun performAuthorised(path: String): ResponseSpec {
+    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=automated-test-client"
+    return client
+      .get()
+      .uri(path)
+      .header("subject-distinguished-name", subjectDistinguishedName)
+      .exchange()
+  }
+
+  fun performAuthorisedPut(path: String): ResponseSpec {
+    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=automated-test-client"
+    return client
+      .put()
+      .uri(path)
+      .header("subject-distinguished-name", subjectDistinguishedName)
+      .exchange()
+  }
+
+  fun performAuthorisedWithCN(
+    path: String,
+    cn: String,
+  ): ResponseSpec {
+    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=$cn"
+    return client
+      .get()
+      .uri(path)
+      .header("subject-distinguished-name", subjectDistinguishedName)
+      .exchange()
+  }
+
+  fun <T : Any> performAuthorisedPost(
+    path: String,
+    requestBody: T,
+  ): ResponseSpec {
+    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=automated-test-client"
+    return client
+      .post()
+      .uri(path)
+      .header("subject-distinguished-name", subjectDistinguishedName)
+      .header("content-type", "application/json")
+      .bodyValue(requestBody)
+      .exchange()
+  }
+
+  fun <T : Any> performAuthorisedPostWithCN(
+    path: String,
+    cn: String,
+    requestBody: T,
+  ): ResponseSpec {
+    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=$cn"
+    return client
+      .post()
+      .uri(path)
+      .header("subject-distinguished-name", subjectDistinguishedName)
+      .header("content-type", "application/json")
+      .bodyValue(requestBody)
+      .exchange()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/IntegrationAPIWebClient.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/IntegrationAPIWebClient.kt
@@ -1,68 +1,70 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 
 class IntegrationAPIWebClient(
   @Autowired val client: WebTestClient,
 ) {
-  fun performAuthorised(path: String): ResponseSpec {
-    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=automated-test-client"
-    return client
+  private fun setAuthHeader(
+    headers: HttpHeaders,
+    cn: String = "automated-test-client",
+  ) {
+    headers.set("subject-distinguished-name", "C=GB,ST=London,L=London,O=Home Office,CN=$cn")
+  }
+
+  fun performAuthorised(path: String): ResponseSpec =
+    client
       .get()
       .uri(path)
-      .header("subject-distinguished-name", subjectDistinguishedName)
+      .headers { headers -> setAuthHeader(headers) }
       .exchange()
-  }
 
   fun performAuthorisedPut(path: String): ResponseSpec {
     val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=automated-test-client"
     return client
       .put()
       .uri(path)
-      .header("subject-distinguished-name", subjectDistinguishedName)
+      .headers { headers -> setAuthHeader(headers) }
       .exchange()
   }
 
   fun performAuthorisedWithCN(
     path: String,
     cn: String,
-  ): ResponseSpec {
-    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=$cn"
-    return client
+  ): ResponseSpec =
+    client
       .get()
       .uri(path)
-      .header("subject-distinguished-name", subjectDistinguishedName)
+      .headers { headers -> setAuthHeader(headers, cn) }
       .exchange()
-  }
 
   fun <T : Any> performAuthorisedPost(
     path: String,
     requestBody: T,
-  ): ResponseSpec {
-    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=automated-test-client"
-    return client
+  ): ResponseSpec =
+    client
       .post()
       .uri(path)
-      .header("subject-distinguished-name", subjectDistinguishedName)
-      .header("content-type", "application/json")
-      .bodyValue(requestBody)
+      .headers { headers ->
+        setAuthHeader(headers)
+        headers.set("content-type", "application/json")
+      }.bodyValue(requestBody)
       .exchange()
-  }
 
   fun <T : Any> performAuthorisedPostWithCN(
     path: String,
     cn: String,
     requestBody: T,
-  ): ResponseSpec {
-    val subjectDistinguishedName = "C=GB,ST=London,L=London,O=Home Office,CN=$cn"
-    return client
+  ): ResponseSpec =
+    client
       .post()
       .uri(path)
-      .header("subject-distinguished-name", subjectDistinguishedName)
-      .header("content-type", "application/json")
-      .bodyValue(requestBody)
+      .headers { headers ->
+        setAuthHeader(headers, cn)
+        headers.set("content-type", "application/json")
+      }.bodyValue(requestBody)
       .exchange()
-  }
 }


### PR DESCRIPTION
This PR can be ignored for now, I was just experimenting using coroutines in controllers. I don't think there is a massive benefit to doing this unless we were also going to use coroutines in our service and gateway layers (a fairly reasonable refactor at this point). I have, at least, learned that `MockMvc` does not play well with coroutines without additional setup,`WebClient` does fix this but does do actual network calls so possibly not the best thing to use in unit tests.