### PR TITLE
Add reception tag to /v1/persons/{hmppsId}/health-and-diet

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/HealthAndDietController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/HealthAndDietController.kt
@@ -44,6 +44,7 @@ class HealthAndDietController(
       ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
     ],
   )
+  @Tag(name = "Reception")
   @GetMapping("/{hmppsId}/health-and-diet")
   @FeatureFlag(name = FeatureFlagConfig.USE_HEALTH_AND_DIET_ENDPOINT)
   fun getHealthAndDiet(


### PR DESCRIPTION
Reception tag was missing from the health and diet endpoint which affects where it shows up in our documentation