### PR TITLE
Remove explicit swagger-ui dependancy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,11 +24,7 @@ dependencies {
     exclude("org.springframework.security", "spring-security-crypto")
     exclude("org.springframework.security", "spring-security-web")
   }
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8") {
-    constraints {
-      implementation("org.webjars:swagger-ui:5.21.0") // Fix security build HMAI-317
-    }
-  }
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
   testImplementation("io.kotest:kotest-assertions-json-jvm:5.9.1")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:5.9.1")


### PR DESCRIPTION
Due to security warning we previously had `swagger-ui` patched to version `5.21.0` in our `build.gradle.kts`. Now that `springdoc-openapi-starter-webmvc-ui` has been updated we no longer need to patch this as this now has the updated version in it's dependencies.