### PR TITLE
Cleanup Authorisation Filter to only call doFilter in a single place

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -48,8 +48,9 @@ class AuthorisationFilter(
       try {
         chain.doFilter(request, response)
       } catch (e: Throwable) {
-        if (e.cause is LimitedAccessException) {
-          res.sendError(HttpServletResponse.SC_FORBIDDEN, e.message)
+        val cause = e.cause
+        if (cause is LimitedAccessException) {
+          res.sendError(HttpServletResponse.SC_FORBIDDEN, cause.message)
         } else {
           throw e
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -73,6 +73,15 @@ class AuthorisationFilter(
       return
     }
 
-    chain.doFilter(request, response)
+    try {
+      chain.doFilter(request, response)
+    } catch (e: Throwable) {
+      val cause = e.cause
+      if (cause is LimitedAccessException) {
+        res.sendError(HttpServletResponse.SC_FORBIDDEN, cause.message)
+      } else {
+        throw e
+      }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -107,13 +107,15 @@ class AuthorisationFilterTest {
     verify(mockResponse, times(1)).sendError(403, "Attempt to access a limited access case")
   }
 
-//  @Test
-//  fun `Forbidden if limited access caused by error for path found in roles (but not in includes)`() {
-//    val authorisationConfig = AuthorisationConfig()
-//    authorisationConfig.consumers = mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles))
-//    val authorisationFilter = AuthorisationFilter(authorisationConfig, exampleGlobalsConfig)
-//    authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
-//
-//    verify(mockChain, times(1)).doFilter(mockRequest, mockResponse)
-//  }
+  @Test
+  fun `Forbidden if limited access caused by error for path found in roles (but not in includes)`() {
+    val authorisationConfig = AuthorisationConfig()
+    authorisationConfig.consumers = mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles))
+    val authorisationFilter = AuthorisationFilter(authorisationConfig, exampleGlobalsConfig)
+    whenever(mockChain.doFilter(mockRequest, mockResponse)).thenThrow(ServletException(LimitedAccessException()))
+
+    authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
+
+    verify(mockResponse, times(1)).sendError(403, "Attempt to access a limited access case")
+  }
 }


### PR DESCRIPTION
This is to prevent an issue like we have seen where someone is trying to wrap around the doFilter call.