### PR TITLE
HMAI-317 - Fix security build caused by swagger-ui 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,11 @@ dependencies {
     exclude("org.springframework.security", "spring-security-crypto")
     exclude("org.springframework.security", "spring-security-web")
   }
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0") {
+    constraints {
+      implementation("org.webjars:swagger-ui:5.20.0") // Fix security build HMAI-317
+    }
+  }
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
   testImplementation("io.kotest:kotest-assertions-json-jvm:5.9.1")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")


### PR DESCRIPTION
This PR pins `org.webjars:swagger-ui` to version `5.20.0` in order to fix a CVE associated with the previous version. This dependency is actually a dependency of `org.springdoc:springdoc-openapi-starter-webmvc-ui` but we can't update that currently as updating this in the past has caused our docs build to fail.

Gradle does show a conflict between `5.20.0` and the previous version (`5.18.2`) but in testing this does not seem to result in any actual issues so this is most likely fine for now.