### PR TITLE
Update DPS spring boot to 8.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.0.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
   kotlin("plugin.spring") version "2.1.20"
 }
 


### PR DESCRIPTION
This fixes a security issue with a dependency in earlier versions.

https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/8.x.md#810