### PR TITLE
HMAI-473 Remove num-of-children feature flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -5,14 +5,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "feature-flag")
 data class FeatureFlagConfig(
   val useArnsEndpoints: Boolean,
-  val useNumberOfChildrenEndpoints: Boolean,
   val usePhysicalCharacteristicsEndpoints: Boolean,
   val useImageEndpoints: Boolean,
   val useEducationAssessmentsEndpoints: Boolean,
 ) {
   companion object {
     const val USE_ARNS_ENDPOINTS = "use-arns-endpoints"
-    const val USE_NUMBER_OF_CHILDREN_ENDPOINTS = "use-number-of-children-endpoints"
     const val USE_PHYSICAL_CHARACTERISTICS_ENDPOINTS = "use-physical-characteristics-endpoints"
     const val USE_IMAGE_ENDPOINTS = "use-image-endpoints"
     const val USE_EDUCATION_ASSESSMENTS_ENDPOINTS = "use-education-assessments-endpoints"
@@ -21,7 +19,6 @@ data class FeatureFlagConfig(
   fun getConfigFlagValue(name: String): Boolean? =
     when (name) {
       USE_ARNS_ENDPOINTS -> this.useArnsEndpoints
-      USE_NUMBER_OF_CHILDREN_ENDPOINTS -> this.useNumberOfChildrenEndpoints
       else -> null
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -18,7 +18,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.FeatureNotEnabledException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.decodeUrlCharacters
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.featureflag.FeatureFlag
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DataResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.IEPLevel
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ImageMetadata
@@ -277,7 +276,6 @@ class PersonController(
   }
 
   @GetMapping("{hmppsId}/number-of-children")
-  @FeatureFlag(name = FeatureFlagConfig.USE_NUMBER_OF_CHILDREN_ENDPOINTS)
   @Operation(
     summary = "Returns a prisoner's number of children.",
     description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,7 +38,6 @@ services:
 
 feature-flag:
   use-arns-endpoints: true
-  use-number-of-children-endpoints: true
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: true

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -55,7 +55,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-number-of-children-endpoints: true
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: true

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -96,7 +96,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-number-of-children-endpoints: true
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,7 +31,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-number-of-children-endpoints: true
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: true

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -36,7 +36,6 @@ services:
 
 feature-flag:
   use-arns-endpoints: false
-  use-number-of-children-endpoints: false
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,7 +36,6 @@ services:
 
 feature-flag:
   use-arns-endpoints: false
-  use-number-of-children-endpoints: false
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -56,7 +56,6 @@ hmpps.sqs:
 
 feature-flag:
   use-arns-endpoints: true
-  use-number-of-children-endpoints: true
   use-physical-characteristics-endpoints: true
   use-image-endpoints: true
   use-education-assessments-endpoints: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/featureflag/FeatureFlagAspectTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/featureflag/FeatureFlagAspectTest.kt
@@ -38,7 +38,7 @@ class FeatureFlagAspectTest {
   @Test
   fun `test feature flag disabled then throw feature flag not enabled exception`() {
     assertThrows<FeatureNotEnabledException> {
-      featureFlagAspect.checkFeatureFlag(proceedingJoinPoint, FeatureFlag(FeatureFlagConfig.USE_ARNS_ENDPOINTS))
+      featureFlagAspect.checkFeatureFlag(proceedingJoinPoint, FeatureFlag(FeatureFlagConfig.USE_PHYSICAL_CHARACTERISTICS_ENDPOINTS))
     }
     verify(proceedingJoinPoint, times(0)).proceed()
     verifyNoMoreInteractions(proceedingJoinPoint)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/featureflag/FeatureFlagAspectTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/featureflag/FeatureFlagAspectTest.kt
@@ -19,7 +19,6 @@ class FeatureFlagAspectTest {
   private val featureFlagConfig: FeatureFlagConfig =
     FeatureFlagConfig(
       useArnsEndpoints = true,
-      useNumberOfChildrenEndpoints = false,
       useImageEndpoints = false,
       useEducationAssessmentsEndpoints = false,
       usePhysicalCharacteristicsEndpoints = false,
@@ -39,7 +38,7 @@ class FeatureFlagAspectTest {
   @Test
   fun `test feature flag disabled then throw feature flag not enabled exception`() {
     assertThrows<FeatureNotEnabledException> {
-      featureFlagAspect.checkFeatureFlag(proceedingJoinPoint, FeatureFlag(FeatureFlagConfig.USE_NUMBER_OF_CHILDREN_ENDPOINTS))
+      featureFlagAspect.checkFeatureFlag(proceedingJoinPoint, FeatureFlag(FeatureFlagConfig.USE_ARNS_ENDPOINTS))
     }
     verify(proceedingJoinPoint, times(0)).proceed()
     verifyNoMoreInteractions(proceedingJoinPoint)


### PR DESCRIPTION
```
* [HTTP/2] [1] OPENED stream for https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/G6333VK/number-of-children
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: https]
* [HTTP/2] [1] [:authority: dev.integration-api.hmpps.service.justice.gov.uk]
* [HTTP/2] [1] [:path: /v1/persons/G6333VK/number-of-children]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
> GET /v1/persons/G6333VK/number-of-children HTTP/2
> Host: dev.integration-api.hmpps.service.justice.gov.uk
> User-Agent: curl/8.7.1
> Accept: */*
{ [33 bytes data]
100    33  100    33    0     0     29      0  0:00:01  0:00:01 --:--:--    29
* Connection #0 to host dev.integration-api.hmpps.service.justice.gov.uk left intact
{
  "data": {
    "numberOfChildren": "0"
  }
}

```
```

{ [34 bytes data]
* [HTTP/2] [1] OPENED stream for https://dev.integration-api.hmpps.service.justice.gov.uk/v1/persons/A1234AA/number-of-children

100    34  100    34    0     0     41      0 --:--:-- --:--:-- --:--:--    41
* Connection #0 to host dev.integration-api.hmpps.service.justice.gov.uk left intact
{
  "data": {
    "numberOfChildren": null
  }
}
```
