### PR TITLE
Add prison filtering to allocate endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueService.kt
@@ -29,6 +29,7 @@ import java.time.LocalDate
 class ActivitiesQueueService(
   @Autowired private val hmppsQueueService: HmppsQueueService,
   @Autowired private val objectMapper: ObjectMapper,
+  @Autowired private val getPersonService: GetPersonService,
   @Autowired private val consumerPrisonAccessService: ConsumerPrisonAccessService,
   @Autowired private val getAttendanceByIdService: GetAttendanceByIdService,
   @Autowired private val getScheduleDetailsService: GetScheduleDetailsService,
@@ -121,6 +122,11 @@ class ActivitiesQueueService(
     validateAllocationDates(prisonerAllocationRequest, today)?.let { return it }
     validateScheduleInstanceIfToday(prisonerAllocationRequest, today)?.let { return it }
     validateExclusionTimes(prisonerAllocationRequest)?.let { return it }
+
+    val personResponse = getPersonService.getPersonWithPrisonFilter(prisonerAllocationRequest.prisonerNumber, filters)
+    if (personResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = personResponse.errors)
+    }
 
     val scheduleResponse = activitiesGateway.getActivityScheduleById(scheduleId)
     if (scheduleResponse.errors.isNotEmpty()) return Response(data = null, errors = scheduleResponse.errors)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueService.kt
@@ -125,6 +125,11 @@ class ActivitiesQueueService(
     val scheduleResponse = activitiesGateway.getActivityScheduleById(scheduleId)
     if (scheduleResponse.errors.isNotEmpty()) return Response(data = null, errors = scheduleResponse.errors)
     val schedule = scheduleResponse.data!!
+    val prisonCode = schedule.activity.prisonCode
+    val consumerPrisonFilterCheck = consumerPrisonAccessService.checkConsumerHasPrisonAccess<HmppsMessageResponse>(prisonCode, filters, upstreamServiceType = UpstreamApi.ACTIVITIES)
+    if (consumerPrisonFilterCheck.errors.isNotEmpty()) {
+      return consumerPrisonFilterCheck
+    }
 
     validatePayBand(schedule, prisonerAllocationRequest, filters)?.let { return it }
     validateAllocationWithinScheduleDates(schedule, prisonerAllocationRequest)?.let { return it }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueServiceTest.kt
@@ -87,6 +87,8 @@ class ActivitiesQueueServiceTest(
         whenever(hmppsQueueService.findByQueueId("activities")).thenReturn(activitiesQueue)
         whenever(consumerPrisonAccessService.checkConsumerHasPrisonAccess<HmppsMessageResponse>(prisonId, filters))
           .thenReturn(Response(data = null, errors = emptyList()))
+        whenever(consumerPrisonAccessService.checkConsumerHasPrisonAccess<HmppsMessageResponse>(prisonId, filters, upstreamServiceType = UpstreamApi.ACTIVITIES))
+          .thenReturn(Response(data = null, errors = emptyList()))
       }
 
       describe("Mark prisoner attendance") {
@@ -615,9 +617,9 @@ class ActivitiesQueueServiceTest(
           result.errors.shouldBe(listOf(error))
         }
 
-        it("should return errors when consumer does not have access to the prison") {
+        it("should return errors when consumer does not have access to the prison for the schedule") {
           val errors = listOf(UpstreamApiError(UpstreamApi.ACTIVITIES, UpstreamApiError.Type.ENTITY_NOT_FOUND, "Not found"))
-          whenever(consumerPrisonAccessService.checkConsumerHasPrisonAccess<HmppsMessageResponse>(prisonId, filters))
+          whenever(consumerPrisonAccessService.checkConsumerHasPrisonAccess<HmppsMessageResponse>(prisonId, filters, upstreamServiceType = UpstreamApi.ACTIVITIES))
             .thenReturn(Response(data = null, errors))
 
           val result = activitiesQueueService.sendPrisonerAllocationRequest(scheduleId, allocationRequest, who, filters)


### PR DESCRIPTION
We were missing some prison filtering in a few places which I have now added:

* Now checks the user has access to the prisoner on the request
* Now checks that the user has access to the schedule