### PR TITLE
HMAI-564 Fix slack alerts when smoke tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ jobs:
       - run:
           name: Run smoke tests
           command: |
+            RUN apk add --no-cache curl
             k6 run ./scripts/K6/full-access-smoke-tests.js
             k6 run ./scripts/K6/limited-access-smoke-tests.js
             k6 run ./scripts/K6/no-access-with-certs-smoke-tests.js
@@ -235,7 +236,7 @@ workflows:
             - hmpps-common-vars
             - hmpps-integration-api-smoke-test-dev
           requires:
-            - post-deploy-heartbeat-for-dev
+#            - post-deploy-heartbeat-for-dev
 
       - create-and-push-image-to-ecr:
           <<: *slack-fail-post-step
@@ -244,7 +245,8 @@ workflows:
             - hmpps-common-vars
             - hmpps-integration-api-preprod
           requires:
-            - smoke-tests-for-dev
+#            - smoke-tests-for-dev
+            - post-deploy-heartbeat-for-dev
           filters:
             branches:
               only:

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -48,7 +48,7 @@ feature-flag:
   use-residential-details-endpoints: true
   use-capacity-endpoint: true
   replace-probation-search: true
-  use-location-deactivate-endpoint: false
+  use-location-deactivate-endpoint: true
   use-health-and-diet-endpoint: true
   use-personal-care-needs-endpoints: true
   use-languages-endpoints: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,7 +48,7 @@ feature-flag:
   use-residential-details-endpoints: true
   use-capacity-endpoint: true
   replace-probation-search: true
-  use-location-deactivate-endpoint: false
+  use-location-deactivate-endpoint: true
   use-health-and-diet-endpoint: true
   use-personal-care-needs-endpoints: true
   use-languages-endpoints: true


### PR DESCRIPTION
Currently when the smoke tests fail, there is an error sending notifications to slack
`Posting Status
BASH_ENV file: /tmp/.bash_env-49e9f3b3-b7db-4f8a-a91d-b46fa5f574b1-0-build
Does Not Exist. Skipping file execution
Checking For JQ + CURL
SLACK ORB ERROR: CURL is required. Please install.

Exited with code exit status 1`

This PR should resolve this