### PR TITLE
HMAI-552 Location/deactivate integration test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/DeactivateLocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/prison/DeactivateLocationIntegrationTest.kt
@@ -3,6 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.prison
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.matchers.shouldBe
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -100,6 +103,7 @@ class DeactivateLocationIntegrationTest : IntegrationTestWithQueueBase("location
           """.trimIndent(),
         ),
       )
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 1 }
 
     val queueMessages = getQueueMessages()
     queueMessages.size.shouldBe(1)
@@ -129,6 +133,8 @@ class DeactivateLocationIntegrationTest : IntegrationTestWithQueueBase("location
           """.trimIndent(),
         ),
       )
+
+    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 1 }
 
     val queueMessages = getQueueMessages()
     queueMessages.size.shouldBe(1)


### PR DESCRIPTION
A couple of tests in the DeactivateLocationIntegrationTest file were periodically failing as the test did not have an await call in it to check the number of messages on the queue before the assertion. This meant that the assertion was sometimes being checked (and failing) before the message had been added to the queue. This has now been added and tested, and have yet to see the tests failing again.