### PR TITLE
Clarify that API access isn't guaranteed.

### DIFF
--- a/tech-docs/source/documentation/get-started/index.html.md.erb
+++ b/tech-docs/source/documentation/get-started/index.html.md.erb
@@ -11,7 +11,7 @@ review_in: 3 months
 
 Email [hmpps-integration-api@digital.justice.gov.uk](mailto:hmpps-integration-api@digital.justice.gov.uk) to request access to this API and Events.
 
-All requests will be manually approved.
+All requests will be manually approved. **We cannot guarantee that you will be given access to the API or which endpoints you will be given access to**.
 
 You may also request access to our non-live environment for testing purposes.
 
@@ -24,5 +24,8 @@ For information on how to use these credentials, see our [Authentication](/authe
 
 ## Explore Available Endpoints
 
-We provide API access on an endpoint by endpoint basis. Please review the available [endpoints](../api/index.html), and
-let us know what data you require when you get in contact.
+Please review the available [endpoints](../api/index.html), and let us know what data you require when you get in contact.
+We provide API access on an endpoint by endpoint basis. **You might not receive access to all the endpoints you request**.
+
+Please contact us at [hmpps-integration-api@digital.justice.gov.uk](mailto:hmpps-integration-api@digital.justice.gov.uk)
+to get a better understanding of what access we are likely to provide.


### PR DESCRIPTION
This is to attempt to prevent potential consumers from planning to use certain endpoints/data before they've been in contact.