### PR TITLE
HMAI-635 Test and set feature flag to true on all environments for v1/prison/{prisonId}/prison-pay-bands

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -53,7 +53,7 @@ feature-flag:
   use-languages-endpoints: true
   use-prison-regime-endpoint: true
   use-prison-activities-endpoint: true
-  use-prison-pay-bands-endpoint: false
+  use-prison-pay-bands-endpoint: true
 
 authorisation:
   consumers:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,7 +53,7 @@ feature-flag:
   use-languages-endpoints: true
   use-prison-regime-endpoint: true
   use-prison-activities-endpoint: true
-  use-prison-pay-bands-endpoint: false
+  use-prison-pay-bands-endpoint: true
 
 authorisation:
   consumers:


### PR DESCRIPTION
Can successfully see 200 with RSI:
{{base-url-dev}}/v1/prison/RSI/prison-pay-bands

`{
    "data": [
        {
            "id": 312,
            "alias": "Pay band 1 (Lowest)",
            "description": "Pay band 1 (Lowest)"
        },
        {
            "id": 313,
            "alias": "Alias of payBand2",
            "description": "Pay band 2"
        },
        {
            "id": 314,
            "alias": "Pay band 3",
            "description": "Pay band 3"
        },
        {
            "id": 315,
            "alias": "Pay band 4",
            "description": "Pay band 4"
        },
        {
            "id": 316,
            "alias": "Pay band 5",
            "description": "Pay band 5"
        },
        {
            "id": 317,
            "alias": "Pay band 6",
            "description": "Pay band 6"
        },
        {
            "id": 318,
            "alias": "Pay band 7",
            "description": "Pay band 7"
        },
        {
            "id": 319,
            "alias": "Pay band 8",
            "description": "Pay band 8"
        },
        {
            "id": 320,
            "alias": "Pay band 9",
            "description": "Pay band 9"
        },
        {
            "id": 321,
            "alias": "Pay band 10 (Highest)",
            "description": "Pay band 10 (Highest)"
        }
    ]
}`

Empty data for MKI or other invalid prison codes as we don’t validate the prison code.

404 only possible where prison id isn’t in filter list.