### PR TITLE
Assign police role to pnd in preprod and prod

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -81,4 +81,4 @@ authorisation:
       include:
       filters:
       roles:
-        - "reference-data-only"
+        - "police"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -81,4 +81,4 @@ authorisation:
       include:
       filters:
       roles:
-        - "reference-data-only"
+        - "police"


### PR DESCRIPTION
We planned to grant production access to PND a couple of weeks ago, but there was a last minute challenge on their side so we paused it. We did introduce a new role for them, and switched their dev account over to that role.

PND are now ready to proceed and so we can assign their user the same role in pre-prod and prod that it currently has in dev.