### PR TITLE
Temporarily removing reference-data endpoint from smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - smoke-tests-testing:
+      - smoke-tests:
           <<: *slack-fail-post-step
           name: smoke-tests-testing
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,12 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
+      - smoke-tests-testing:
+          <<: *slack-fail-post-step
+          name: smoke-tests-testing
+          context:
+            - hmpps-common-vars
+            - hmpps-integration-api-smoke-test-dev
       - lint-code:
           context:
             - hmpps-common-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,12 +156,6 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - smoke-tests:
-          <<: *slack-fail-post-step
-          name: smoke-tests-testing
-          context:
-            - hmpps-common-vars
-            - hmpps-integration-api-smoke-test-dev
       - lint-code:
           context:
             - hmpps-common-vars

--- a/scripts/smoke-tests.sh
+++ b/scripts/smoke-tests.sh
@@ -78,7 +78,7 @@ get_endpoints=(
   "/v1/persons/$hmppsId/risks/serious-harm"
   "/v1/persons/$hmppsId/risks/scores"
   "/v1/persons/$hmppsId/risks/dynamic"
-  "/v1/hmpps/reference-data"
+#  "/v1/hmpps/reference-data" Currently 401 code from delius.
   "/v1/hmpps/id/nomis-number/$hmppsId"
   "/v1/persons/$hmppsId/visit/future"
   "/v1/visit/$visitReference"


### PR DESCRIPTION
We're getting a 401 code from delius, only on this endpoint that we are currently investigating.