### PR TITLE
Rename activities gateway method to getActivitySchedules

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ActivitiesGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ActivitiesGateway.kt
@@ -53,35 +53,11 @@ class ActivitiesGateway(
     }
   }
 
-  fun getActivitiesSchedule(activityId: Long): Response<List<ActivitiesActivitySchedule>?> {
+  fun getActivitySchedules(activityId: Long): Response<List<ActivitiesActivitySchedule>?> {
     val result =
       webClient.requestList<ActivitiesActivitySchedule>(
         HttpMethod.GET,
         "/activities/$activityId/schedules",
-        authenticationHeader(),
-        UpstreamApi.ACTIVITIES,
-        badRequestAsError = true,
-      )
-
-    return when (result) {
-      is WebClientWrapperResponse.Success -> {
-        Response(data = result.data)
-      }
-
-      is WebClientWrapperResponse.Error -> {
-        Response(
-          data = null,
-          errors = result.errors,
-        )
-      }
-    }
-  }
-
-  fun getAllRunningActivities(prisonCode: String): Response<List<ActivitiesRunningActivity>?> {
-    val result =
-      webClient.requestList<ActivitiesRunningActivity>(
-        HttpMethod.GET,
-        "/prison/$prisonCode/activities",
         authenticationHeader(),
         UpstreamApi.ACTIVITIES,
         badRequestAsError = true,
@@ -106,6 +82,30 @@ class ActivitiesGateway(
       webClient.request<ActivitiesActivityScheduleDetailed>(
         HttpMethod.GET,
         "/schedules/$scheduleId",
+        authenticationHeader(),
+        UpstreamApi.ACTIVITIES,
+        badRequestAsError = true,
+      )
+
+    return when (result) {
+      is WebClientWrapperResponse.Success -> {
+        Response(data = result.data)
+      }
+
+      is WebClientWrapperResponse.Error -> {
+        Response(
+          data = null,
+          errors = result.errors,
+        )
+      }
+    }
+  }
+
+  fun getAllRunningActivities(prisonCode: String): Response<List<ActivitiesRunningActivity>?> {
+    val result =
+      webClient.requestList<ActivitiesRunningActivity>(
+        HttpMethod.GET,
+        "/prison/$prisonCode/activities",
         authenticationHeader(),
         UpstreamApi.ACTIVITIES,
         badRequestAsError = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetActivitySchedulesGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetActivitySchedulesGatewayTest.kt
@@ -33,7 +33,7 @@ import java.time.LocalDateTime
   initializers = [ConfigDataApplicationContextInitializer::class],
   classes = [ActivitiesGateway::class],
 )
-class GetActivitiesScheduleGatewayTest(
+class GetActivitySchedulesGatewayTest(
   @MockitoBean val hmppsAuthGateway: HmppsAuthGateway,
   private val activitiesGateway: ActivitiesGateway,
 ) : DescribeSpec(
@@ -55,7 +55,7 @@ class GetActivitiesScheduleGatewayTest(
       }
 
       it("authenticates using HMPPS Auth with credentials") {
-        activitiesGateway.getActivitiesSchedule(activityId)
+        activitiesGateway.getActivitySchedules(activityId)
 
         verify(hmppsAuthGateway, VerificationModeFactory.times(1)).getClientToken("ACTIVITIES")
       }
@@ -66,7 +66,7 @@ class GetActivitiesScheduleGatewayTest(
           File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitiesSchedule.json").readText(),
         )
 
-        val result = activitiesGateway.getActivitiesSchedule(activityId)
+        val result = activitiesGateway.getActivitySchedules(activityId)
         result.errors.shouldBeEmpty()
         result.data.shouldNotBeNull()
         result.data[0].shouldBe(
@@ -152,7 +152,7 @@ class GetActivitiesScheduleGatewayTest(
           HttpStatus.BAD_REQUEST,
         )
 
-        val result = activitiesGateway.getActivitiesSchedule(activityId)
+        val result = activitiesGateway.getActivitySchedules(activityId)
         result.errors.shouldBe(listOf(UpstreamApiError(causedBy = UpstreamApi.ACTIVITIES, type = UpstreamApiError.Type.BAD_REQUEST)))
       }
     },


### PR DESCRIPTION
Updated naming of gateway method from getActivitiesSchedule to getActivitySchedules to better reflect what the gateway returns.