### PR TITLE
Prism Dockerfile - Change image to v5 instead of specific minor

### DIFF
--- a/Dockerfile.prism
+++ b/Dockerfile.prism
@@ -1,4 +1,4 @@
-FROM stoplight/prism:5.12.1
+FROM stoplight/prism:5
 
 RUN apk add --no-cache curl jq
 RUN npm install -g @apidevtools/swagger-cli


### PR DESCRIPTION
We had an issue with Prism version 5.14 where it completely broke the docker image, this was automatically being used as we were using version 5 of the docker container, meaning it was only pinned the major version. To fix this we pinned to the previous version (5.12.1).

This has since been fixed in 5.14.1 so this PR is to revert back to using v5 instead of pinning the minor version.