### PR TITLE
New base class for Integration tests that need queues

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestWithQueueBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestWithQueueBase.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration
+
+import io.kotest.matchers.shouldBe
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
+
+abstract class IntegrationTestWithQueueBase(
+  val queueName: String,
+) : IntegrationTestBase() {
+  @Autowired
+  protected lateinit var hmppsQueueService: HmppsQueueService
+
+  internal val testQueue by lazy { hmppsQueueService.findByQueueId(queueName) ?: throw RuntimeException("Queue with name $queueName doesn't exist") }
+  internal val testSqsClient by lazy { testQueue.sqsClient }
+  internal val testQueueUrl by lazy { testQueue.queueUrl }
+
+  fun getNumberOfMessagesCurrentlyOnQueue(): Int = testSqsClient.countAllMessagesOnQueue(testQueueUrl).get()
+
+  fun checkQueueIsEmpty() {
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
+    getNumberOfMessagesCurrentlyOnQueue().shouldBe(0)
+  }
+
+  fun getQueueMessages(): List<Message> = testSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(testQueueUrl).build()).join().messages()
+
+  @BeforeEach
+  fun `clear queues`() {
+    testSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(testQueueUrl).build())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/EducationAssessmentsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/EducationAssessmentsIntegrationTest.kt
@@ -6,47 +6,19 @@ import io.kotest.matchers.shouldBe
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import software.amazon.awssdk.services.sqs.model.Message
-import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestWithQueueBase
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.EducationAssessmentStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.EducationAssessmentStatusChangeRequest
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
-import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.net.URI
 import java.time.LocalDate
 import java.util.UUID
 
-class EducationAssessmentsIntegrationTest : IntegrationTestBase() {
-  @Autowired
-  protected lateinit var hmppsQueueService: HmppsQueueService
-
-  internal val testQueue by lazy { hmppsQueueService.findByQueueId("assessmentevents") ?: throw RuntimeException("Queue with name visits doesn't exist") }
-  internal val testSqsClient by lazy { testQueue.sqsClient }
-  internal val testQueueUrl by lazy { testQueue.queueUrl }
-
-  fun getNumberOfMessagesCurrentlyOnQueue(): Int = testSqsClient.countAllMessagesOnQueue(testQueueUrl).get()
-
-  fun checkQueueIsEmpty() {
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
-    getNumberOfMessagesCurrentlyOnQueue().shouldBe(0)
-  }
-
-  fun getQueueMessages(): List<Message> = testSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(testQueueUrl).build()).join().messages()
-
-  @BeforeEach
-  fun `clear queues`() {
-    testSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(testQueueUrl).build())
-  }
-
+class EducationAssessmentsIntegrationTest : IntegrationTestWithQueueBase("assessmentevents") {
   @DisplayName("POST /v1/persons/{hmppsId}/education/assessments/status")
   @Nested
   inner class PostVisit {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/DeactivateLocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/DeactivateLocationIntegrationTest.kt
@@ -3,41 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.prison
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.matchers.shouldBe
-import org.awaitility.kotlin.await
-import org.awaitility.kotlin.matches
-import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import software.amazon.awssdk.services.sqs.model.Message
-import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestWithQueueBase
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivateLocationRequest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivationReason
-import uk.gov.justice.hmpps.sqs.HmppsQueueService
-import uk.gov.justice.hmpps.sqs.countAllMessagesOnQueue
 import java.time.LocalDate
 
-class DeactivateLocationIntegrationTest : IntegrationTestBase() {
-  @Autowired
-  private lateinit var hmppsQueueService: HmppsQueueService
-
-  internal val testQueue by lazy { hmppsQueueService.findByQueueId("locations") ?: throw RuntimeException("Queue with name locations doesn't exist") }
-  internal val testSqsClient by lazy { testQueue.sqsClient }
-  internal val testQueueUrl by lazy { testQueue.queueUrl }
-
-  fun getNumberOfMessagesCurrentlyOnQueue(): Int = testSqsClient.countAllMessagesOnQueue(testQueueUrl).get()
-
-  fun checkQueueIsEmpty() {
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 0 }
-    getNumberOfMessagesCurrentlyOnQueue().shouldBe(0)
-  }
-
-  fun getQueueMessages(): List<Message> = testSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(testQueueUrl).build()).join().messages()
-
+class DeactivateLocationIntegrationTest : IntegrationTestWithQueueBase("locations") {
   private val prisonId = "MDI"
   private val key = "MDI-A-1-001"
   private val path = "/v1/prison/$prisonId/location/$key/deactivate"
@@ -48,11 +22,6 @@ class DeactivateLocationIntegrationTest : IntegrationTestBase() {
       proposedReactivationDate = LocalDate.now(),
       planetFmReference = "23423TH/5",
     )
-
-  @BeforeEach
-  fun `clear queues`() {
-    testSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(testQueueUrl).build())
-  }
 
   @Test
   fun `return the response saying message on queue`() {


### PR DESCRIPTION
This PR introduces a new base file for doing integration tests that involve a queue, IntegrationTestWithQueueBase. This allows you to supply a queue name and it will provide the methods to check values on that queue without having to implement it each time, it also clears down the queue before each test. This extends the existing IntegrationTestBase