### PR TITLE
HMAI-626 Test and set feature flag to true on all environments for GET /v1/prison/{prisonId}/activities

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -52,7 +52,7 @@ feature-flag:
   use-personal-care-needs-endpoints: true
   use-languages-endpoints: true
   use-prison-regime-endpoint: true
-  use-prison-activities-endpoint: false
+  use-prison-activities-endpoint: true
 
 authorisation:
   consumers:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,7 +52,7 @@ feature-flag:
   use-personal-care-needs-endpoints: true
   use-languages-endpoints: true
   use-prison-regime-endpoint: true
-  use-prison-activities-endpoint: false
+  use-prison-activities-endpoint: true
 
 authorisation:
   consumers:


### PR DESCRIPTION
Can successfully see 200 with RSI:
{{base-url-dev}}/v1/prison/RSI/activities

`{
    "data": [
        {
            "id": 401,
            "activityName": "Admin Orderly",
            "category": {
                "code": "SAA_PRISON_JOBS",
                "name": "Prison jobs",
                "description": "Such as kitchen, cleaning, gardens or other maintenance and services to keep the prison running"
            },
            "capacity": 2,
            "allocated": 4,
            "waitlisted": 4,
            "activityState": "LIVE"
        },`

Empty data for MKI or other invalid prison codes as we don’t validate the prison code.

404 only possible where prison id isn’t in filter list.