### PR TITLE
Prisoner contact restrictions model schema + field changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PrisonerContactRestrictions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PrisonerContactRestrictions.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 data class PrisonerContactRestrictions(
   var prisonerContactRestrictions: List<PrisonerContactRestriction>? = emptyList(),
   var contactGlobalRestrictions: List<ContactGlobalRestriction>? = emptyList(),
@@ -26,30 +24,17 @@ data class PrisonerContactRestriction(
 )
 
 data class ContactGlobalRestriction(
-  @JsonProperty("contactRestrictionId")
   val contactRestrictionId: Long,
-  @JsonProperty("contactId")
   val contactId: Long,
-  @JsonProperty("restrictionType")
   val restrictionType: String,
-  @JsonProperty("restrictionTypeDescription")
   val restrictionTypeDescription: String,
-  @JsonProperty("startDate")
   val startDate: String,
-  @JsonProperty("expiryDate")
   val expiryDate: String,
-  @JsonProperty("comments")
   val comments: String,
-  @JsonProperty("enteredByUsername")
   val enteredByUsername: String,
-  @JsonProperty("enteredByDisplayName")
   val enteredByDisplayName: String,
-  @JsonProperty("createdBy")
   val createdBy: String,
-  @JsonProperty("createdTime")
   val createdTime: String,
-  @JsonProperty("updatedBy")
   val updatedBy: String,
-  @JsonProperty("updatedTime")
   val updatedTime: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PrisonerContactRestrictions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PrisonerContactRestrictions.kt
@@ -1,31 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
 data class PrisonerContactRestrictions(
-  var prisonerContactRestrictions: List<PrisonerContactRestriction>? = emptyList(),
-  var contactGlobalRestrictions: List<ContactGlobalRestriction>? = emptyList(),
+  var prisonerContactRestrictions: List<ContactRestriction>? = emptyList(),
+  var contactGlobalRestrictions: List<ContactRestriction>? = emptyList(),
 )
 
-data class PrisonerContactRestriction(
-  val prisonerContactRestrictionId: Long,
-  val prisonerContactId: Long,
-  val contactId: Long,
-  val prisonerNumber: String,
-  val restrictionType: String,
-  val restrictionTypeDescription: String,
-  val startDate: String,
-  val expiryDate: String,
-  val comments: String,
-  val enteredByUsername: String,
-  val enteredByDisplayName: String,
-  val createdBy: String,
-  val createdTime: String,
-  val updatedBy: String,
-  val updatedTime: String,
-)
-
-data class ContactGlobalRestriction(
-  val contactRestrictionId: Long,
-  val contactId: Long,
+data class ContactRestriction(
   val restrictionType: String,
   val restrictionTypeDescription: String,
   val startDate: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PrisonerContactRestrictions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PrisonerContactRestrictions.kt
@@ -1,20 +1,35 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class PrisonerContactRestrictions(
+  @Schema(description = "Relationship specific restrictions")
   var prisonerContactRestrictions: List<ContactRestriction>? = emptyList(),
+  @Schema(description = "Global (estate-wide) restrictions for the contact")
   var contactGlobalRestrictions: List<ContactRestriction>? = emptyList(),
 )
 
 data class ContactRestriction(
+  @Schema(description = "The restriction code", examples = ["CC", "BAN", "CHILD", "CLOSED", "RESTRICTED", "DIHCON", "NONCON"])
   val restrictionType: String,
+  @Schema(description = "The description of the restriction type", example = "Banned")
   val restrictionTypeDescription: String,
+  @Schema(description = "Restriction created date", example = "2024-01-01")
   val startDate: String,
+  @Schema(description = "Restriction expiry date", example = "2024-01-01")
   val expiryDate: String,
+  @Schema(description = "Comments for the restriction", example = "N/A")
   val comments: String,
+  @Schema(description = "The username of either the person who created the restriction or the last person to update it if it has been modified", example = "admin")
   val enteredByUsername: String,
+  @Schema(description = "The display name of either the person who created the restriction or the last person to update it if it has been modified", example = "John Smith")
   val enteredByDisplayName: String,
+  @Schema(description = "User who created the entry", example = "admin")
   val createdBy: String,
+  @Schema(description = "Timestamp when the entry was created", example = "2023-09-23T10:15:30")
   val createdTime: String,
+  @Schema(description = "User who updated the entry", example = "admin")
   val updatedBy: String,
+  @Schema(description = "Timestamp when the entry was updated", example = "2023-09-23T10:15:30")
   val updatedTime: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRPrisonerContactRestrictions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRPrisonerContactRestrictions.kt
@@ -1,8 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactGlobalRestriction
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonerContactRestriction
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactRestriction
 
 data class PRPrisonerContactRestrictions(
   val prisonerContactRestrictions: List<PRPrisonerContactRestriction>? = emptyList(),
@@ -26,12 +25,8 @@ data class PRPrisonerContactRestriction(
   val updatedBy: String,
   val updatedTime: String,
 ) {
-  fun toPrisonerContactRestriction() =
-    PrisonerContactRestriction(
-      prisonerContactRestrictionId = this.prisonerContactRestrictionId,
-      prisonerContactId = this.prisonerContactId,
-      contactId = this.contactId,
-      prisonerNumber = this.prisonerNumber,
+  fun toContactRestriction() =
+    ContactRestriction(
       restrictionType = this.restrictionType,
       restrictionTypeDescription = this.restrictionTypeDescription,
       startDate = this.startDate,
@@ -74,10 +69,8 @@ data class PRContactGlobalRestriction(
   @JsonProperty("updatedTime")
   val updatedTime: String,
 ) {
-  fun toContactGlobalRestriction() =
-    ContactGlobalRestriction(
-      contactRestrictionId = this.contactRestrictionId,
-      contactId = this.contactId,
+  fun toContactRestriction() =
+    ContactRestriction(
       restrictionType = this.restrictionType,
       restrictionTypeDescription = this.restrictionTypeDescription,
       startDate = this.startDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetVisitorRestrictionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetVisitorRestrictionsService.kt
@@ -4,8 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.common.ConsumerPrisonAccessService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PersonalRelationshipsGateway
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactGlobalRestriction
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonerContactRestriction
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactRestriction
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonerContactRestrictions
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -47,18 +46,18 @@ class GetVisitorRestrictionsService(
       return Response(null, listOf(UpstreamApiError(UpstreamApi.PERSONAL_RELATIONSHIPS, UpstreamApiError.Type.ENTITY_NOT_FOUND, "Prisoner not found")))
     }
 
-    val prisonerContactRestrictions = mutableListOf<PrisonerContactRestriction>()
-    var contactGlobalRestrictions = listOf<ContactGlobalRestriction>()
+    val prisonerContactRestrictions = mutableListOf<ContactRestriction>()
+    var contactGlobalRestrictions = listOf<ContactRestriction>()
 
     val prisonerContactIds = linkedPrisoner.relationships?.map { it.prisonerContactId }.orEmpty()
     for (prisonerContactId in prisonerContactIds) {
       val gatewayResult = personalRelationshipsGateway.getPrisonerContactRestrictions(prisonerContactId!!)
       if (gatewayResult.errors.isEmpty() && gatewayResult.data != null) {
         if (gatewayResult.data.prisonerContactRestrictions != null) {
-          prisonerContactRestrictions.addAll(gatewayResult.data.prisonerContactRestrictions.map { it.toPrisonerContactRestriction() })
+          prisonerContactRestrictions.addAll(gatewayResult.data.prisonerContactRestrictions.map { it.toContactRestriction() })
         }
         if (prisonerContactId == prisonerContactIds.first() && gatewayResult.data.contactGlobalRestrictions != null) {
-          contactGlobalRestrictions = gatewayResult.data.contactGlobalRestrictions.map { it.toContactGlobalRestriction() }
+          contactGlobalRestrictions = gatewayResult.data.contactGlobalRestrictions.map { it.toContactRestriction() }
         }
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/VisitRestrictionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/VisitRestrictionsControllerTest.kt
@@ -15,9 +15,8 @@ import org.springframework.test.web.servlet.MockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.common.ConsumerPrisonAccessService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactGlobalRestriction
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactRestriction
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PersonVisitRestriction
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonerContactRestriction
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonerContactRestrictions
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -43,11 +42,7 @@ internal class VisitRestrictionsControllerTest(
       val restrictionsPath = "/v1/persons/$hmppsId/visitor/$contactId/restrictions"
       val prisonerContactRestrictionsResponse =
         mutableListOf(
-          PrisonerContactRestriction(
-            prisonerContactRestrictionId = 123456L,
-            prisonerContactId = 123456L,
-            contactId = 123456L,
-            prisonerNumber = "A1234BC",
+          ContactRestriction(
             restrictionType = "BAN",
             restrictionTypeDescription = "Banned",
             startDate = "2024-01-01",
@@ -64,9 +59,7 @@ internal class VisitRestrictionsControllerTest(
 
       val contactGlobalRestrictionsResponse =
         listOf(
-          ContactGlobalRestriction(
-            contactRestrictionId = 1L,
-            contactId = 123L,
+          ContactRestriction(
             restrictionType = "BAN",
             restrictionTypeDescription = "Banned",
             startDate = "2024-01-01",
@@ -191,10 +184,6 @@ internal class VisitRestrictionsControllerTest(
             {
               "prisonerContactRestrictions": [
                 {
-                  "prisonerContactRestrictionId": 123456,
-                  "prisonerContactId": 123456,
-                  "contactId": 123456,
-                  "prisonerNumber": "A1234BC",
                   "restrictionType": "BAN",
                   "restrictionTypeDescription": "Banned",
                   "startDate": "2024-01-01",
@@ -210,8 +199,6 @@ internal class VisitRestrictionsControllerTest(
               ],
               "contactGlobalRestrictions": [
                 {
-                  "contactRestrictionId": 1,
-                  "contactId": 123,
                   "restrictionType": "BAN",
                   "restrictionTypeDescription": "Banned",
                   "startDate": "2024-01-01",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/VisitRestrictionIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/VisitRestrictionIntegrationTest.kt
@@ -33,7 +33,7 @@ class VisitRestrictionIntegrationTest : IntegrationTestBase() {
 
   // Visitor restriction endpoint
   @Test
-  fun `returns visitor restrictions for a prisoner`() {
+  fun `returns visitor contact restrictions for a prisoner`() {
     callApi("$basePath/$nomsId/visitor/$contactId/restrictions")
       .andExpect(status().isOk)
       .andExpect(content().json(getExpectedResponse("visitor-restrictions")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetVisitorRestrictionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetVisitorRestrictionsServiceTest.kt
@@ -161,8 +161,8 @@ class GetVisitorRestrictionsServiceTest(
 
         val expectedMappedResponse =
           PrisonerContactRestrictions(
-            prisonerContactRestrictions = prisonerContactRestrictionsResponse.map { it.toPrisonerContactRestriction() },
-            contactGlobalRestrictions = contactGlobalRestrictionsResponse.map { it.toContactGlobalRestriction() },
+            prisonerContactRestrictions = prisonerContactRestrictionsResponse.map { it.toContactRestriction() },
+            contactGlobalRestrictions = contactGlobalRestrictionsResponse.map { it.toContactRestriction() },
           )
 
         val response = getVisitorRestrictionsService.execute(hmppsId, contactId, filters)

--- a/src/test/resources/expected-responses/visitor-restrictions
+++ b/src/test/resources/expected-responses/visitor-restrictions
@@ -2,10 +2,6 @@
   "data": {
     "prisonerContactRestrictions": [
       {
-        "prisonerContactRestrictionId": 123456,
-        "prisonerContactId": 123456,
-        "contactId": 123456,
-        "prisonerNumber": "A1234BC",
         "restrictionType": "BAN",
         "restrictionTypeDescription": "Banned",
         "startDate": "2024-01-01",
@@ -21,8 +17,6 @@
     ],
     "contactGlobalRestrictions": [
       {
-        "contactRestrictionId": 1,
-        "contactId": 123,
         "restrictionType": "BAN",
         "restrictionTypeDescription": "Banned",
         "startDate": "2024-01-01",


### PR DESCRIPTION
* Remove internal ID fields 
* Merged `PrisonerContactRestriction` and `ContactGlobalRestriction` into `ContactRestriction` as they had exactly the same fields after the internal ID fields were removed.
* Added @Schema annotations to the models 