### PR TITLE
Allow array request bodies on web client wrapper

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -41,12 +41,14 @@ data class TestDomainModel(
 class WebClientWrapperTest :
   DescribeSpec({
     val mockServer = TestApiMockServer()
+    lateinit var webClient: WebClientWrapper
+
     val id = "ABC1234"
     val headers = mapOf("foo" to "bar")
 
     beforeEach {
       mockServer.start()
-      mockServer.resetAll()
+      webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
     }
 
     afterTest {
@@ -65,7 +67,6 @@ class WebClientWrapperTest :
             """.removeWhitespaceAndNewlines(),
           )
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result = webClient.request<TestModel>(HttpMethod.GET, "/test/$id", headers, UpstreamApi.TEST)
 
           if (result is WebClientWrapperResponse.Success) {
@@ -93,7 +94,6 @@ class WebClientWrapperTest :
             """.removeWhitespaceAndNewlines(),
           )
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result = webClient.request<SearchModel>(HttpMethod.POST, "/testPost", headers, UpstreamApi.TEST, mapOf("sourceName" to "Paul"))
 
           if (result is WebClientWrapperResponse.Success) {
@@ -108,7 +108,6 @@ class WebClientWrapperTest :
         it("performs a POST request where the request body is an array") {
           mockServer.stubPostTest("{}")
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result =
             webClient.request<Any>(
               HttpMethod.POST,
@@ -136,7 +135,6 @@ class WebClientWrapperTest :
               "bar" to "baz",
             )
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result = webClient.request<StringModel>(HttpMethod.GET, "/test", headers = headers, UpstreamApi.TEST)
 
           if (result is WebClientWrapperResponse.Success) {
@@ -160,7 +158,6 @@ class WebClientWrapperTest :
             """.removeWhitespaceAndNewlines(),
           )
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result =
             webClient.requestList<TestModel>(
               HttpMethod.GET,
@@ -189,7 +186,6 @@ class WebClientWrapperTest :
             """.removeWhitespaceAndNewlines(),
           )
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result =
             webClient.requestList<TestModel>(
               HttpMethod.POST,
@@ -208,7 +204,6 @@ class WebClientWrapperTest :
         it("performs a POST request where the request body is an array") {
           mockServer.stubPostTest("{}")
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result =
             webClient.requestList<Any>(
               HttpMethod.POST,
@@ -236,7 +231,6 @@ class WebClientWrapperTest :
               "bar" to "baz",
             )
 
-          val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
           val result = webClient.requestList<StringModel>(HttpMethod.GET, "/test", headers = headers, UpstreamApi.TEST)
 
           if (result is WebClientWrapperResponse.Success) {
@@ -252,7 +246,7 @@ class WebClientWrapperTest :
     describe("when webClientWrapperResponse is Error") {
       it("returns an entity not found UpstreamApiError when the request 404's") {
         mockServer.stubPostTest("", HttpStatus.NOT_FOUND)
-        val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
+
         val result = webClient.request<TestModel>(HttpMethod.GET, "/test/$id", headers, UpstreamApi.TEST)
 
         if (result is WebClientWrapperResponse.Error) {
@@ -269,7 +263,7 @@ class WebClientWrapperTest :
 
       it("returns a forbidden UpstreamApiError when the request 403's") {
         mockServer.stubPostTest("", HttpStatus.FORBIDDEN)
-        val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
+
         val result = webClient.request<TestModel>(HttpMethod.GET, "/test/$id", headers, UpstreamApi.TEST)
 
         if (result is WebClientWrapperResponse.Error) {
@@ -286,7 +280,7 @@ class WebClientWrapperTest :
 
       it("returns a bad request UpstreamApiError when the request 400's") {
         mockServer.stubPostTest("", HttpStatus.BAD_REQUEST)
-        val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
+
         val result = webClient.request<TestModel>(HttpMethod.GET, "/test/$id", headers, UpstreamApi.TEST)
 
         if (result is WebClientWrapperResponse.Error) {
@@ -303,7 +297,7 @@ class WebClientWrapperTest :
 
       it("returns a internal server error UpstreamApiError when the request 500's") {
         mockServer.stubPostTest("", HttpStatus.INTERNAL_SERVER_ERROR)
-        val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
+
         val result = webClient.request<TestModel>(HttpMethod.GET, "/test/$id", headers, UpstreamApi.TEST)
 
         if (result is WebClientWrapperResponse.Error) {
@@ -328,7 +322,6 @@ class WebClientWrapperTest :
       )
 
       try {
-        val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
         webClient.request<SearchModel>(HttpMethod.GET, "/test/$id", headers = headers, UpstreamApi.TEST)
       } catch (_: WebClientResponseException) {
         fail("Exceeded memory buffer")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -19,10 +19,9 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.TestApiMockS
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import java.io.File
-import kotlin.test.assertTrue
 
 data class StringModel(
-  val headers: String,
+  val result: String,
 )
 
 data class TestModel(
@@ -107,31 +106,39 @@ class WebClientWrapperTest :
         }
 
         it("performs a POST request where the request body is an array") {
-          mockServer.stubPostTest(postPath, "{}")
+          mockServer.stubPostTest(
+            postPath,
+            """
+            {
+              "result": "success"
+            }
+            """.removeWhitespaceAndNewlines(),
+          )
 
           val result =
-            webClient.request<Any>(
+            webClient.request<StringModel>(
               HttpMethod.POST,
               postPath,
               headers,
               UpstreamApi.TEST,
               listOf("Paul"),
             )
-
           mockServer.verify(
             postRequestedFor(urlEqualTo(postPath))
               .withRequestBody(equalToJson("[\"Paul\"]"))
               .withHeader("Content-Type", equalTo("application/json")),
           )
-
-          assertTrue { result is WebClientWrapperResponse.Success }
+          result.shouldBeInstanceOf<WebClientWrapperResponse.Success<StringModel>>()
+          result.data.result.shouldBe("success")
         }
 
         it("performs a GET request with multiple headers") {
           mockServer.stubGetTest(
             getPath,
             """
-              { "headers": "headers matched" }
+            {
+              "result": "headers matched"
+            }
             """.removeWhitespaceAndNewlines(),
           )
 
@@ -148,7 +155,7 @@ class WebClientWrapperTest :
               .withHeader("bar", equalTo(headers["bar"])),
           )
           result.shouldBeInstanceOf<WebClientWrapperResponse.Success<StringModel>>()
-          result.data.headers.shouldBe("headers matched")
+          result.data.result.shouldBe("headers matched")
         }
       }
 
@@ -209,10 +216,17 @@ class WebClientWrapperTest :
         }
 
         it("performs a POST request where the request body is an array") {
-          mockServer.stubPostTest(postPath, "{}")
+          mockServer.stubPostTest(
+            postPath,
+            """
+            {
+              "result": "success"
+            }
+            """.removeWhitespaceAndNewlines(),
+          )
 
           val result =
-            webClient.requestList<Any>(
+            webClient.requestList<StringModel>(
               HttpMethod.POST,
               postPath,
               headers,
@@ -225,15 +239,20 @@ class WebClientWrapperTest :
               .withRequestBody(equalToJson("[\"Paul\"]"))
               .withHeader("Content-Type", equalTo("application/json")),
           )
-
-          assertTrue { result is WebClientWrapperResponse.Success }
+          result.shouldBeInstanceOf<WebClientWrapperResponse.Success<List<StringModel>>>()
+          result.data
+            .first()
+            .result
+            .shouldBe("success")
         }
 
         it("performs a GET request with multiple headers") {
           mockServer.stubGetTest(
             getPath,
             """
-              { "headers": "headers matched" }
+            {
+              "result": "headers matched"
+            }
             """.removeWhitespaceAndNewlines(),
           )
 
@@ -252,7 +271,7 @@ class WebClientWrapperTest :
           result.shouldBeInstanceOf<WebClientWrapperResponse.Success<List<StringModel>>>()
           result.data
             .first()
-            .headers
+            .result
             .shouldBe("headers matched")
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -62,14 +62,7 @@ class WebClientWrapperTest :
     describe("when webClientWrapperResponse is Success") {
       describe("when request") {
         it("performs a GET request where the result is a json object") {
-          mockServer.stubGetTest(
-            getPath,
-            """
-            {
-              "sourceName" : "Harold"
-            }
-            """.removeWhitespaceAndNewlines(),
-          )
+          mockServer.stubGetTest(getPath, """{"sourceName" : "Harold"}""".removeWhitespaceAndNewlines())
 
           val result = webClient.request<TestModel>(HttpMethod.GET, getPath, headers, UpstreamApi.TEST)
           result.shouldBeInstanceOf<WebClientWrapperResponse.Success<TestModel>>()
@@ -106,14 +99,7 @@ class WebClientWrapperTest :
         }
 
         it("performs a POST request where the request body is an array") {
-          mockServer.stubPostTest(
-            postPath,
-            """
-            {
-              "result": "success"
-            }
-            """.removeWhitespaceAndNewlines(),
-          )
+          mockServer.stubPostTest(postPath, """{"result": "success"}""")
 
           val result =
             webClient.request<StringModel>(
@@ -133,14 +119,7 @@ class WebClientWrapperTest :
         }
 
         it("performs a GET request with multiple headers") {
-          mockServer.stubGetTest(
-            getPath,
-            """
-            {
-              "result": "headers matched"
-            }
-            """.removeWhitespaceAndNewlines(),
-          )
+          mockServer.stubGetTest(getPath, """{"result": "headers matched"}""")
 
           val headers =
             mapOf(
@@ -216,14 +195,7 @@ class WebClientWrapperTest :
         }
 
         it("performs a POST request where the request body is an array") {
-          mockServer.stubPostTest(
-            postPath,
-            """
-            {
-              "result": "success"
-            }
-            """.removeWhitespaceAndNewlines(),
-          )
+          mockServer.stubPostTest(postPath, """{"result": "success"}""")
 
           val result =
             webClient.requestList<StringModel>(
@@ -247,14 +219,7 @@ class WebClientWrapperTest :
         }
 
         it("performs a GET request with multiple headers") {
-          mockServer.stubGetTest(
-            getPath,
-            """
-            {
-              "result": "headers matched"
-            }
-            """.removeWhitespaceAndNewlines(),
-          )
+          mockServer.stubGetTest(getPath, """{"result": "headers matched"}""")
 
           val headers =
             mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import io.kotest.assertions.fail
@@ -127,7 +128,12 @@ class WebClientWrapperTest :
         }
 
         it("performs a GET request with multiple headers") {
-          mockServer.stubGetWithHeadersTest(getPath)
+          mockServer.stubGetTest(
+            getPath,
+            """
+              { "headers": "headers matched" }
+            """.removeWhitespaceAndNewlines(),
+          )
 
           val headers =
             mapOf(
@@ -136,6 +142,11 @@ class WebClientWrapperTest :
             )
 
           val result = webClient.request<StringModel>(HttpMethod.GET, getPath, headers = headers, UpstreamApi.TEST)
+          mockServer.verify(
+            getRequestedFor(urlEqualTo(getPath))
+              .withHeader("foo", equalTo(headers["foo"]))
+              .withHeader("bar", equalTo(headers["bar"])),
+          )
           result.shouldBeInstanceOf<WebClientWrapperResponse.Success<StringModel>>()
           result.data.headers.shouldBe("headers matched")
         }
@@ -219,7 +230,12 @@ class WebClientWrapperTest :
         }
 
         it("performs a GET request with multiple headers") {
-          mockServer.stubGetWithHeadersTest(getPath)
+          mockServer.stubGetTest(
+            getPath,
+            """
+              { "headers": "headers matched" }
+            """.removeWhitespaceAndNewlines(),
+          )
 
           val headers =
             mapOf(
@@ -228,6 +244,11 @@ class WebClientWrapperTest :
             )
 
           val result = webClient.requestList<StringModel>(HttpMethod.GET, getPath, headers = headers, UpstreamApi.TEST)
+          mockServer.verify(
+            getRequestedFor(urlEqualTo(getPath))
+              .withHeader("foo", equalTo(headers["foo"]))
+              .withHeader("bar", equalTo(headers["bar"])),
+          )
           result.shouldBeInstanceOf<WebClientWrapperResponse.Success<List<StringModel>>>()
           result.data
             .first()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -123,7 +123,7 @@ class WebClientWrapperTest :
           assertTrue { result is WebClientWrapperResponse.Success }
         }
 
-        it("performs a request with multiple headers for .request()") {
+        it("performs a GET request with multiple headers") {
           mockServer.stubGetWithHeadersTest()
 
           val headers =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -53,10 +53,10 @@ class WebClientWrapperTest :
           mockServer.stubGetTest(
             id,
             """
-          {
-            "sourceName" : "Harold"
-          }
-          """.removeWhitespaceAndNewlines(),
+            {
+              "sourceName" : "Harold"
+            }
+            """.removeWhitespaceAndNewlines(),
           )
 
           val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
@@ -71,20 +71,20 @@ class WebClientWrapperTest :
         it("performs a post request where the response is a json object") {
           mockServer.stubPostTest(
             """
-        {
-          "content":
-          [
             {
-              "sourceName": "Paul",
-              "sourceLastName": "Paper"
-            },
-            {
-              "sourceName": "Paul",
-              "sourceLastName": "Card"
+              "content":
+              [
+                {
+                  "sourceName": "Paul",
+                  "sourceLastName": "Paper"
+                },
+                {
+                  "sourceName": "Paul",
+                  "sourceLastName": "Card"
+                }
+              ]
             }
-          ]
-        }
-      """.removeWhitespaceAndNewlines(),
+            """.removeWhitespaceAndNewlines(),
           )
 
           val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
@@ -121,15 +121,15 @@ class WebClientWrapperTest :
         it("performs a GET request where the response is an array") {
           mockServer.stubPostTest(
             """
-        [
-          {
-            "sourceName": "Paul"
-          },
-          {
-            "sourceName": "Paul"
-          }
-        ]
-      """.removeWhitespaceAndNewlines(),
+            [
+              {
+                "sourceName": "Paul"
+              },
+              {
+                "sourceName": "Paul"
+              }
+            ]
+            """.removeWhitespaceAndNewlines(),
           )
 
           val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
@@ -150,15 +150,15 @@ class WebClientWrapperTest :
         it("performs a post request where the response is an array") {
           mockServer.stubPostTest(
             """
-        [
-          {
-            "sourceName": "Paul"
-          },
-          {
-            "sourceName": "Paul"
-          }
-        ]
-      """.removeWhitespaceAndNewlines(),
+            [
+              {
+                "sourceName": "Paul"
+              },
+              {
+                "sourceName": "Paul"
+              }
+            ]
+            """.removeWhitespaceAndNewlines(),
           )
 
           val webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/TestApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/TestApiMockServer.kt
@@ -9,21 +9,6 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 4000
   }
 
-  fun stubGetWithHeadersTest(path: String) {
-    stubFor(
-      WireMock
-        .get(path)
-        .withHeader("foo", WireMock.equalTo("bar"))
-        .withHeader("bar", WireMock.equalTo("baz"))
-        .willReturn(
-          WireMock
-            .aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody("""{"headers":"headers matched"}"""),
-        ),
-    )
-  }
-
   fun stubGetTest(
     path: String,
     body: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/TestApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/TestApiMockServer.kt
@@ -9,10 +9,10 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
     private const val WIREMOCK_PORT = 4000
   }
 
-  fun stubGetWithHeadersTest() {
+  fun stubGetWithHeadersTest(path: String) {
     stubFor(
       WireMock
-        .get("/test")
+        .get(path)
         .withHeader("foo", WireMock.equalTo("bar"))
         .withHeader("bar", WireMock.equalTo("baz"))
         .willReturn(
@@ -25,13 +25,13 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun stubGetTest(
-    id: String,
+    path: String,
     body: String,
     status: HttpStatus = HttpStatus.OK,
   ) {
     stubFor(
       WireMock
-        .get("/test/$id")
+        .get(path)
         .willReturn(
           WireMock
             .aResponse()
@@ -43,11 +43,12 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun stubPostTest(
+    path: String,
     body: String,
     status: HttpStatus = HttpStatus.OK,
   ) {
     stubFor(
-      WireMock.post("/testPost").willReturn(
+      WireMock.post(path).willReturn(
         WireMock
           .aResponse()
           .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Currently, our `WebClientWrapper` expects request bodies to be of type `Map<String, Any?>?`. This generally hasn't been a problem up until now as most request bodies conform to this but `/scheduled-events/prison/{prisonCode}` on the Activities API expects an array of strings to be provided.

To fix this I have changed the request body type to be `Any?`, as in reality anything that can be stringified should be allowed.

When adding specific tests to check that passing in an array didn't cause any regressions I noticed and corrected some issues with the tests in the `WebClientWrapperTest` file.

* Lots of tests had conditional checks
* Removing the conditional checks actually caused many tests to fail - all of these failures were due to incorrect logic in the tests which were being masked by the checks not actually running within them.
* Quite a bit of repetition of things that should be in top level variables

