### PR TITLE
Change prison ID on prison regime smoke test

### DIFF
--- a/scripts/K6/full-access-smoke-tests.js
+++ b/scripts/K6/full-access-smoke-tests.js
@@ -60,7 +60,7 @@ const get_endpoints = [
   `/v1/prison/${prisonId}/location/${locationIdKey}`,
   `/v1/prison/${prisonId}/residential-details`,
   `/v1/prison/${prisonId}/capacity`,
-  `/v1/prison/${prisonId}/prison-regime`,
+  `/v1/prison/RSI/prison-regime`,
   `/v1/contacts/${clientReference}`,
   `/v1/persons?first_name=john`,
   `/v1/persons/${deliusCrn}`,


### PR DESCRIPTION
Looks like `MKI` is not currently set up in dev, have changed it to `RSI` for now