### PR TITLE
Pin Prism version in Dockerfile

### DIFF
--- a/Dockerfile.prism
+++ b/Dockerfile.prism
@@ -1,5 +1,4 @@
-FROM stoplight/prism:5
-
+FROM stoplight/prism:5.12.1
 
 RUN apk add --no-cache curl jq
 RUN npm install -g @apidevtools/swagger-cli


### PR DESCRIPTION
It looks like Prism has broken in v5.14 (see issue https://github.com/stoplightio/prism/issues/2688). This PR pins Prism to v5.12.1 which is the previous version we had working