### PR TITLE
Fix case notes smoke test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CaseNotesGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CaseNotesGateway.kt
@@ -26,12 +26,11 @@ class CaseNotesGateway(
   ): Response<OCNCaseNote?> {
     val requestBody =
       CNSearchNotesRequest(
-        // date-time format enforced demands format RFC3339, ISO Offset isnt valid apparently
+        // date-time format enforced demands format RFC3339, ISO Offset isn't valid apparently
         occurredFrom = filter.startDate?.let { it.toString() + "Z" },
         occurredTo = filter.endDate?.let { it.toString() + "Z" },
         page = filter.page,
         size = filter.size,
-        sort = filter.sort,
       )
 
     val result =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/caseNotes/CNSearchNotesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/caseNotes/CNSearchNotesRequest.kt
@@ -6,7 +6,6 @@ data class CNSearchNotesRequest(
   val occurredTo: String? = null,
   val page: Int? = null,
   val size: Int? = null,
-  val sort: String? = null,
 ) {
   fun toApiConformingMap(): Map<String, Any> {
     val map = mutableMapOf<String, Any>()
@@ -24,9 +23,6 @@ data class CNSearchNotesRequest(
     }
     if (size != null) {
       map["size"] = size.toInt()
-    }
-    if (sort != null) {
-      map["sort"] = sort
     }
     return map
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/filters/CaseNoteFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/filters/CaseNoteFilter.kt
@@ -8,5 +8,4 @@ data class CaseNoteFilter(
   val endDate: LocalDateTime? = null,
   val page: Int = 1,
   val size: Int = 10,
-  val sort: String = "",
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/prismMocks/case-notes.json
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/prismMocks/case-notes.json
@@ -1623,7 +1623,7 @@
             "type": "string"
           }
         },
-        "required": ["includeSensitive", "page", "size", "sort"]
+        "required": ["page", "size"]
       },
       "TypeSubTypeRequest": {
         "type": "object",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/caseNotes/CaseNotesGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/caseNotes/CaseNotesGatewayTest.kt
@@ -39,7 +39,7 @@ class CaseNotesGatewayTest(
       val id = "123"
       val pathNoParams = "/search/case-notes/$id"
       val caseNotesApiMockServer = ApiMockServer.create(UpstreamApi.CASE_NOTES)
-      val caseNoteRequest = CNSearchNotesRequest(page = 1, size = 10, sort = "")
+      val caseNoteRequest = CNSearchNotesRequest(page = 1, size = 10)
       val caseNoteFilter = CaseNoteFilter(hmppsId = id)
 
       val jsonRequest = objectMapper.writeValueAsString(caseNoteRequest.toApiConformingMap())
@@ -133,7 +133,7 @@ class CaseNotesGatewayTest(
           ?.content!!
           .count()
           .shouldBe(1)
-        response.data!!.content.shouldExist { it -> it.caseNoteId == id }
+        response.data!!.content.shouldExist { it.caseNoteId == id }
       }
     },
   )


### PR DESCRIPTION
This PR fixes an issue found by our smoke tests after merging #757 

```
/v1/persons/A8451DY/case-notes returned 500 - "400 Bad Request from POST https://dev.offender-case-notes.service.justice.gov.uk/search/case-notes/A8451DY"
```

Issue was caused by an empty string being passed to the `sort` property on the request sent to the upstream endpoint. Since this is actually an optional property and we don't accept it on our endpoint, I have removed it completely from the request model.