### PR TITLE
Correct event type code for location deactivations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/HmppsMessageEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/HmppsMessageEventType.kt
@@ -34,7 +34,7 @@ enum class HmppsMessageEventType(
   ),
   LOCATION_DEACTIVATE(
     type = "locations-inside-prison.location.deactivate",
-    eventTypeCode = "LocationDeactivate",
+    eventTypeCode = "LocationTemporarilyDeactivated",
     description = "A location has been deactivated",
   ),
   EDUCATION_ASSESSMENT_EVENT_CREATED(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/LocationQueueServiceTest.kt
@@ -101,7 +101,7 @@ internal class LocationQueueServiceTest(
       }
 
       it("successfully adds to message queue") {
-        val messageBody = """{"messageId":"1","eventType":"LocationDeactivate","messageAttributes":{}}"""
+        val messageBody = """{"messageId":"1","eventType":"LocationTemporarilyDeactivated","messageAttributes":{}}"""
         whenever(objectMapper.writeValueAsString(any<HmppsMessage>())).thenReturn(messageBody)
 
         val result = locationQueueService.sendDeactivateLocationRequest(deactivateLocationRequest, prisonId, key, who, filters)


### PR DESCRIPTION
The name of the event in the locations API had been updated and not reflected in our API. This PR corrects that.