### PR TITLE
HMAI-463 - Prevent multiple visit notes of same type

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/VisitQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/VisitQueueServiceTest.kt
@@ -259,6 +259,13 @@ internal class VisitQueueServiceTest(
         response.data.shouldBeNull()
         response.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.PERSONAL_RELATIONSHIPS, UpstreamApiError.Type.ENTITY_NOT_FOUND, "No contact found with an ID of $visitorContactId")))
       }
+
+      it("return error if visit notes contains notes of the same type") {
+        val createVisitRequestWithDuplicateNoteTypes = createVisitRequest.copy(visitNotes = listOf(createVisitRequest.visitNotes[0].copy(), createVisitRequest.visitNotes[0].copy()))
+        val response = visitQueueService.sendCreateVisit(createVisitRequestWithDuplicateNoteTypes, who, filters)
+        response.data.shouldBeNull()
+        response.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.MANAGE_PRISON_VISITS, UpstreamApiError.Type.BAD_REQUEST, "You cannot have multiple visit notes of the same type")))
+      }
     }
 
     describe("update visit request") {
@@ -332,6 +339,13 @@ internal class VisitQueueServiceTest(
         val response = visitQueueService.sendUpdateVisit(visitReference, updateVisitRequest, who, filters)
         response.data.shouldBeNull()
         response.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.PERSONAL_RELATIONSHIPS, UpstreamApiError.Type.ENTITY_NOT_FOUND, "No contact found with an ID of $visitorContactId")))
+      }
+
+      it("return error if visit notes contains notes of the same type") {
+        val updateVisitRequestWithDuplicateNoteTypes = updateVisitRequest.copy(visitNotes = listOf(updateVisitRequest.visitNotes[0].copy(), updateVisitRequest.visitNotes[0].copy()))
+        val response = visitQueueService.sendUpdateVisit(visitReference, updateVisitRequestWithDuplicateNoteTypes, who, filters)
+        response.data.shouldBeNull()
+        response.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.MANAGE_PRISON_VISITS, UpstreamApiError.Type.BAD_REQUEST, "You cannot have multiple visit notes of the same type")))
       }
     }
 


### PR DESCRIPTION
In investigation the issue with out visit updates not working, I discovered that there is a unique constraint on a visit to ensure that you can only have 1 note of each available type (VISIT_CONCERN etc) on a visit. In keeping with a our strategy to make the visit as valid as possible before it ends up on the queue, this PR introduces new validation to make sure this is the case.