### PR TITLE
Switch unit test ports to avoid collision with integration test ports.

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
+# Use ports >= 4010
 services:
   hmpps-auth.base-url: http://localhost:9090
-
   adjudications.base-url: http://localhost:4010
   assess-risks-and-needs.base-url: http://localhost:4011
   case-notes.base-url: http://localhost:4012

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,6 +5,7 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
+# Use ports <4010, reuse if required
 services:
   prison-api:
     base-url: http://localhost:4000
@@ -31,13 +32,13 @@ services:
   manage-pom-case-api:
     base-url: http://localhost:4009
   plp:
-    base-url: http://localhost:4010
+    base-url: http://localhost:4004
   non-associations:
     base-url: http://localhost:4005
   personal-relationships:
-    base-url: http://localhost:4022
+    base-url: http://localhost:4006
   manage-prison-visits:
-    base-url: http://localhost:4023
+    base-url: http://localhost:4007
 
 hmpps.sqs:
   provider: localstack

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PersonalRelationshipsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PersonalRelationshipsApiMockServer.kt
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus
 
 class PersonalRelationshipsApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
-    private const val WIREMOCK_PORT = 4022
+    private const val WIREMOCK_PORT = 4006
   }
 
   fun stubPersonalRelationshipsApiResponse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonVisitsApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/PrisonVisitsApiMockServer.kt
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus
 
 class PrisonVisitsApiMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
-    private const val WIREMOCK_PORT = 4023
+    private const val WIREMOCK_PORT = 4007
   }
 
   fun stubPrisonVisitsApiResponse(


### PR DESCRIPTION
Also added a note to use ports less than 4010 in unit tests and greater in integration tests/prism. Port reuse does not matter as much in the unit tests as servers are turned odd and it's rare a test needs more than a couple of mock servers.