### PR TITLE
HMAI-672 - Fix visit by client ref smoke test

### DIFF
--- a/scripts/K6/full-access-smoke-tests.js
+++ b/scripts/K6/full-access-smoke-tests.js
@@ -71,7 +71,7 @@ const get_endpoints = [
   `/v1/prison/${alternativeprisonId}/prison-regime`,
   `/v1/prison/${alternativeprisonId}/activities`,
   `/v1/prison/${alternativeprisonId}/prison-pay-bands`,
-  `/v1/contacts/${clientReference}`,
+  `/v1/contacts/${contactId}`,
   `/v1/persons?first_name=john`,
   `/v1/persons/${deliusCrn}`,
   `/v1/persons/${hmppsId}/licences/conditions`,

--- a/scripts/K6/full-access-smoke-tests.js
+++ b/scripts/K6/full-access-smoke-tests.js
@@ -25,7 +25,7 @@ const risksCrn = "X756352";
 const prisonId = "MKI";
 const alternativeprisonId = "RSI";
 const visitReference = "qd-lh-gy-lx";
-const clientReference = "123456";
+const clientVisitReference = "SMOKE_TEST_CLIENT_REF";
 const contactId = "1898610";
 const imageId = "1988315";
 const locationIdKey = "MKI-A";
@@ -89,7 +89,7 @@ const get_endpoints = [
   `/v1/hmpps/id/nomis-number/${hmppsId}`,
   `/v1/persons/${hmppsId}/visit/future`,
   `/v1/visit/${visitReference}`,
-  // `/v1/visit/id/by-client-ref/${clientReference}`, REMOVED AS THIS ENDPOINT IS TIMING OUT AS TOO MANY VISITS SHARE THIS ID
+  `/v1/visit/id/by-client-ref/${clientVisitReference}`,
   `/v1/prison/${prisonId}/visit/search?visitStatus=BOOKED`,
   `/v1/persons/${deliusCrn}/protected-characteristics`,
   `/v1/epf/person-details/${deliusCrn}/1`,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/DetailedContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/DetailedContact.kt
@@ -34,9 +34,9 @@ data class DetailedContact(
   @Schema(description = "All email addresses for the contact")
   val emailAddresses: List<ContactEmailAddress>,
   @Schema(description = "The NOMIS code for the contacts gender. See reference data with group code 'GENDER'")
-  val genderCode: String,
+  val genderCode: String?,
   @Schema(description = "The description of gender code. See reference data with group code 'GENDER'")
-  val genderDescription: String,
+  val genderDescription: String?,
 )
 
 data class ContactAddress(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRDetailedContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRDetailedContact.kt
@@ -21,8 +21,8 @@ data class PRDetailedContact(
   val addresses: List<Address>,
   val phoneNumbers: List<PhoneNumber>,
   val emailAddresses: List<EmailAddress>,
-  val genderCode: String,
-  val genderDescription: String,
+  val genderCode: String?,
+  val genderDescription: String?,
 ) {
   fun toDetailedContact(): DetailedContact =
     DetailedContact(


### PR DESCRIPTION
Changed the client visit ref to be one with only 1 visit, which I manually created in postman. It shouldn't be a problem going forward as the visit POST will not create anymore visits linked to this client visit reference