### PR TITLE
HMAI-495 - Fix docs build

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
@@ -14,13 +14,10 @@ import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ForbiddenByUpstreamServiceException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.featureflag.FeatureFlag
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DataResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PersonInPrison
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ResidentialHierarchyItem
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError.Type.BAD_REQUEST
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError.Type.ENTITY_NOT_FOUND
@@ -176,45 +173,45 @@ class PrisonController(
     return response.data.toPaginatedResponse()
   }
 
-  @GetMapping("/{prisonId}/residential-hierarchy")
-  @Tag(name = "residential-areas")
-  @Operation(
-    summary = "Gets the residential hierarchy for a prison.",
-    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
-    responses = [
-      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully performed the query on upstream APIs. An empty list is returned when no results are found."),
-      ApiResponse(
-        responseCode = "400",
-        description = "",
-        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
-      ),
-      ApiResponse(responseCode = "403", content = [Content(schema = Schema(ref = "#/components/schemas/ForbiddenResponse"))]),
-      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
-      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
-    ],
-  )
-  @FeatureFlag(name = FeatureFlagConfig.USE_RESIDENTIAL_HIERARCHY_ENDPOINTS)
-  fun getResidentialHierarchy(
-    @Parameter(description = "The ID of the prison to be queried against") @PathVariable prisonId: String,
-    @RequestAttribute filters: ConsumerFilters?,
-  ): DataResponse<List<ResidentialHierarchyItem>?> {
-    val response = getResidentialHierarchyService.execute(prisonId, filters)
-
-    if (response.hasError(BAD_REQUEST)) {
-      throw ValidationException("Invalid query parameters.")
-    }
-
-    if (response.hasError(ENTITY_NOT_FOUND)) {
-      throw EntityNotFoundException("Could not find residential hierarchy with supplied query parameters.")
-    }
-
-    auditService.createEvent(
-      "GET_PRISON_RESIDENTIAL_HIERARCHY",
-      mapOf("prisonId" to prisonId),
-    )
-
-    return DataResponse(data = response.data)
-  }
+//  @GetMapping("/{prisonId}/residential-hierarchy")
+//  @Tag(name = "residential-areas")
+//  @Operation(
+//    summary = "Gets the residential hierarchy for a prison.",
+//    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
+//    responses = [
+//      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully performed the query on upstream APIs. An empty list is returned when no results are found."),
+//      ApiResponse(
+//        responseCode = "400",
+//        description = "",
+//        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
+//      ),
+//      ApiResponse(responseCode = "403", content = [Content(schema = Schema(ref = "#/components/schemas/ForbiddenResponse"))]),
+//      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
+//      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
+//    ],
+//  )
+//  @FeatureFlag(name = FeatureFlagConfig.USE_RESIDENTIAL_HIERARCHY_ENDPOINTS)
+//  fun getResidentialHierarchy(
+//    @Parameter(description = "The ID of the prison to be queried against") @PathVariable prisonId: String,
+//    @RequestAttribute filters: ConsumerFilters?,
+//  ): DataResponse<List<ResidentialHierarchyItem>?> {
+//    val response = getResidentialHierarchyService.execute(prisonId, filters)
+//
+//    if (response.hasError(BAD_REQUEST)) {
+//      throw ValidationException("Invalid query parameters.")
+//    }
+//
+//    if (response.hasError(ENTITY_NOT_FOUND)) {
+//      throw EntityNotFoundException("Could not find residential hierarchy with supplied query parameters.")
+//    }
+//
+//    auditService.createEvent(
+//      "GET_PRISON_RESIDENTIAL_HIERARCHY",
+//      mapOf("prisonId" to prisonId),
+//    )
+//
+//    return DataResponse(data = response.data)
+//  }
 
   private fun isValidISODateFormat(dateString: String): Boolean =
     try {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
@@ -180,7 +180,7 @@ class PrisonController(
     return response.data.toPaginatedResponse()
   }
 
-  @Hidden
+  @Hidden // This is currently hidden because the recursive type breaks the docs
   @GetMapping("/{prisonId}/residential-hierarchy")
   @Tag(name = "residential-areas")
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.prison
 
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -179,6 +180,7 @@ class PrisonController(
     return response.data.toPaginatedResponse()
   }
 
+  @Hidden
   @GetMapping("/{prisonId}/residential-hierarchy")
   @Tag(name = "residential-areas")
   @Operation(

--- a/tech-docs/config/tech-docs.yml
+++ b/tech-docs/config/tech-docs.yml
@@ -33,4 +33,4 @@ prevent_indexing: true
 
 show_contribution_banner: false
 
-api_path: https://ministryofjustice.github.io/hmpps-integration-api/openapi/api-docs.json
+api_path: http://host.docker.internal:8080/v3/api-docs

--- a/tech-docs/config/tech-docs.yml
+++ b/tech-docs/config/tech-docs.yml
@@ -33,4 +33,4 @@ prevent_indexing: true
 
 show_contribution_banner: false
 
-api_path: http://host.docker.internal:8080/v3/api-docs
+api_path: https://ministryofjustice.github.io/hmpps-integration-api/openapi/api-docs.json


### PR DESCRIPTION
This PR is a temporary fix to get our docs builds working again. The issue is being caused by the `/v1/prisons/{prisonId}/residential-hierarchy` endpoint returning a data type which is recursive. Currently `tech-docs-gem` doesn't seem to be able to work this recursive types so for now we are hiding this endpoint so it doesn't go into the docs.