### PR TITLE
HMAI-368 Add validation to cancel visit endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/CancelVisitRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/CancelVisitRequest.kt
@@ -1,13 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 @Schema(description = "Private prison visit cancellation request")
 data class CancelVisitRequest(
   @Schema(description = "Outcome status and description", required = true)
+  @field:Valid
   val cancelOutcome: CancelOutcome,
   @Schema(description = "Username for user who actioned this request", required = false)
+  @field:NotBlank
   val actionedBy: String? = null,
 ) {
   fun toHmppsMessage(
@@ -30,9 +34,9 @@ data class CancelVisitRequest(
 
 data class CancelOutcome(
   @Schema(description = "Outcome status", required = true)
-  @field:NotBlank
+  @field:NotNull
   val outcomeStatus: OutcomeStatus,
-  @Schema(description = "Outcome description", required = true)
+  @Schema(description = "Outcome description", required = false)
   val text: String?,
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetVisitInformationByReferenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetVisitInformationByReferenceService.kt
@@ -21,7 +21,7 @@ class GetVisitInformationByReferenceService(
   ): Response<Visit?> {
     val prisonVisitsResponse = prisonVisitsGateway.getVisitByReference(visitReference)
 
-    if (!prisonVisitsResponse.errors.isNullOrEmpty()) {
+    if (prisonVisitsResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = prisonVisitsResponse.errors)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/VisitsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/VisitsIntegrationTest.kt
@@ -389,9 +389,9 @@ class VisitsIntegrationTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `post a visit with no prison id, should get 400 with no message on the queue`() {
-      val createVisitRequest = getInvalidCancelVisitRequest(noActionedBy = true)
-      val requestBody = asJsonString(createVisitRequest)
+    fun `post a visit cancellation with no actioned by, should get 400 with no message on the queue`() {
+      val cancelVisitRequest = getInvalidCancelVisitRequest(noActionedBy = true)
+      val requestBody = asJsonString(cancelVisitRequest)
 
       postToApi(path, requestBody)
         .andExpect(status().isBadRequest)


### PR DESCRIPTION
Added field validation and tested - all other validation existed

The data is well formed (or 400)
Fields are legal (or 400)
The visit reference exists (or 404)
The prison is at one of the filtered prisons (or 404)