### PR TITLE
HMAI-666 - Handle null end date on schedule when deallocating

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueService.kt
@@ -94,7 +94,7 @@ class ActivitiesQueueService(
     schedule.allocations.filter { it.prisonerNumber == prisonerDeallocationRequest.prisonerNumber && it.status != "ENDED" }.ifEmpty { null }
       ?: return Response(data = null, errors = listOf(UpstreamApiError(UpstreamApi.ACTIVITIES, UpstreamApiError.Type.ENTITY_NOT_FOUND, "Allocations not found for prisoner: ${prisonerDeallocationRequest.prisonerNumber}")))
 
-    if (prisonerDeallocationRequest.endDate.isAfter(LocalDate.parse(schedule.endDate))) {
+    if (schedule.endDate != null && prisonerDeallocationRequest.endDate.isAfter(LocalDate.parse(schedule.endDate))) {
       return Response(data = null, errors = listOf(UpstreamApiError(UpstreamApi.ACTIVITIES, UpstreamApiError.Type.BAD_REQUEST, "Passed in end date cannot be after the end date of the schedule: ${schedule.endDate}")))
     }
 


### PR DESCRIPTION
If the schedule returns a null `endDate` then we get an exception thrown.

https://ministryofjustice.sentry.io/issues/6732038497/?project=4505165221462016&query=is%3Aunresolved&referrer=issue-stream&stream_index=0