### PR TITLE
HMAI-455 - Remove the manual deployment gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,11 +262,6 @@ workflows:
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           slack_notification: false
 
-      - request-prod-approval:
-          type: approval
-          requires:
-            - deploy-to-preprod
-
       - create-and-push-image-to-ecr:
           <<: *slack-fail-post-step
           name: create-and-push-image-to-prod-ecr
@@ -274,7 +269,7 @@ workflows:
             - hmpps-integration-api-prod
             - hmpps-common-vars
           requires:
-            - request-prod-approval
+            - deploy-to-preprod
           filters:
             branches:
               only:


### PR DESCRIPTION
Last week we added a manual approval step before being able to deploy to prod - 
[PI-2971 Add gate to request approval for deploy to prod](https://github.com/ministryofjustice/hmpps-integration-api/commit/fa554614faf4a34ade03b15e9d19ccbf4fd9b15a)

We have now implemented an [automated test suite](https://github.com/ministryofjustice/hmpps-integration-api/pull/807) which covers all GET endpoints except the images endpoint and expression of interest endpoint. We also tests the [POST v1/visit](https://github.com/ministryofjustice/hmpps-integration-api/pull/810/files), and therefore think the manual gate can be removed.


