### PR TITLE
Fix gradle deprecations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ tasks {
   }
 
   register<Test>("integrationTest") {
+    description = "Runs the integration tests, make sure that dependencies are available first by running `make serve`."
     testClassesDirs = sourceSets["integrationTest"].output.classesDirs
     classpath = sourceSets["integrationTest"].runtimeClasspath
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -47,28 +46,31 @@ dependencies {
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
+
 repositories {
   mavenCentral()
+}
+
+sourceSets {
+  create("integrationTest") {
+    kotlin {
+      srcDirs("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration")
+    }
+    compileClasspath += sourceSets["main"].output + configurations["testRuntimeClasspath"] + sourceSets["test"].output
+    runtimeClasspath += output + compileClasspath
+  }
 }
 
 tasks {
   register<Test>("unitTest") {
     filter {
-      excludeTestsMatching("uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke*")
       excludeTestsMatching("uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration*")
     }
   }
 
-  register<Test>("smokeTest") {
-    filter {
-      includeTestsMatching("uk.gov.justice.digital.hmpps.hmppsintegrationapi.smoke*")
-    }
-  }
-
   register<Test>("integrationTest") {
-    filter {
-      includeTestsMatching("uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration*")
-    }
+    testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+    classpath = sourceSets["integrationTest"].runtimeClasspath
   }
 
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.exclude
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "7.1.3"
@@ -71,8 +72,8 @@ tasks {
   }
 
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-      jvmTarget = "21"
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_21
     }
   }
 }


### PR DESCRIPTION
This PR addresses some long standing deprecation warnings from Gradle. I have checked the changes against other repos in MoJ and used followed the examples in there.

`kotlinOptions` has been deprecated so I have replaced this with `compilerOptions`.

Currently we also get these 2 warnings when running our integration tests:

```
Relying on the convention for Test.classpath in custom Test tasks has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_task_default_classpath

Relying on the convention for Test.testClassesDirs in custom Test tasks has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.5/userguide/upgrading_version_8.html#test_task_default_classpath
```

I have changed how integration tests runs so we no longer get these warnings and shouldn't have issues when eventually using Gradle 9.