### PR TITLE
Fix test with incorrect variables.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueServiceTest.kt
@@ -173,7 +173,7 @@ class ActivitiesQueueServiceTest(
             instances =
               listOf(
                 ActivityScheduleInstance(
-                  scheduleInstanceId = scheduleId,
+                  id = scheduleId,
                   date = "2022-10-20",
                   startTime = "09:00",
                   endTime = "12:00",
@@ -242,7 +242,6 @@ class ActivitiesQueueServiceTest(
                 ),
               ),
             description = "Morning Education Class",
-            internalLocation = 123,
             capacity = 25,
             scheduleWeeks = 2,
             slots =


### PR DESCRIPTION
I believe this was because the consistency PR was open while another change was merged.