### PR TITLE
HMAI-395 - Visit Integration Tests fix

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/VisitsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/VisitsIntegrationTest.kt
@@ -42,6 +42,7 @@ class VisitsIntegrationTest : IntegrationTestBase() {
   fun getNumberOfMessagesCurrentlyOnQueue(): Int = testSqsClient.countAllMessagesOnQueue(testQueueUrl).get()
 
   fun checkQueueIsEmpty() {
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
     getNumberOfMessagesCurrentlyOnQueue().shouldBe(0)
   }
 


### PR DESCRIPTION
fix 'return a 400 when prisoner ID not valid' periodically failing integration tests