### PR TITLE
HMAI-698 - Fix visits future endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonVisitsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonVisitsGateway.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -155,10 +154,5 @@ class PrisonVisitsGateway(
     return mapOf(
       "Authorization" to "Bearer $token",
     )
-  }
-
-  fun mapToVisits(result: WebClientWrapperResponse.Success<List<PVVisit>?>): List<PVVisit> {
-    val mappedResult: List<PVVisit> = mapper.convertValue(result.data, object : TypeReference<List<PVVisit>>() {})
-    return mappedResult
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonVisitsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonVisitsGateway.kt
@@ -99,7 +99,7 @@ class PrisonVisitsGateway(
 
   fun getFutureVisits(prisonerId: String): Response<List<PVVisit>?> {
     val result =
-      webClient.request<List<PVVisit>?>(
+      webClient.requestList<PVVisit>(
         HttpMethod.GET,
         "/visits/search/future/$prisonerId",
         authenticationHeader(),
@@ -110,7 +110,7 @@ class PrisonVisitsGateway(
     return when (result) {
       is WebClientWrapperResponse.Success -> {
         Response(
-          data = mapToVisits(result),
+          data = result.data,
         )
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonVisits/PVVisit.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonVisits/PVVisit.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonVisits
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Visit
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.VisitContact
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.VisitExternalSystemDetails
@@ -9,47 +8,26 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.VisitorSupp
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Visitors
 
 data class PVVisit(
-  @JsonProperty("applicationReference")
   val applicationReference: String?,
-  @JsonProperty("reference")
   val reference: String?,
-  @JsonProperty("prisonerId")
   val prisonerId: String,
-  @JsonProperty("prisonId")
   val prisonId: String,
-  @JsonProperty("prisonName")
   val prisonName: String?,
-  @JsonProperty("sessionTemplateReference")
   val sessionTemplateReference: String?,
-  @JsonProperty("visitRoom")
   val visitRoom: String,
-  @JsonProperty("visitType")
   val visitType: String,
-  @JsonProperty("visitStatus")
   val visitStatus: String,
-  @JsonProperty("outcomeStatus")
   val outcomeStatus: String?,
-  @JsonProperty("visitRestriction")
   val visitRestriction: String,
-  @JsonProperty("startTimestamp")
   val startTimestamp: String,
-  @JsonProperty("endTimestamp")
   val endTimestamp: String,
-  @JsonProperty("visitNotes")
   val visitNotes: List<PVVisitNotes>?,
-  @JsonProperty("visitContact")
   val visitContact: PVVisitContact?,
-  @JsonProperty("visitors")
   val visitors: List<PVVisitors>?,
-  @JsonProperty("visitorSupport")
   val visitorSupport: PVVisitorSupport?,
-  @JsonProperty("createdTimestamp")
   val createdTimestamp: String,
-  @JsonProperty("modifiedTimestamp")
   val modifiedTimestamp: String,
-  @JsonProperty("firstBookedDateTime")
   val firstBookedDateTime: String?,
-  @JsonProperty("visitExternalSystemDetails")
   val visitExternalSystemDetails: PVVistExternalSystemDetails?,
 ) {
   fun toVisit(): Visit =
@@ -79,45 +57,35 @@ data class PVVisit(
 }
 
 data class PVVisitNotes(
-  @JsonProperty("type")
   val type: String,
-  @JsonProperty("text")
   val text: String,
 ) {
   fun toVisitNotes(): VisitNotes = VisitNotes(type = this.type, text = this.text)
 }
 
 data class PVVisitors(
-  @JsonProperty("nomisPersonId")
   val nomisPersonId: Long,
-  @JsonProperty("visitContact")
   val visitContact: Boolean?,
 ) {
   fun toVisitors(): Visitors = Visitors(contactId = this.nomisPersonId, visitContact = this.visitContact)
 }
 
 data class PVVisitContact(
-  @JsonProperty("name")
   val name: String,
-  @JsonProperty("telephone")
   val telephone: String?,
-  @JsonProperty("email")
   val email: String?,
 ) {
   fun toVisitContact(): VisitContact = VisitContact(name = this.name, telephone = this.telephone, email = this.email)
 }
 
 data class PVVisitorSupport(
-  @JsonProperty("description")
   val description: String,
 ) {
   fun toVisitorSupport(): VisitorSupport = VisitorSupport(description = this.description)
 }
 
 data class PVVistExternalSystemDetails(
-  @JsonProperty("clientName")
   val clientName: String?,
-  @JsonProperty("clientVisitReference")
   val clientVisitReference: String?,
 ) {
   fun toVisitExternalSystemDetails(): VisitExternalSystemDetails = VisitExternalSystemDetails(clientName = this.clientName, clientVisitReference = this.clientVisitReference)


### PR DESCRIPTION
We are getting this error when calling `/v1/persons/{hmppsId}/visits/future`:

```
{
    "status": 500,
    "errorCode": null,
    "userMessage": "Unrecognized field \"visitSubStatus\" (class uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonVisits.PVVisit), not marked as ignorable (21 known properties: \"visitRestriction\", \"outcomeStatus\", \"visitType\", \"prisonId\", \"reference\", \"modifiedTimestamp\", \"createdTimestamp\", \"prisonerId\", \"startTimestamp\", \"visitContact\", \"prisonName\", \"applicationReference\", \"visitStatus\", \"visitorSupport\", \"visitors\", \"visitRoom\", \"firstBookedDateTime\", \"visitNotes\", \"sessionTemplateReference\", \"visitExternalSystemDetails\", \"endTimestamp\"])\n at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.ArrayList[0]->uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonVisits.PVVisit[\"visitSubStatus\"])",
    "developerMessage": "Unexpected error: Unrecognized field \"visitSubStatus\" (class uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonVisits.PVVisit), not marked as ignorable (21 known properties: \"visitRestriction\", \"outcomeStatus\", \"visitType\", \"prisonId\", \"reference\", \"modifiedTimestamp\", \"createdTimestamp\", \"prisonerId\", \"startTimestamp\", \"visitContact\", \"prisonName\", \"applicationReference\", \"visitStatus\", \"visitorSupport\", \"visitors\", \"visitRoom\", \"firstBookedDateTime\", \"visitNotes\", \"sessionTemplateReference\", \"visitExternalSystemDetails\", \"endTimestamp\"])\n at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.ArrayList[0]->uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonVisits.PVVisit[\"visitSubStatus\"])",
    "moreInfo": null
}
```

I believe this is because we were manually deserialising the model with `ObjectMapper` and this did not have the option set to ignore unrecognised fields. In any case, we have a `requestList` method on the `webClient` that should now mean this technique is not needed anyways.

I will also look to find any other instances where this technique is being used and remove them to prevent getting more of these types of issues in future.