### PR TITLE
Remove feature flag on /v1/persons/{hmppsId}/images/{id}

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -38,7 +38,7 @@ feature-flag:
   use-arns-endpoints: false
   use-number-of-children-endpoints: false
   use-physical-characteristics-endpoints: false
-  use-image-endpoints: false
+  use-image-endpoints: true
   use-education-assessments-endpoints: false
 
 authorisation:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,7 +38,7 @@ feature-flag:
   use-arns-endpoints: false
   use-number-of-children-endpoints: false
   use-physical-characteristics-endpoints: false
-  use-image-endpoints: false
+  use-image-endpoints: true
   use-education-assessments-endpoints: false
 
 authorisation:


### PR DESCRIPTION
This has been tested in dev so this PR is to remove the feature flag from this endpoint.

Verified we get a 200 status code and the image.

```
GET https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/G6333VK/images/1687866

---
content-type: image/jpeg
content-length: 3222
```

Verified we get a 400 bad request when passing in an invalid HMPPS ID

```
GET https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/G6333V/images/1687866

{
    "status": 400,
    "errorCode": null,
    "userMessage": "Invalid HMPPS ID: G6333V",
    "developerMessage": "Validation failure: Invalid HMPPS ID: G6333V",
    "moreInfo": null
}
```

Verified we get a 404 not found when passing in a HMPPS ID which does not exist

```
GET https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/G6333SL/images/1687866

{
    "status": 404,
    "errorCode": null,
    "userMessage": "Could not find image with id: 1687866",
    "developerMessage": "404 Not found error: Could not find image with id: 1687866",
    "moreInfo": null
}
```

Verified we get a 404 not found when the HMPPS ID exists but the image ID does not

```
GET https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/G6333VK/images/168786

{
    "status": 404,
    "errorCode": null,
    "userMessage": "Could not find image with id: 168786",
    "developerMessage": "404 Not found error: Could not find image with id: 168786",
    "moreInfo": null
}
```

Verified we get a 404 not found when both the HMPPS ID exists and the image exists, but the image is not linked to that HMPPS ID

```
GET https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/A8451DY/images/1687866

{
    "status": 404,
    "errorCode": null,
    "userMessage": "Could not find image with id: 1687866",
    "developerMessage": "404 Not found error: Could not find image with id: 1687866",
    "moreInfo": null
}
```