### PR TITLE
HMAI-470 Remove Feature flag from /v1/persons/{encodedHmppsId}/images

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -6,11 +6,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class FeatureFlagConfig(
   val useArnsEndpoints: Boolean,
   val useNumberOfChildrenEndpoints: Boolean,
-  val usePrisonFilterImagesEndpoint: Boolean,
 ) {
   companion object {
     const val USE_ARNS_ENDPOINTS = "use-arns-endpoints"
     const val USE_NUMBER_OF_CHILDREN_ENDPOINTS = "use-number-of-children-endpoints"
-    const val USE_PRISON_FILTER_IMAGES_ENDPOINT = "use-prison-filter-images-endpoint"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetImageMetadataForPersonService.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NomisGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ProbationOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ImageMetadata
@@ -15,33 +14,22 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 class GetImageMetadataForPersonService(
   @Autowired val nomisGateway: NomisGateway,
   @Autowired val probationOffenderSearchGateway: ProbationOffenderSearchGateway,
-  @Autowired val featureFlagConfig: FeatureFlagConfig,
   @Autowired val getPersonService: GetPersonService,
 ) {
   fun execute(
     hmppsId: String,
     filters: ConsumerFilters?,
   ): Response<List<ImageMetadata>> {
-    if (featureFlagConfig.usePrisonFilterImagesEndpoint) {
-      val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
-      if (personResponse.errors.isNotEmpty()) {
-        return Response(data = emptyList(), errors = personResponse.errors)
-      }
-
-      val nomisNumber =
-        personResponse.data?.nomisNumber ?: return Response(
-          data = emptyList(),
-          errors = listOf(UpstreamApiError(UpstreamApi.NOMIS, UpstreamApiError.Type.ENTITY_NOT_FOUND)),
-        )
-      return nomisGateway.getImageMetadataForPerson(nomisNumber)
-    } else {
-      val responseFromProbationOffenderSearch = probationOffenderSearchGateway.getPerson(hmppsId)
-      val nomisNumber =
-        responseFromProbationOffenderSearch.data?.identifiers?.nomisNumber ?: return Response(
-          data = emptyList(),
-          errors = responseFromProbationOffenderSearch.errors,
-        )
-      return nomisGateway.getImageMetadataForPerson(nomisNumber)
+    val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
+    if (personResponse.errors.isNotEmpty()) {
+      return Response(data = emptyList(), errors = personResponse.errors)
     }
+
+    val nomisNumber =
+      personResponse.data?.nomisNumber ?: return Response(
+        data = emptyList(),
+        errors = listOf(UpstreamApiError(UpstreamApi.NOMIS, UpstreamApiError.Type.ENTITY_NOT_FOUND)),
+      )
+    return nomisGateway.getImageMetadataForPerson(nomisNumber)
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,7 +39,6 @@ services:
 feature-flag:
   use-arns-endpoints: true
   use-number-of-children-endpoints: true
-  use-prison-filter-images-endpoint: true
 
 authorisation:
   consumers:

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -55,7 +55,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-prison-filter-images-endpoint: true
   use-number-of-children-endpoints: true
 
 authorisation:

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -95,5 +95,4 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-prison-filter-images-endpoint: true
   use-number-of-children-endpoints: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,7 +31,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-prison-filter-images-endpoint: true
   use-number-of-children-endpoints: true
 
 authorisation:

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -36,7 +36,6 @@ services:
 
 feature-flag:
   use-arns-endpoints: false
-  use-prison-filter-images-endpoint: false
   use-number-of-children-endpoints: false
 
 authorisation:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,7 +36,6 @@ services:
 
 feature-flag:
   use-arns-endpoints: false
-  use-prison-filter-images-endpoint: false
   use-number-of-children-endpoints: false
 
 authorisation:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -56,7 +56,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-prison-filter-images-endpoint: true
   use-number-of-children-endpoints: true
 
 authorisation:


### PR DESCRIPTION
Following the implementation of new functionality with prison filters behind a feature flag, we have tested in dev and are happy that the endpoint is still functioning as expected. 

This ticket therefore, removes the feature flag.