### PR TITLE
HMAI-469 /v1/person/hmppsID/images controller doesn't handle 400 bad request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -130,6 +130,7 @@ class PersonController(
     description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
     responses = [
       ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully found a person with the provided HMPPS ID. If a person doesn't have any images, then an empty list (`[]`) is returned in the `data` property."),
+      ApiResponse(responseCode = "400", content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))]),
       ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
       ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
     ],
@@ -144,6 +145,10 @@ class PersonController(
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
+    }
+
+    if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
+      throw ValidationException("Invalid HMPPS ID: $hmppsId")
     }
 
     auditService.createEvent("GET_PERSON_IMAGE", mapOf("hmppsId" to hmppsId))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PersonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PersonIntegrationTest.kt
@@ -48,6 +48,12 @@ class PersonIntegrationTest : IntegrationTestBase() {
       callApiWithCN("$basePath/$nomsId/images", noPrisonsCn)
         .andExpect(status().isNotFound)
     }
+
+    @Test
+    fun `return a 400 when invalid noms passed in`() {
+      callApi("$basePath/$invalidNomsId/images")
+        .andExpect(status().isBadRequest)
+    }
   }
 
   @Nested


### PR DESCRIPTION
Testing highlighted the 400 Bad Request wasn't being handled and was instead returning a 200 Empty List. This change resolves that issue