### PR TITLE
Add integration tests for endpoints using feature flags

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FeatureFlaggedEndpointsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FeatureFlaggedEndpointsIntegrationTest.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+
+internal class FeatureFlaggedEndpointsIntegrationTest : IntegrationTestBase() {
+  @MockitoBean
+  private lateinit var featureFlagConfig: FeatureFlagConfig
+
+  @Test
+  fun `number of children endpoint should return 503`() {
+    whenever(featureFlagConfig.useNumberOfChildrenEndpoints).thenReturn(false)
+    callApi("$basePath/$nomsId/number-of-children")
+      .andExpect(status().isServiceUnavailable)
+  }
+
+  @Test
+  fun `physical characteristics endpoint should return 503`() {
+    whenever(featureFlagConfig.usePhysicalCharacteristicsEndpoints).thenReturn(false)
+    callApi("$basePath/$nomsId/physical-characteristics")
+      .andExpect(status().isServiceUnavailable)
+  }
+
+  @Test
+  fun `images by idendpoint should return 503`() {
+    whenever(featureFlagConfig.useImageEndpoints).thenReturn(false)
+    callApi("$basePath/$nomsId/images/2461788")
+      .andExpect(status().isServiceUnavailable)
+  }
+}


### PR DESCRIPTION
This PR is an attempt at standardising our approach to testing feature flags are working correctly on certain endpoints where they are being used. These will replace the current method which is to test these in our controller unit tests.

Some key points about this proposed approach:

* We no longer test this in our controller unit tests because it is tricky to do so given our new annotations approach to feature flags. This is because the annotations rely on Spring boot and we tend to run units tests in a more isolated way, this makes it hard to mock the feature flags in our controller tests as it is no longer an injected dependency of the controller.
* Integration tests are a better test anyway as feature flag logic may not always be in the controller layer (controller unit tests would just mock everything the controller uses)
* Having this in a seperate file to other integration tests on our endpoints makes sense because it puts them all in one place but also we don't want to mock the feature flag config in the vast majority of our tests, we want to see that it correctly gets it from the application yaml file
* The feature flag config is the only thing being mocked in these tests (aside from Prism obviously)