### PR TITLE
Add location controller

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationController.kt
@@ -1,0 +1,127 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.prison
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.tags.Tags
+import jakarta.validation.Valid
+import jakarta.validation.ValidationException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ConflictFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.featureflag.FeatureFlag
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DataResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivateLocationRequest
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsMessageResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Location
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError.Type.BAD_REQUEST
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError.Type.ENTITY_NOT_FOUND
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetLocationByKeyService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.LocationQueueService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+
+@RestController
+@RequestMapping("/v1/prison/{prisonId}/location")
+@Tags(value = [Tag("Prison"), Tag("Residential Areas")])
+class LocationController(
+  @Autowired val auditService: AuditService,
+  @Autowired val getLocationByKeyService: GetLocationByKeyService,
+  @Autowired val locationQueueService: LocationQueueService,
+) {
+  @GetMapping("/{key}")
+  @Tag(name = "Residential Areas")
+  @Operation(
+    summary = "Gets the location information for a prison location based on a key.",
+    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
+    responses = [
+      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully performed the query on upstream APIs."),
+      ApiResponse(
+        responseCode = "400",
+        description = "",
+        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
+      ),
+      ApiResponse(responseCode = "403", content = [Content(schema = Schema(ref = "#/components/schemas/ForbiddenResponse"))]),
+      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
+      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
+    ],
+  )
+  @FeatureFlag(name = FeatureFlagConfig.USE_LOCATION_ENDPOINT)
+  fun getLocationInformation(
+    @Parameter(description = "The ID of the prison to be queried against") @PathVariable prisonId: String,
+    @Parameter(description = "The key of the location to be queried against in the format of (PrisonId-locationKey") @PathVariable key: String,
+    @RequestAttribute filters: ConsumerFilters?,
+  ): DataResponse<Location?> {
+    val response = getLocationByKeyService.execute(prisonId, key, filters)
+
+    if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
+      throw ValidationException("Invalid query parameters.")
+    }
+
+    if (response.hasError(ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Could not find location information with supplied query parameters.")
+    }
+
+    auditService.createEvent(
+      "GET_LOCATION_INFORMATION",
+      mapOf("prisonId" to prisonId, "key" to key),
+    )
+
+    return DataResponse(data = response.data)
+  }
+
+  @PostMapping("/{key}/deactivate")
+  @Tag(name = "Residential Areas")
+  @Operation(
+    summary = "Temporarily mark a location as inactive.",
+    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
+    responses = [
+      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully posted to upstream APIs."),
+      ApiResponse(
+        responseCode = "400",
+        description = "",
+        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
+      ),
+      ApiResponse(responseCode = "403", content = [Content(schema = Schema(ref = "#/components/schemas/ForbiddenResponse"))]),
+      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
+      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
+    ],
+  )
+  @FeatureFlag(name = FeatureFlagConfig.USE_LOCATION_DEACTIVATE_ENDPOINT)
+  fun deactivateLocation(
+    @Parameter(description = "The ID of the prison the location is in") @PathVariable prisonId: String,
+    @Parameter(description = "The key of the location") @PathVariable key: String,
+    @Valid @RequestBody deactivateLocationRequest: DeactivateLocationRequest,
+    @RequestAttribute clientName: String?,
+    @RequestAttribute filters: ConsumerFilters?,
+  ): DataResponse<HmppsMessageResponse?> {
+    val response = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, clientName.orEmpty(), filters)
+    if (response.hasError(ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException(response.errors[0].description ?: "Could not find provided location.")
+    }
+
+    if (response.hasError(BAD_REQUEST)) {
+      throw ValidationException(response.errors[0].description ?: "Invalid request.")
+    }
+
+    if (response.hasError(UpstreamApiError.Type.CONFLICT)) {
+      throw ConflictFoundException(response.errors[0].description ?: "Conflict.")
+    }
+
+    auditService.createEvent("DEACTIVATE_LOCATION", mapOf("prisonId" to prisonId, "key" to key))
+
+    return DataResponse(response.data)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationController.kt
@@ -83,7 +83,7 @@ class LocationController(
 
   @PostMapping("/{key}/deactivate")
   @Operation(
-    summary = "Temporarily mark a location as inactive.",
+    summary = "Temporarily mark a location as inactive. The location must be a cell.",
     description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
     responses = [
       ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully posted to upstream APIs."),
@@ -100,7 +100,7 @@ class LocationController(
   @FeatureFlag(name = FeatureFlagConfig.USE_LOCATION_DEACTIVATE_ENDPOINT)
   fun deactivateLocation(
     @Parameter(description = "The ID of the prison the location is in") @PathVariable prisonId: String,
-    @Parameter(description = "The key of the location") @PathVariable key: String,
+    @Parameter(description = "The key of the location, must be a cell") @PathVariable key: String,
     @Valid @RequestBody deactivateLocationRequest: DeactivateLocationRequest,
     @RequestAttribute clientName: String?,
     @RequestAttribute filters: ConsumerFilters?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationController.kt
@@ -42,7 +42,6 @@ class LocationController(
   @Autowired val locationQueueService: LocationQueueService,
 ) {
   @GetMapping("/{key}")
-  @Tag(name = "Residential Areas")
   @Operation(
     summary = "Gets the location information for a prison location based on a key.",
     description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
@@ -83,7 +82,6 @@ class LocationController(
   }
 
   @PostMapping("/{key}/deactivate")
-  @Tag(name = "Residential Areas")
   @Operation(
     summary = "Temporarily mark a location as inactive.",
     description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonController.kt
@@ -7,26 +7,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.swagger.v3.oas.annotations.tags.Tags
-import jakarta.validation.Valid
 import jakarta.validation.ValidationException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestAttribute
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ConflictFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ForbiddenByUpstreamServiceException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.featureflag.FeatureFlag
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DataResponse
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivateLocationRequest
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsMessageResponse
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Location
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PersonInPrison
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonCapacity
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ResidentialDetails
@@ -39,13 +32,11 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Visit
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.interfaces.toPaginatedResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetCapacityForPrisonService
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetLocationByKeyService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPrisonersService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetResidentialDetailsService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetResidentialHierarchyService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetVisitsService
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.LocationQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.PaginatedResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.paginateWith
@@ -63,8 +54,6 @@ class PrisonController(
   @Autowired val getResidentialDetailsService: GetResidentialDetailsService,
   @Autowired val getCapacityForPrisonService: GetCapacityForPrisonService,
   @Autowired val auditService: AuditService,
-  @Autowired val getLocationByKeyService: GetLocationByKeyService,
-  @Autowired val locationQueueService: LocationQueueService,
 ) {
   @GetMapping("/prisoners/{hmppsId}")
   @Tags(value = [Tag(name = "Prisoners"), Tag(name = "Reception")])
@@ -239,47 +228,6 @@ class PrisonController(
     return DataResponse(data = response.data)
   }
 
-  @GetMapping("/{prisonId}/location/{key}")
-  @Tag(name = "Residential Areas")
-  @Operation(
-    summary = "Gets the location information for a prison location based on a key.",
-    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
-    responses = [
-      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully performed the query on upstream APIs."),
-      ApiResponse(
-        responseCode = "400",
-        description = "",
-        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
-      ),
-      ApiResponse(responseCode = "403", content = [Content(schema = Schema(ref = "#/components/schemas/ForbiddenResponse"))]),
-      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
-      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
-    ],
-  )
-  @FeatureFlag(name = FeatureFlagConfig.USE_LOCATION_ENDPOINT)
-  fun getLocationInformation(
-    @Parameter(description = "The ID of the prison to be queried against") @PathVariable prisonId: String,
-    @Parameter(description = "The key of the location to be queried against in the format of (PrisonId-locationKey") @PathVariable key: String,
-    @RequestAttribute filters: ConsumerFilters?,
-  ): DataResponse<Location?> {
-    val response = getLocationByKeyService.execute(prisonId, key, filters)
-
-    if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
-      throw ValidationException("Invalid query parameters.")
-    }
-
-    if (response.hasError(ENTITY_NOT_FOUND)) {
-      throw EntityNotFoundException("Could not find location information with supplied query parameters.")
-    }
-
-    auditService.createEvent(
-      "GET_LOCATION_INFORMATION",
-      mapOf("prisonId" to prisonId, "key" to key),
-    )
-
-    return DataResponse(data = response.data)
-  }
-
   @GetMapping("/{prisonId}/residential-details")
   @Tag(name = "Residential Areas")
   @Operation(
@@ -361,49 +309,6 @@ class PrisonController(
     )
 
     return DataResponse(data = response.data)
-  }
-
-  @PostMapping("/{prisonId}/location/{key}/deactivate")
-  @Tag(name = "Residential Areas")
-  @Operation(
-    summary = "Temporarily mark a location as inactive.",
-    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
-    responses = [
-      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully posted to upstream APIs."),
-      ApiResponse(
-        responseCode = "400",
-        description = "",
-        content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))],
-      ),
-      ApiResponse(responseCode = "403", content = [Content(schema = Schema(ref = "#/components/schemas/ForbiddenResponse"))]),
-      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
-      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
-    ],
-  )
-  @FeatureFlag(name = FeatureFlagConfig.USE_LOCATION_DEACTIVATE_ENDPOINT)
-  fun deactivateLocation(
-    @Parameter(description = "The ID of the prison the location is in") @PathVariable prisonId: String,
-    @Parameter(description = "The key of the location") @PathVariable key: String,
-    @Valid @RequestBody deactivateLocationRequest: DeactivateLocationRequest,
-    @RequestAttribute clientName: String?,
-    @RequestAttribute filters: ConsumerFilters?,
-  ): DataResponse<HmppsMessageResponse?> {
-    val response = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, clientName.orEmpty(), filters)
-    if (response.hasError(ENTITY_NOT_FOUND)) {
-      throw EntityNotFoundException(response.errors[0].description ?: "Could not find provided location.")
-    }
-
-    if (response.hasError(BAD_REQUEST)) {
-      throw ValidationException(response.errors[0].description ?: "Invalid request.")
-    }
-
-    if (response.hasError(UpstreamApiError.Type.CONFLICT)) {
-      throw ConflictFoundException(response.errors[0].description ?: "Conflict.")
-    }
-
-    auditService.createEvent("DEACTIVATE_LOCATION", mapOf("prisonId" to prisonId, "key" to key))
-
-    return DataResponse(response.data)
   }
 
   private fun isValidISODateFormat(dateString: String): Boolean =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationControllerTest.kt
@@ -1,0 +1,225 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.prison
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.MockMvcExtensions.contentAsJson
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DataResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivateLocationRequest
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivationReason
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsMessageResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Location
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.locationsInsidePrison.LIPLocation
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetLocationByKeyService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.LocationQueueService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@WebMvcTest(controllers = [LocationController::class])
+@ActiveProfiles("test")
+class LocationControllerTest(
+  @Autowired var springMockMvc: MockMvc,
+  @MockitoBean val auditService: AuditService,
+  @MockitoBean val getLocationByKeyService: GetLocationByKeyService,
+  @MockitoBean val locationQueueService: LocationQueueService,
+) : DescribeSpec({
+    val prisonId = "MDI"
+    val basePath = "/v1/prison/$prisonId/location"
+    val mockMvc = IntegrationAPIMockMvc(springMockMvc)
+    val key = "A-1-001"
+
+    beforeEach {
+      Mockito.reset(auditService)
+    }
+
+    describe("GET /{key}") {
+      val filters = null
+      val path = "$basePath/$key"
+
+      val lipLocation =
+        LIPLocation(
+          id = "123",
+          prisonId = "MDI",
+          code = "001",
+          pathHierarchy = "A-1-001",
+          locationType = "CELL",
+          localName = "Wing A",
+          comments = "Standard cell",
+          permanentlyInactive = false,
+          permanentlyInactiveReason = null,
+          capacity = null,
+          oldWorkingCapacity = null,
+          certification = null,
+          usage = null,
+          accommodationTypes = listOf("NORMAL_ACCOMMODATION"),
+          specialistCellTypes = listOf("ACCESSIBLE_CELL"),
+          usedFor = listOf("STANDARD_ACCOMMODATION"),
+          status = "ACTIVE",
+          convertedCellType = null,
+          otherConvertedCellType = null,
+          active = true,
+          deactivatedByParent = false,
+          deactivatedDate = "2023-01-23T12:23:00",
+          deactivatedReason = null,
+          deactivationReasonDescription = null,
+          deactivatedBy = null,
+          proposedReactivationDate = "2026-01-24",
+          planetFmReference = "2323/45M",
+          topLevelId = "MDI-A",
+          level = 1,
+          leafLevel = true,
+          parentId = "MDI-A-1",
+          parentLocation = null,
+          inactiveCells = 0,
+          numberOfCellLocations = 1,
+          childLocations = null,
+          changeHistory = null,
+          transactionHistory = null,
+          lastModifiedBy = "USER1",
+          lastModifiedDate = LocalDateTime.now(),
+          key = "MDI-A-1-001",
+          isResidential = true,
+        )
+      val mappedLIPResponse = lipLocation.toLocation()
+
+      it("should return 200 when success") {
+        whenever(getLocationByKeyService.execute(prisonId, key, filters)).thenReturn(Response(data = mappedLIPResponse))
+
+        val result = mockMvc.performAuthorised(path)
+        result.response.status.shouldBe(HttpStatus.OK.value())
+        result.response.contentAsJson<Response<Location>>().shouldBe(Response(data = mappedLIPResponse))
+      }
+
+      it("should call the audit service") {
+        whenever(getLocationByKeyService.execute(prisonId, key, filters)).thenReturn(Response(data = mappedLIPResponse))
+
+        mockMvc.performAuthorised(path)
+        verify(
+          auditService,
+          times(1),
+        ).createEvent(
+          "GET_LOCATION_INFORMATION",
+          mapOf("prisonId" to prisonId, "key" to key),
+        )
+      }
+
+      it("returns 400 when invalid params") {
+        val invalidParam = "ABC123"
+        val invalidPath = "$basePath/$invalidParam"
+        whenever(getLocationByKeyService.execute(prisonId, invalidParam, filters)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  type = UpstreamApiError.Type.BAD_REQUEST,
+                  causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON,
+                ),
+              ),
+          ),
+        )
+
+        val result = mockMvc.performAuthorised(invalidPath)
+        result.response.status.shouldBe(400)
+      }
+
+      it("returns 404 when getLocationByKeyService returns not found") {
+        whenever(getLocationByKeyService.execute(prisonId, key, filters)).thenReturn(
+          Response(
+            data = null,
+            errors =
+              listOf(
+                UpstreamApiError(
+                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
+                  causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON,
+                ),
+              ),
+          ),
+        )
+
+        val result = mockMvc.performAuthorised(path)
+        result.response.status.shouldBe(404)
+      }
+    }
+
+    describe("POST /{key}/deactivate") {
+      val path = "$basePath/$key/deactivate"
+      val who = "automated-test-client"
+      val deactivateLocationRequest =
+        DeactivateLocationRequest(
+          deactivationReason = DeactivationReason.DAMAGED,
+          deactivationReasonDescription = "Scheduled maintenance",
+          proposedReactivationDate = LocalDate.now(),
+          planetFmReference = "23423TH/5",
+        )
+
+      it("returns 200 when location is successfully deactivated") {
+        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
+          Response(data = HmppsMessageResponse(message = "Deactivate location written to queue")),
+        )
+
+        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
+        result.response.status.shouldBe(200)
+        result.response.contentAsJson<DataResponse<HmppsMessageResponse>>().shouldBe(
+          DataResponse(data = HmppsMessageResponse(message = "Deactivate location written to queue")),
+        )
+      }
+
+      it("returns 404 when location is not found") {
+        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
+          Response(data = null, errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.ENTITY_NOT_FOUND, description = "Location not found", causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON))),
+        )
+
+        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
+        result.response.status.shouldBe(404)
+      }
+
+      it("returns 400 when invalid request data is provided") {
+        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
+          Response(data = null, errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, description = "Invalid data", causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON))),
+        )
+
+        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
+        result.response.status.shouldBe(400)
+      }
+
+      it("returns 409 when prisoner is in cell") {
+        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
+          Response(data = null, errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.CONFLICT, description = "Prisoner in cell", causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH))),
+        )
+
+        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
+        result.response.status.shouldBe(409)
+        result.response.contentAsString.contains("Prisoner in cell")
+      }
+
+      it("logs audit event when location is deactivated") {
+        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
+          Response(data = HmppsMessageResponse(message = "Deactivate location written to queue")),
+        )
+
+        mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
+        verify(auditService, times(1)).createEvent(
+          "DEACTIVATE_LOCATION",
+          mapOf(
+            "prisonId" to prisonId,
+            "key" to key,
+          ),
+        )
+      }
+    }
+  })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonControllerTest.kt
@@ -19,9 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.MockMvcExtens
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DataResponse
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivateLocationRequest
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DeactivationReason
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsMessageResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Location
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.LocationCapacity
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.LocationCertification
@@ -37,20 +34,16 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Visit
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.VisitContact
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.VisitExternalSystemDetails
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.VisitorSupport
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.locationsInsidePrison.LIPLocation
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.locationsInsidePrison.LIPPrisonSummary
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetCapacityForPrisonService
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetLocationByKeyService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPrisonersService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetResidentialDetailsService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetResidentialHierarchyService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetVisitsService
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.LocationQueueService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @WebMvcTest(controllers = [PrisonController::class])
 @ActiveProfiles("test")
@@ -62,10 +55,8 @@ internal class PrisonControllerTest(
   @MockitoBean val getPrisonersService: GetPrisonersService,
   @MockitoBean val getVisitsService: GetVisitsService,
   @MockitoBean val getResidentialHierarchyService: GetResidentialHierarchyService,
-  @MockitoBean val getLocationByKeyService: GetLocationByKeyService,
   @MockitoBean val getResidentialDetailsService: GetResidentialDetailsService,
   @MockitoBean val getCapacityForPrisonService: GetCapacityForPrisonService,
-  @MockitoBean val locationQueueService: LocationQueueService,
 ) : DescribeSpec({
     val hmppsId = "200313116M"
     val basePath = "/v1/prison"
@@ -689,192 +680,6 @@ internal class PrisonControllerTest(
 
         val result = mockMvc.performAuthorised(path)
         result.response.status.shouldBe(404)
-      }
-    }
-
-    describe("GET /{prisonId}/location/{key}") {
-      val prisonId = "MDI"
-      val key = "A-1-001"
-      val filters = null
-      val path = "$basePath/$prisonId/location/$key"
-
-      val lipLocation =
-        LIPLocation(
-          id = "123",
-          prisonId = "MDI",
-          code = "001",
-          pathHierarchy = "A-1-001",
-          locationType = "CELL",
-          localName = "Wing A",
-          comments = "Standard cell",
-          permanentlyInactive = false,
-          permanentlyInactiveReason = null,
-          capacity = null,
-          oldWorkingCapacity = null,
-          certification = null,
-          usage = null,
-          accommodationTypes = listOf("NORMAL_ACCOMMODATION"),
-          specialistCellTypes = listOf("ACCESSIBLE_CELL"),
-          usedFor = listOf("STANDARD_ACCOMMODATION"),
-          status = "ACTIVE",
-          convertedCellType = null,
-          otherConvertedCellType = null,
-          active = true,
-          deactivatedByParent = false,
-          deactivatedDate = "2023-01-23T12:23:00",
-          deactivatedReason = null,
-          deactivationReasonDescription = null,
-          deactivatedBy = null,
-          proposedReactivationDate = "2026-01-24",
-          planetFmReference = "2323/45M",
-          topLevelId = "MDI-A",
-          level = 1,
-          leafLevel = true,
-          parentId = "MDI-A-1",
-          parentLocation = null,
-          inactiveCells = 0,
-          numberOfCellLocations = 1,
-          childLocations = null,
-          changeHistory = null,
-          transactionHistory = null,
-          lastModifiedBy = "USER1",
-          lastModifiedDate = LocalDateTime.now(),
-          key = "MDI-A-1-001",
-          isResidential = true,
-        )
-
-      val mappedLIPResponse = lipLocation.toLocation()
-
-      beforeEach {
-        Mockito.reset(getResidentialHierarchyService)
-      }
-
-      it("should return 200 when success") {
-        whenever(getLocationByKeyService.execute(prisonId, key, filters)).thenReturn(Response(data = mappedLIPResponse))
-
-        val result = mockMvc.performAuthorised(path)
-        result.response.status.shouldBe(HttpStatus.OK.value())
-        result.response.contentAsJson<Response<Location>>().shouldBe(Response(data = mappedLIPResponse))
-      }
-
-      it("should call the audit service") {
-        whenever(getLocationByKeyService.execute(prisonId, key, filters)).thenReturn(Response(data = mappedLIPResponse))
-
-        mockMvc.performAuthorised(path)
-        verify(
-          auditService,
-          times(1),
-        ).createEvent(
-          "GET_LOCATION_INFORMATION",
-          mapOf("prisonId" to prisonId, "key" to key),
-        )
-      }
-
-      it("returns 400 when invalid params") {
-        val invalidParam = "ABC123"
-        val invalidPath = "$basePath/$prisonId/location/$invalidParam"
-        whenever(getLocationByKeyService.execute(prisonId, invalidParam, filters)).thenReturn(
-          Response(
-            data = null,
-            errors =
-              listOf(
-                UpstreamApiError(
-                  type = UpstreamApiError.Type.BAD_REQUEST,
-                  causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON,
-                ),
-              ),
-          ),
-        )
-
-        val result = mockMvc.performAuthorised(invalidPath)
-        result.response.status.shouldBe(400)
-      }
-
-      it("returns 404 when getLocationByKeyService returns not found") {
-        whenever(getLocationByKeyService.execute(prisonId, key, filters)).thenReturn(
-          Response(
-            data = null,
-            errors =
-              listOf(
-                UpstreamApiError(
-                  type = UpstreamApiError.Type.ENTITY_NOT_FOUND,
-                  causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON,
-                ),
-              ),
-          ),
-        )
-
-        val result = mockMvc.performAuthorised(path)
-        result.response.status.shouldBe(404)
-      }
-    }
-
-    describe("POST /{prisonId}/location/{key}/deactivate") {
-      val prisonId = "MDI"
-      val key = "A-1-001"
-      val path = "/v1/prison/$prisonId/location/$key/deactivate"
-      val who = "automated-test-client"
-      val deactivateLocationRequest =
-        DeactivateLocationRequest(
-          deactivationReason = DeactivationReason.DAMAGED,
-          deactivationReasonDescription = "Scheduled maintenance",
-          proposedReactivationDate = LocalDate.now(),
-          planetFmReference = "23423TH/5",
-        )
-
-      it("returns 200 when location is successfully deactivated") {
-        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
-          Response(data = HmppsMessageResponse(message = "Deactivate location written to queue")),
-        )
-
-        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
-        result.response.status.shouldBe(200)
-        result.response.contentAsJson<DataResponse<HmppsMessageResponse>>().shouldBe(
-          DataResponse(data = HmppsMessageResponse(message = "Deactivate location written to queue")),
-        )
-      }
-
-      it("returns 404 when location is not found") {
-        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
-          Response(data = null, errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.ENTITY_NOT_FOUND, description = "Location not found", causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON))),
-        )
-
-        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
-        result.response.status.shouldBe(404)
-      }
-
-      it("returns 400 when invalid request data is provided") {
-        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
-          Response(data = null, errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, description = "Invalid data", causedBy = UpstreamApi.LOCATIONS_INSIDE_PRISON))),
-        )
-
-        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
-        result.response.status.shouldBe(400)
-      }
-
-      it("returns 409 when prisoner is in cell") {
-        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
-          Response(data = null, errors = listOf(UpstreamApiError(type = UpstreamApiError.Type.CONFLICT, description = "Prisoner in cell", causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH))),
-        )
-
-        val result = mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
-        result.response.status.shouldBe(409)
-        result.response.contentAsString.contains("Prisoner in cell")
-      }
-
-      it("logs audit event when location is deactivated") {
-        whenever(locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, null)).thenReturn(
-          Response(data = HmppsMessageResponse(message = "Deactivate location written to queue")),
-        )
-
-        mockMvc.performAuthorisedPost(path, deactivateLocationRequest)
-        verify(auditService, times(1)).createEvent(
-          "DEACTIVATE_LOCATION",
-          mapOf(
-            "prisonId" to prisonId,
-            "key" to key,
-          ),
-        )
       }
     }
   })


### PR DESCRIPTION
This moves the location endpoints (`GET /{key}` and `POST /{key}/deactivate`) to a new dedicated controller and out of `PrisonController`. This is purely to not clutter the prison controller and associated tests and also make it easier to quickly find location endpoints.

I also added a note to the deactivate endpoint to indicate it will only work for a cell.