### PR TITLE
Enable schedule detail endpoint in prod and preprod.

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -42,7 +42,7 @@ feature-flag:
   use-arns-endpoints: false
   use-education-assessments-endpoints: false
   use-update-attendance-endpoint: false
-  use-schedule-detail-endpoint: false
+  use-schedule-detail-endpoint: true
   use-search-appointments-endpoint: false
   use-deallocation-endpoint: false
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -42,7 +42,7 @@ feature-flag:
   use-arns-endpoints: false
   use-education-assessments-endpoints: false
   use-update-attendance-endpoint: false
-  use-schedule-detail-endpoint: false
+  use-schedule-detail-endpoint: true
   use-search-appointments-endpoint: false
   use-deallocation-endpoint: false
 


### PR DESCRIPTION
Can successfully see 200 with:
`{{base-url-dev}}/v1/activities/schedule/1162`

```
{"data":{"instances":[],"allocations":[],"description":"Plastering course","suspensions":[],"capacity":4,"scheduleWeeks":1,"slots":[{"id":3322,"timeSlot":"AM","weekNumber":1,"startTime":"08:30","endTime":"11:45","daysOfWeek":["Mon"],"mondayFlag":true,"tuesdayFlag":false,"wednesdayFlag":false,"thursdayFlag":false,"fridayFlag":false,"saturdayFlag":false,"sundayFlag":false},{"id":3323,"timeSlot":"PM","weekNumber":1,"startTime":"13:45","endTime":"16:45","daysOfWeek":["Mon"],"mondayFlag":true,"tuesdayFlag":false,"wednesdayFlag":false,"thursdayFlag":false,"fridayFlag":false,"saturdayFlag":false,"sundayFlag":false}],"startDate":"2025-07-31","endDate":null,"runsOnBankHoliday":false,"usePrisonRegimeTime":true}}                                                                                                                                                                                      
```

returns a 400 when bad request is made:
{{base-url-dev}}/v1/activities/schedule/test

```
{
  "status": 400,
  "errorCode": null,
  "userMessage": "Invalid input type for 'scheduleId'",
  "developerMessage": "Type mismatch: Method parameter 'scheduleId': Failed to convert value of type 'java.lang.String' to required type 'long'; For input string: \"test\"",
  "moreInfo": null
}
```

returns a 404 when activity id is in valid format but not found:
{{base-url-dev}}/v1/activities/schedule/10000

```
{
  "status": 404,
  "errorCode": null,
  "userMessage": "Could not find schedule details for supplied schedule id: 10000.",
  "developerMessage": "404 Not found error: Could not find schedule details for supplied schedule id: 10000.",
  "moreInfo": null
}
```