### PR TITLE
HMAI-440 - Handle missing request params with 400

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/HmppsIntegrationApiExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -161,6 +162,20 @@ class HmppsIntegrationApiExceptionHandler {
       .body(
         ErrorResponse(
           status = SERVICE_UNAVAILABLE,
+          developerMessage = e.message,
+          userMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException::class)
+  fun handleFMissingServletRequestParameterException(e: MissingServletRequestParameterException): ResponseEntity<ErrorResponse> {
+    logAndCapture("Missing request parameter exception: {}", e)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST,
           developerMessage = e.message,
           userMessage = e.message,
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/VisitSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/VisitSearchIntegrationTest.kt
@@ -35,4 +35,11 @@ class VisitSearchIntegrationTest : IntegrationTestBase() {
     callApi("$path?visitStatus=$invalidStatus&page=$page&size=$size&prisonerId=$hmppsId&fromDate=$fromDate&toDate=$toDate")
       .andExpect(status().isBadRequest)
   }
+
+  @Test
+  fun `missing visit status results in a 400`() {
+    val pathWithQueryParams = "?page=$page&size=$size&prisonerId=$hmppsId&fromDate=$fromDate&toDate=$toDate"
+    callApi("$path$pathWithQueryParams")
+      .andExpect(status().isBadRequest)
+  }
 }


### PR DESCRIPTION
In testing `/v1/prison/{prisonId}/visit/search`, I noticed that missing a required request parameter resulted in a 500 being returned not a 400 as you might expect. I have added a new exception handler which should mean this is now the case, and a new integration test specifically to test this endpoint.