### PR TITLE
Add visits DLQ secret

### DIFF
--- a/helm_deploy/hmpps-integration-api/values.yaml
+++ b/helm_deploy/hmpps-integration-api/values.yaml
@@ -57,6 +57,8 @@ generic-service:
       HMPPS_SQS_QUEUES_JOBSBOARDINTEGRATION_QUEUE_NAME: "integrationqueue"
     sqs-hmpps-prison-visits-write-events-secret:
       HMPPS_SQS_QUEUES_VISITS_QUEUE_NAME: "sqs_queue_name"
+    sqs-hmpps-prison-visits-write-events-dlq-secret:
+      HMPPS_SQS_QUEUES_VISITS_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
     unrestricted: "0.0.0.0/0"


### PR DESCRIPTION
This PR adds the secret for the visit writes DLQ to our env variables via helm so we have the ability to manage it via our queue endpoints (the automatically generated ones).