### PR TITLE
HMAI-639 - Update HMPPS Spring Gradle Plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0-beta"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0"
   kotlin("plugin.spring") version "2.1.21"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.0-beta"
   kotlin("plugin.spring") version "2.1.21"
 }
 


### PR DESCRIPTION
Updates the `uk.gov.justice.hmpps.gradle-spring-boot` plugin to version `8.3.0` to see that it fixes our security alerts in CircleCI. The CVEs should all be patched by bumps to deps in the plugin.