### PR TITLE
HMAI-544 - Check cell active before deactivation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueService.kt
@@ -55,8 +55,11 @@ class LocationQueueService(
       return Response(data = null, errors = listOf(UpstreamApiError(causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON, type = UpstreamApiError.Type.BAD_REQUEST, description = "Location type must be a CELL")))
     }
 
-    val prisonersInCellResponse = getPrisonersInCellService.execute(prisonId, locationResponse.data.pathHierarchy)
+    if (!locationResponse.data.active || locationResponse.data.deactivatedByParent) {
+      return Response(data = null, errors = listOf(UpstreamApiError(causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON, type = UpstreamApiError.Type.CONFLICT, description = "This cell is already deactivated")))
+    }
 
+    val prisonersInCellResponse = getPrisonersInCellService.execute(prisonId, locationResponse.data.pathHierarchy)
     if (prisonersInCellResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = prisonersInCellResponse.errors)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueServiceTest.kt
@@ -154,7 +154,7 @@ internal class LocationQueueServiceTest(
 
         val result = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, filters)
         result.data.shouldBe(null)
-        result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.BAD_REQUEST, "Location already deactivated")))
+        result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.CONFLICT, "This cell is already deactivated")))
       }
 
       it("should return error when location is not active") {
@@ -162,7 +162,7 @@ internal class LocationQueueServiceTest(
 
         val result = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, filters)
         result.data.shouldBe(null)
-        result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.BAD_REQUEST, "Location already deactivated")))
+        result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.CONFLICT, "This cell is already deactivated")))
       }
 
       it("should return error when cell is not empty") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueServiceTest.kt
@@ -149,6 +149,22 @@ internal class LocationQueueServiceTest(
         result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.BAD_REQUEST, "Location type must be a CELL")))
       }
 
+      it("should return error when location is not active due to parent being inactive") {
+        whenever(locationsInsidePrisonGateway.getLocationByKey(key)).thenReturn(Response(data = lipLocation.copy(deactivatedByParent = true)))
+
+        val result = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, filters)
+        result.data.shouldBe(null)
+        result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.BAD_REQUEST, "Location already deactivated")))
+      }
+
+      it("should return error when location is not active") {
+        whenever(locationsInsidePrisonGateway.getLocationByKey(key)).thenReturn(Response(data = lipLocation.copy(active = false)))
+
+        val result = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, filters)
+        result.data.shouldBe(null)
+        result.errors.shouldBe(listOf(UpstreamApiError(UpstreamApi.LOCATIONS_INSIDE_PRISON, UpstreamApiError.Type.BAD_REQUEST, "Location already deactivated")))
+      }
+
       it("should return error when cell is not empty") {
         whenever(getPrisonersInCellService.execute(prisonId, lipLocation.pathHierarchy)).thenReturn(
           Response(


### PR DESCRIPTION
If a cell is inactive (which could be due to it's parent being inactive) then the locations API will throw an exception when it tries to deactivate it. To avoid these ending up on the DLQ, we now do this validation on our side too.