### PR TITLE
HMAI-532 - Update OpenAPI spec to use v3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
           - "patch"
         patterns:
           - "*"
-    ignore:
-      # Ignore this because updating breaks the tech-docs
-      # This is due to OpenAPI 3.1.0 being used which is not supported by other deps
-      - dependency-name: "org.springdoc:springdoc-openapi-starter-webmvc-ui"
   - package-ecosystem: "bundler"
     directory: "/tech-docs"
     schedule:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,11 @@ dependencies {
     exclude("org.springframework.security", "spring-security-crypto")
     exclude("org.springframework.security", "spring-security-web")
   }
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6") {
+    constraints {
+      implementation("org.webjars:swagger-ui:5.21.0") // Fix security build HMAI-317
+    }
+  }
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
   testImplementation("io.kotest:kotest-assertions-json-jvm:5.9.1")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,11 +24,7 @@ dependencies {
     exclude("org.springframework.security", "spring-security-crypto")
     exclude("org.springframework.security", "spring-security-web")
   }
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0") {
-    constraints {
-      implementation("org.webjars:swagger-ui:5.21.0") // Fix security build HMAI-317
-    }
-  }
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
   testImplementation("io.kotest:kotest-assertions-json-jvm:5.9.1")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")


### PR DESCRIPTION
Now that we are not building our API docs using the `tech-docs-gem` we are able to update our OpenAPI schema version from `3.0.1` to `3.1.0` via an update to our `org.springdoc:springdoc-openapi-starter-webmvc-ui` dependancy. This version of the OpenAPI schema was incompatible with `tech-docs-gem`, see #590 for where we had to revert the update and add to our dependabot ignore list.

Updating to `3.1.0` also fixes some display issues on our swagger page

Before:

![image](https://github.com/user-attachments/assets/b27197a1-3a90-4dc5-ae02-2fbddb3f0c2c)

After:

<img width="468" alt="image" src="https://github.com/user-attachments/assets/67fbb493-ba25-4c8a-ad1a-ad1b4419be47" />
