### PR TITLE
Enable deep linking in API reference docs

### DIFF
--- a/tech-docs/source/documentation/api/index.html.md.erb
+++ b/tech-docs/source/documentation/api/index.html.md.erb
@@ -44,7 +44,8 @@ window.addEventListener("load", (event) => {
       SwaggerUIStandalonePreset
     ],
     layout: "StandaloneLayout",
-    displayOperationId: false
+    displayOperationId: false,
+    deepLinking: true
   })
 });
 </script>


### PR DESCRIPTION
This makes it easier to share a link to a specific endpoint in the Swagger output.