### PR TITLE
Add api-keys to the git ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ __pycache__/
 *.pem
 *.enc
 *.p12
+*-api-key
 
 # Localstack
 localstack/cache


### PR DESCRIPTION
These are pulled when generating client credentials