### PR TITLE
HMAI-396 - Fix  /v1/person/{hmppsId}/person-responsible-officer 404s

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonResponsibleOfficerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonResponsibleOfficerController.kt
@@ -36,8 +36,8 @@ class PersonResponsibleOfficerController(
     description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
     responses = [
       ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully found the person responsible officer for a person with the provided HMPPS ID."),
-      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
       ApiResponse(responseCode = "400", content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))]),
+      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
       ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
     ],
   )
@@ -46,18 +46,23 @@ class PersonResponsibleOfficerController(
     @RequestAttribute filters: ConsumerFilters?,
   ): DataResponse<PersonResponsibleOfficer> {
     val prisonOffenderManager = getPrisonOffenderManagerForPersonService.execute(hmppsId, filters)
-    val communityOffenderManager = getCommunityOffenderManagerForPersonService.execute(hmppsId, filters)
 
-    if (prisonOffenderManager.hasError(UpstreamApiError.Type.BAD_REQUEST) || communityOffenderManager.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
+    if (prisonOffenderManager.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
       throw ValidationException("Invalid HMPPS ID: $hmppsId")
     }
 
     if (prisonOffenderManager.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
-      throw EntityNotFoundException("Could not find prison offender manager related to id: $hmppsId")
+      throw EntityNotFoundException("Could not find person with id: $hmppsId")
+    }
+
+    val communityOffenderManager = getCommunityOffenderManagerForPersonService.execute(hmppsId, filters)
+
+    if (communityOffenderManager.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
+      throw ValidationException("Invalid HMPPS ID: $hmppsId")
     }
 
     if (communityOffenderManager.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
-      throw EntityNotFoundException("Could not find community offender manager related to id: $hmppsId")
+      throw EntityNotFoundException("Could not find person with id: $hmppsId")
     }
 
     val mergedData =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ManagePOMCaseGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ManagePOMCaseGateway.kt
@@ -19,11 +19,11 @@ class ManagePOMCaseGateway(
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  fun getPrimaryPOMForNomisNumber(id: String): Response<PrisonOffenderManager> {
+  fun getPrimaryPOMForNomisNumber(nomsNumber: String): Response<PrisonOffenderManager> {
     val result =
       webClient.request<AllocationPrimaryPOM>(
         HttpMethod.GET,
-        "/api/allocation/$id/primary_pom",
+        "/api/allocation/$nomsNumber/primary_pom",
         authenticationHeader(),
         UpstreamApi.MANAGE_POM_CASE,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ManagePOMCaseGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ManagePOMCaseGateway.kt
@@ -19,9 +19,9 @@ class ManagePOMCaseGateway(
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  fun getPrimaryPOMForNomisNumber(nomsNumber: String): Response<PrisonOffenderManager> {
+  fun getPrimaryPOMForNomisNumber(nomsNumber: String): Response<PrisonOffenderManager?> {
     val result =
-      webClient.request<AllocationPrimaryPOM>(
+      webClient.request<AllocationPrimaryPOM?>(
         HttpMethod.GET,
         "/api/allocation/$nomsNumber/primary_pom",
         authenticationHeader(),
@@ -30,12 +30,12 @@ class ManagePOMCaseGateway(
 
     return when (result) {
       is WebClientWrapper.WebClientWrapperResponse.Success -> {
-        Response(data = result.data.toPrisonOffenderManager())
+        Response(data = result.data?.toPrisonOffenderManager())
       }
 
       is WebClientWrapper.WebClientWrapperResponse.Error -> {
         Response(
-          data = PrisonOffenderManager(),
+          data = null,
           errors = result.errors,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -142,9 +142,9 @@ class NDeliusGateway(
     }
   }
 
-  fun getCommunityOffenderManagerForPerson(id: String): Response<CommunityOffenderManager> {
+  fun getCommunityOffenderManagerForPerson(id: String): Response<CommunityOffenderManager?> {
     val result =
-      webClient.request<NDeliusSupervisions>(
+      webClient.request<NDeliusSupervisions?>(
         HttpMethod.GET,
         "/case/$id/supervisions",
         authenticationHeader(),
@@ -152,12 +152,12 @@ class NDeliusGateway(
       )
     return when (result) {
       is WebClientWrapperResponse.Success -> {
-        Response(data = result.data.communityManager.toCommunityOffenderManager())
+        Response(data = result.data?.communityManager?.toCommunityOffenderManager())
       }
 
       is WebClientWrapperResponse.Error -> {
         Response(
-          data = CommunityOffenderManager(),
+          data = null,
           errors = result.errors,
         )
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -142,11 +142,11 @@ class NDeliusGateway(
     }
   }
 
-  fun getCommunityOffenderManagerForPerson(id: String): Response<CommunityOffenderManager?> {
+  fun getCommunityOffenderManagerForPerson(crn: String): Response<CommunityOffenderManager?> {
     val result =
       webClient.request<NDeliusSupervisions?>(
         HttpMethod.GET,
-        "/case/$id/supervisions",
+        "/case/$crn/supervisions",
         authenticationHeader(),
         UpstreamApi.NDELIUS,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PersonResponsibleOfficer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PersonResponsibleOfficer.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
 data class PersonResponsibleOfficer(
-  val prisonOffenderManager: PrisonOffenderManager = PrisonOffenderManager(),
-  val communityOffenderManager: CommunityOffenderManager = CommunityOffenderManager(),
+  val prisonOffenderManager: PrisonOffenderManager?,
+  val communityOffenderManager: CommunityOffenderManager?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonService.kt
@@ -23,7 +23,7 @@ class GetCommunityOffenderManagerForPersonService(
 
     val deliusCrn = personResponse.data?.identifiers?.deliusCrn ?: return Response(data = null)
 
-    val nDeliusMappaDetailResponse = nDeliusGateway.getCommunityOffenderManagerForPerson(id = deliusCrn)
+    val nDeliusMappaDetailResponse = nDeliusGateway.getCommunityOffenderManagerForPerson(crn = deliusCrn)
     if (nDeliusMappaDetailResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = nDeliusMappaDetailResponse.errors)
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.CommunityOffenderManager
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 @Service
@@ -24,7 +25,7 @@ class GetCommunityOffenderManagerForPersonService(
     val deliusCrn = personResponse.data?.identifiers?.deliusCrn ?: return Response(data = null)
 
     val nDeliusMappaDetailResponse = nDeliusGateway.getCommunityOffenderManagerForPerson(crn = deliusCrn)
-    if (nDeliusMappaDetailResponse.errors.isNotEmpty()) {
+    if (nDeliusMappaDetailResponse.errors.isNotEmpty() && !nDeliusMappaDetailResponse.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       return Response(data = null, errors = nDeliusMappaDetailResponse.errors)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonService.kt
@@ -15,19 +15,21 @@ class GetCommunityOffenderManagerForPersonService(
   fun execute(
     hmppsId: String,
     filters: ConsumerFilters?,
-  ): Response<CommunityOffenderManager> {
+  ): Response<CommunityOffenderManager?> {
     val personResponse = getPersonService.getPersonWithPrisonFilter(hmppsId, filters)
+    if (personResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = personResponse.errors)
+    }
 
-    val deliusCrn = personResponse.data?.identifiers?.deliusCrn
-    var nDeliusMappaDetailResponse: Response<CommunityOffenderManager> = Response(data = CommunityOffenderManager())
+    val deliusCrn = personResponse.data?.identifiers?.deliusCrn ?: return Response(data = null)
 
-    if (deliusCrn != null) {
-      nDeliusMappaDetailResponse = nDeliusGateway.getCommunityOffenderManagerForPerson(id = deliusCrn)
+    val nDeliusMappaDetailResponse = nDeliusGateway.getCommunityOffenderManagerForPerson(id = deliusCrn)
+    if (nDeliusMappaDetailResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = nDeliusMappaDetailResponse.errors)
     }
 
     return Response(
       data = nDeliusMappaDetailResponse.data,
-      errors = personResponse.errors + nDeliusMappaDetailResponse.errors,
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonService.kt
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ManagePOMCaseGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonOffenderManager
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 @Service
@@ -15,19 +17,21 @@ class GetPrisonOffenderManagerForPersonService(
   fun execute(
     hmppsId: String,
     filters: ConsumerFilters?,
-  ): Response<PrisonOffenderManager> {
+  ): Response<PrisonOffenderManager?> {
     val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
+    if (personResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = personResponse.errors)
+    }
 
-    val nomisNumber = personResponse.data?.nomisNumber
-    var prisonOffenderManager: Response<PrisonOffenderManager> = Response(data = PrisonOffenderManager())
+    val nomisNumber = personResponse.data?.nomisNumber ?: return Response(data = null, errors = listOf(UpstreamApiError(UpstreamApi.NOMIS, UpstreamApiError.Type.ENTITY_NOT_FOUND)))
 
-    if (nomisNumber != null) {
-      prisonOffenderManager = managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomisNumber)
+    val prisonOffenderManagerResponse = managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomisNumber)
+    if (prisonOffenderManagerResponse.errors.isNotEmpty() && !prisonOffenderManagerResponse.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      return Response(data = null, errors = prisonOffenderManagerResponse.errors)
     }
 
     return Response(
-      data = prisonOffenderManager.data,
-      errors = personResponse.errors + prisonOffenderManager.errors,
+      data = prisonOffenderManagerResponse.data,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/managePOMcase/ManagePOMCaseGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/managePOMcase/ManagePOMCaseGatewayTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.managePOMcase
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory
@@ -78,8 +79,9 @@ class ManagePOMCaseGatewayTest(
         )
 
         val response = managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomsNumber)
-        response.data.forename.shouldBe("string")
-        response.data.surname.shouldBe("string")
+        response.data.shouldNotBeNull()
+        response.data!!.forename.shouldBe("string")
+        response.data!!.surname.shouldBe("string")
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/managePOMcase/ManagePOMCaseGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/managePOMcase/ManagePOMCaseGatewayTest.kt
@@ -26,11 +26,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 )
 class ManagePOMCaseGatewayTest(
   @MockitoBean val hmppsAuthGateway: HmppsAuthGateway,
-  val managePOMCaseGateway: ManagePOMCaseGateway,
+  private val managePOMCaseGateway: ManagePOMCaseGateway,
 ) : DescribeSpec(
     {
-      val id = "X1234YZ"
-      val path = "/api/allocation/$id/primary_pom"
+      val nomsNumber = "X1234YZ"
+      val path = "/api/allocation/$nomsNumber/primary_pom"
       val managePOMCaseApiMockServer = ApiMockServer.create(UpstreamApi.MANAGE_POM_CASE)
       beforeEach {
         managePOMCaseApiMockServer.start()
@@ -45,7 +45,7 @@ class ManagePOMCaseGatewayTest(
       }
 
       it("authenticates using HMPPS Auth with credentials") {
-        managePOMCaseGateway.getPrimaryPOMForNomisNumber(id = id)
+        managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomsNumber)
 
         verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("ManagePOMCase")
       }
@@ -54,7 +54,7 @@ class ManagePOMCaseGatewayTest(
         managePOMCaseApiMockServer.stubForGet(path, "", HttpStatus.BAD_REQUEST)
         val response =
           shouldThrow<WebClientResponseException> {
-            managePOMCaseGateway.getPrimaryPOMForNomisNumber(id = id)
+            managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomsNumber)
           }
         response.statusCode.shouldBe(HttpStatus.BAD_REQUEST)
       }
@@ -77,7 +77,7 @@ class ManagePOMCaseGatewayTest(
           HttpStatus.OK,
         )
 
-        val response = managePOMCaseGateway.getPrimaryPOMForNomisNumber(id = id)
+        val response = managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomsNumber)
         response.data.forename.shouldBe("string")
         response.data.surname.shouldBe("string")
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonServiceTest.kt
@@ -42,7 +42,7 @@ class GetCommunityOffenderManagerForPersonServiceTest(
         Mockito.reset(nDeliusGateway)
 
         whenever(getPersonService.getPersonWithPrisonFilter(hmppsId = hmppsId, filter)).thenReturn(Response(person))
-        whenever(nDeliusGateway.getCommunityOffenderManagerForPerson(id = deliusCrn)).thenReturn(Response(communityOffenderManager))
+        whenever(nDeliusGateway.getCommunityOffenderManagerForPerson(crn = deliusCrn)).thenReturn(Response(communityOffenderManager))
       }
 
       it("performs a search according to hmpps Id") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCommunityOffenderManagerForPersonServiceTest.kt
@@ -1,9 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
-import org.mockito.internal.verification.VerificationModeFactory
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
@@ -34,7 +35,6 @@ class GetCommunityOffenderManagerForPersonServiceTest(
       val filter = null
 
       val person = Person(firstName = "Sam", lastName = "Smith", identifiers = Identifiers(deliusCrn = deliusCrn))
-
       val communityOffenderManager = CommunityOffenderManager(name = PersonResponsibleOfficerName(forename = "Michael", surname = "Green"), email = "email@email.com", telephoneNumber = "07471234567", team = PersonResponsibleOfficerTeam(code = "Code2", description = "Service description", email = "email2@email2.com", telephoneNumber = "07170987654"))
 
       beforeEach {
@@ -47,7 +47,7 @@ class GetCommunityOffenderManagerForPersonServiceTest(
 
       it("performs a search according to hmpps Id") {
         getCommunityOffenderManagerForPersonService.execute(hmppsId, filter)
-        verify(getPersonService, VerificationModeFactory.times(1)).getPersonWithPrisonFilter(hmppsId = hmppsId, filter)
+        verify(getPersonService, times(1)).getPersonWithPrisonFilter(hmppsId = hmppsId, filter)
       }
 
       it("Returns a community offender manager for person given a hmppsId") {
@@ -56,29 +56,63 @@ class GetCommunityOffenderManagerForPersonServiceTest(
             data = person,
           ),
         )
+
         val result = getCommunityOffenderManagerForPersonService.execute(hmppsId, filter)
         result.shouldBe(Response(data = communityOffenderManager))
       }
 
-      it("should return a list of errors if person not found") {
+      it("should return a list of errors if getPersonService returns errors") {
+        val errors =
+          listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NDELIUS,
+              type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+            ),
+          )
         whenever(getPersonService.getPersonWithPrisonFilter(hmppsId = "NOT_FOUND", filter)).thenReturn(
           Response(
             data = null,
-            errors =
-              listOf(
-                UpstreamApiError(
-                  causedBy = UpstreamApi.NDELIUS,
-                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-                ),
-              ),
+            errors = errors,
           ),
         )
+
         val result = getCommunityOffenderManagerForPersonService.execute("NOT_FOUND", filter)
-        result.data.shouldBe(CommunityOffenderManager())
-        result.errors
-          .first()
-          .type
-          .shouldBe(UpstreamApiError.Type.ENTITY_NOT_FOUND)
+        result.data.shouldBe(null)
+        result.errors.shouldBe(errors)
+      }
+
+      it("Should return null if nDelius gateway returns 404") {
+        whenever(nDeliusGateway.getCommunityOffenderManagerForPerson(crn = deliusCrn)).thenReturn(
+          Response(
+            data = null,
+            errors = listOf(UpstreamApiError(UpstreamApi.NDELIUS, UpstreamApiError.Type.ENTITY_NOT_FOUND)),
+          ),
+        )
+
+        val result = getCommunityOffenderManagerForPersonService.execute(hmppsId, filter)
+        result.data.shouldBe(null)
+        result.errors.shouldBeEmpty()
+      }
+
+      it("Should return errors if nDelius gateway returns non 404 errors") {
+        val errors =
+          listOf(
+            UpstreamApiError(
+              causedBy = UpstreamApi.NDELIUS,
+              type = UpstreamApiError.Type.INTERNAL_SERVER_ERROR,
+              description = "Error returned by nDelius gateway",
+            ),
+          )
+        whenever(nDeliusGateway.getCommunityOffenderManagerForPerson(crn = deliusCrn)).thenReturn(
+          Response(
+            data = null,
+            errors = errors,
+          ),
+        )
+
+        val result = getCommunityOffenderManagerForPersonService.execute(hmppsId, filter)
+        result.data.shouldBe(null)
+        result.errors.shouldBe(errors)
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonServiceTest.kt
@@ -81,7 +81,7 @@ class GetPrisonOffenderManagerForPersonServiceTest(
         )
 
         val result = getPrisonOffenderManagerForPersonService.execute(hmppsId, filters)
-        result.shouldBe(Response(data = null))
+        result.data.shouldBe(null)
         result.errors.shouldBeEmpty()
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonServiceTest.kt
@@ -41,7 +41,7 @@ class GetPrisonOffenderManagerForPersonServiceTest(
         Mockito.reset(managePOMCaseGateway)
 
         whenever(getPersonService.getNomisNumberWithPrisonFilter(hmppsId = hmppsId, filters)).thenReturn(Response(NomisNumber(nomisNumber)))
-        whenever(managePOMCaseGateway.getPrimaryPOMForNomisNumber(id = nomisNumber)).thenReturn(Response(prisonOffenderManager))
+        whenever(managePOMCaseGateway.getPrimaryPOMForNomisNumber(nomsNumber = nomisNumber)).thenReturn(Response(prisonOffenderManager))
       }
 
       it("performs a search according to hmpps Id") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPrisonOffenderManagerForPersonServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.kotlin.times
@@ -81,6 +82,7 @@ class GetPrisonOffenderManagerForPersonServiceTest(
 
         val result = getPrisonOffenderManagerForPersonService.execute(hmppsId, filters)
         result.shouldBe(Response(data = null))
+        result.errors.shouldBeEmpty()
       }
 
       it("Should return errors if Manage POM gateway returns non 404 errors") {


### PR DESCRIPTION
This PR makes changes to `/v1/person/{hmppsId}/person-responsible-officer` to prevent an issue with us getting 404s when calling this endpoint.

* If we get a 404 from either the POM or nDelius gateway we ignore it and just return null in the respective fields, all other errors are still treated as errors though
* We still check the person exists and return 404 if not (including by checking filters)
* The logic being that the person may not be in delius and therefore not have a community manager
* Manage POM gateway returns this error message on 404, which doesn't feel like something we should be treating as an error on our side 
```json
{
    "status": "error",
    "message": "Not ready for allocation"
}
```
* I also noticed some obvious tidy ups and some missing test coverage
* TODO: When checking this endpoint in dev, we may get a 401 due on the nDelius endpoint, I could not access it from postman with our creds and this has masked until now by the 404 from Manage POM