### PR TITLE
PI-3252: Create api filter feature flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -34,6 +34,7 @@ data class FeatureFlagConfig(
     const val USE_SUITABILITY_ENDPOINT = "use-suitability-endpoint"
     const val USE_HISTORICAL_ATTENDANCES_ENDPOINT = "use-historical-attendances-endpoint"
     const val USE_WAITING_LIST_ENDPOINT = "use-waiting-list-endpoint"
+    const val USE_ALERTS_API_FILTER = "use-alerts-api-filter"
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AlertsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AlertsController.kt
@@ -53,7 +53,7 @@ class AlertsController(
     @Parameter(description = "The maximum number of results for a page", schema = Schema(minimum = "1")) @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
     @RequestAttribute filters: ConsumerFilters?,
   ): PaginatedResponse<Alert> {
-    val response = getAlertsForPersonService.execute(hmppsId, filters, page, perPage)
+    val response = if (featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)) getAlertsForPersonService.getAlerts(hmppsId, filters, page, perPage, emptyList()) else getAlertsForPersonService.execute(hmppsId, filters, page, perPage)
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
@@ -87,7 +87,7 @@ class AlertsController(
     @Parameter(description = "The maximum number of results for a page", schema = Schema(minimum = "1")) @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
     @RequestAttribute filters: ConsumerFilters?,
   ): PaginatedResponse<Alert> {
-    val response = if (featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)) getAlertsForPersonService.getAlerts(hmppsId, filters, page, perPage, PAPaginatedAlerts.PND_ALERT_CODES) else getAlertsForPersonService.execute(hmppsId, filters, page, perPage, pndOnly = true)
+    val response = getAlertsForPersonService.execute(hmppsId, filters, page, perPage, pndOnly = true)
 
     if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerAlertsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerAlertsGateway.kt
@@ -62,20 +62,19 @@ class PrisonerAlertsGateway(
   /**
    * @param page page number (1 based)
    * @param size records per page
-   * @param alertCodes alert codes to return, will return all if empty
+   * @param alertCodes The alert codes to return in the response. If empty then all codes will be returned
    */
   fun getPrisonerAlertsForCodes(
     prisonerNumber: String,
     page: Int,
     size: Int,
-    alertCodes: List<String> = emptyList(),
+    alertCodes: List<String>,
   ): Response<PAPaginatedAlerts?> {
-    val passFilters = alertCodes.isNotEmpty()
     val uri = "/prisoners/$prisonerNumber/alerts?page=${page - 1}&size=$size"
     val result =
       webClient.request<PAPaginatedAlerts>(
         HttpMethod.GET,
-        if (passFilters) {
+        if (alertCodes.isNotEmpty()) {
           "$uri&alertCode=${alertCodes.joinToString(",")}"
         } else {
           uri

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerAlertsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerAlertsGateway.kt
@@ -68,7 +68,7 @@ class PrisonerAlertsGateway(
     prisonerNumber: String,
     page: Int,
     size: Int,
-    alertCodes: List<String>,
+    alertCodes: List<String> = emptyList(),
   ): Response<PAPaginatedAlerts?> {
     val uri = "/prisoners/$prisonerNumber/alerts?page=${page - 1}&size=$size"
     val result =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerAlertsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerAlertsGateway.kt
@@ -50,7 +50,6 @@ class PrisonerAlertsGateway(
           data = result.data,
         )
       }
-
       is WebClientWrapperResponse.Error -> {
         Response(
           data = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonerAlerts/PAPaginatedAlerts.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonerAlerts/PAPaginatedAlerts.kt
@@ -15,19 +15,8 @@ data class PAPaginatedAlerts(
   val pageable: PAPageable,
   val empty: Boolean,
 ) {
-  fun toPaginatedAlerts(pndOnly: Boolean = false) =
-    PaginatedAlerts(
-      content = (if (pndOnly) this.content.filter { isPndAlert(it) } else this.content).map { it.toAlert() },
-      totalPages = this.totalPages,
-      totalCount = this.totalElements,
-      isLastPage = this.last,
-      count = this.numberOfElements,
-      page = this.number + 1, // Alerts API pagination is 0 based
-      perPage = this.size,
-    )
-
-  private fun isPndAlert(alert: PAAlert): Boolean =
-    alert.alertCode.code in
+  companion object {
+    val PND_ALERT_CODES =
       listOf(
         "BECTER",
         "HA",
@@ -60,4 +49,20 @@ data class PAPaginatedAlerts(
         "HS",
         "SC",
       )
+  }
+
+  fun toPaginatedAlerts(
+    pndOnly: Boolean = false,
+    useApiFilter: Boolean = false,
+  ) = PaginatedAlerts(
+    content = (if (pndOnly && !useApiFilter) this.content.filter { isPndAlert(it) } else this.content).map { it.toAlert() },
+    totalPages = this.totalPages,
+    totalCount = this.totalElements,
+    isLastPage = this.last,
+    count = this.numberOfElements,
+    page = this.number + 1, // Alerts API pagination is 0 based
+    perPage = this.size,
+  )
+
+  private fun isPndAlert(alert: PAAlert): Boolean = alert.alertCode.code in PND_ALERT_CODES
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonerAlerts/PAPaginatedAlerts.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/prisonerAlerts/PAPaginatedAlerts.kt
@@ -15,6 +15,28 @@ data class PAPaginatedAlerts(
   val pageable: PAPageable,
   val empty: Boolean,
 ) {
+  fun toPaginatedAlerts(pndOnly: Boolean = false) =
+    PaginatedAlerts(
+      content = (if (pndOnly) this.content.filter { isPndAlert(it) } else this.content).map { it.toAlert() },
+      totalPages = this.totalPages,
+      totalCount = this.totalElements,
+      isLastPage = this.last,
+      count = this.numberOfElements,
+      page = this.number + 1, // Alerts API pagination is 0 based
+      perPage = this.size,
+    )
+
+  fun toPaginatedAlertsFilterApplied() =
+    PaginatedAlerts(
+      content = this.content.map { it.toAlert() },
+      totalPages = this.totalPages,
+      totalCount = this.totalElements,
+      isLastPage = this.last,
+      count = this.numberOfElements,
+      page = this.number + 1, // Alerts API pagination is 0 based
+      perPage = this.size,
+    )
+
   companion object {
     val PND_ALERT_CODES =
       listOf(
@@ -50,19 +72,6 @@ data class PAPaginatedAlerts(
         "SC",
       )
   }
-
-  fun toPaginatedAlerts(
-    pndOnly: Boolean = false,
-    useApiFilter: Boolean = false,
-  ) = PaginatedAlerts(
-    content = (if (pndOnly && !useApiFilter) this.content.filter { isPndAlert(it) } else this.content).map { it.toAlert() },
-    totalPages = this.totalPages,
-    totalCount = this.totalElements,
-    isLastPage = this.last,
-    count = this.numberOfElements,
-    page = this.number + 1, // Alerts API pagination is 0 based
-    perPage = this.size,
-  )
 
   private fun isPndAlert(alert: PAAlert): Boolean = alert.alertCode.code in PND_ALERT_CODES
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAlertsForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAlertsForPersonService.kt
@@ -2,21 +2,17 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.USE_ALERTS_API_FILTER
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerAlertsGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedAlerts
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonerAlerts.PAPaginatedAlerts
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 @Service
 class GetAlertsForPersonService(
   @Autowired val getPersonService: GetPersonService,
   @Autowired val prisonerAlertsGateway: PrisonerAlertsGateway,
-  @Autowired val featureConfig: FeatureFlagConfig,
 ) {
   fun execute(
     hmppsId: String,
@@ -26,8 +22,6 @@ class GetAlertsForPersonService(
     pndOnly: Boolean = false,
   ): Response<PaginatedAlerts?> {
     val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
-
-    val useApiFilter = featureConfig.isEnabled(USE_ALERTS_API_FILTER)
 
     if (personResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = personResponse.errors)
@@ -39,19 +33,42 @@ class GetAlertsForPersonService(
         errors = listOf(UpstreamApiError(UpstreamApi.PRISON_API, UpstreamApiError.Type.ENTITY_NOT_FOUND)),
       )
 
-    val alertsResponse =
-      if (useApiFilter && pndOnly) {
-        prisonerAlertsGateway.getPrisonerAlerts(nomisNumber, page, size = perPage, PAPaginatedAlerts.PND_ALERT_CODES)
-      } else {
-        prisonerAlertsGateway.getPrisonerAlerts(nomisNumber, page, size = perPage)
-      }
-
+    val alertsResponse = prisonerAlertsGateway.getPrisonerAlerts(nomisNumber, page, size = perPage)
     if (alertsResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = alertsResponse.errors)
     }
 
     return Response(
-      data = alertsResponse.data?.toPaginatedAlerts(pndOnly, useApiFilter),
+      data = alertsResponse.data?.toPaginatedAlerts(pndOnly),
+    )
+  }
+
+  fun getAlerts(
+    hmppsId: String,
+    filters: ConsumerFilters?,
+    page: Int,
+    perPage: Int,
+    alertCodes: List<String> = emptyList(),
+  ): Response<PaginatedAlerts?> {
+    val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
+
+    if (personResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = personResponse.errors)
+    }
+
+    val nomisNumber =
+      personResponse.data?.nomisNumber ?: return Response(
+        data = null,
+        errors = listOf(UpstreamApiError(UpstreamApi.PRISON_API, UpstreamApiError.Type.ENTITY_NOT_FOUND)),
+      )
+
+    val alertsResponse = prisonerAlertsGateway.getPrisonerAlertsForCodes(nomisNumber, page, size = perPage, alertCodes)
+    if (alertsResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = alertsResponse.errors)
+    }
+
+    return Response(
+      data = alertsResponse.data?.toPaginatedAlertsFilterApplied(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAlertsForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAlertsForPersonService.kt
@@ -2,17 +2,21 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.USE_ALERTS_API_FILTER
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerAlertsGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedAlerts
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisonerAlerts.PAPaginatedAlerts
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 @Service
 class GetAlertsForPersonService(
   @Autowired val getPersonService: GetPersonService,
   @Autowired val prisonerAlertsGateway: PrisonerAlertsGateway,
+  @Autowired val featureConfig: FeatureFlagConfig,
 ) {
   fun execute(
     hmppsId: String,
@@ -22,6 +26,9 @@ class GetAlertsForPersonService(
     pndOnly: Boolean = false,
   ): Response<PaginatedAlerts?> {
     val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
+
+    val useApiFilter = featureConfig.isEnabled(USE_ALERTS_API_FILTER)
+
     if (personResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = personResponse.errors)
     }
@@ -32,13 +39,19 @@ class GetAlertsForPersonService(
         errors = listOf(UpstreamApiError(UpstreamApi.PRISON_API, UpstreamApiError.Type.ENTITY_NOT_FOUND)),
       )
 
-    val alertsResponse = prisonerAlertsGateway.getPrisonerAlerts(nomisNumber, page, size = perPage)
+    val alertsResponse =
+      if (useApiFilter && pndOnly) {
+        prisonerAlertsGateway.getPrisonerAlerts(nomisNumber, page, size = perPage, PAPaginatedAlerts.PND_ALERT_CODES)
+      } else {
+        prisonerAlertsGateway.getPrisonerAlerts(nomisNumber, page, size = perPage)
+      }
+
     if (alertsResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = alertsResponse.errors)
     }
 
     return Response(
-      data = alertsResponse.data?.toPaginatedAlerts(pndOnly),
+      data = alertsResponse.data?.toPaginatedAlerts(pndOnly, useApiFilter),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAlertsForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetAlertsForPersonService.kt
@@ -22,7 +22,6 @@ class GetAlertsForPersonService(
     pndOnly: Boolean = false,
   ): Response<PaginatedAlerts?> {
     val personResponse = getPersonService.getNomisNumberWithPrisonFilter(hmppsId, filters)
-
     if (personResponse.errors.isNotEmpty()) {
       return Response(data = null, errors = personResponse.errors)
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -282,3 +282,8 @@ authorisation:
       filters:
       roles:
         - "full-access"
+    pmcphee:
+      include:
+      filters:
+      roles:
+        - "full-access"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -56,6 +56,7 @@ feature-flag:
   use-prisoner-base-location-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: true
+  use-alerts-api-filter: true
 
 authorisation:
   consumers:

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -79,6 +79,7 @@ feature-flag:
   use-historical-attendances-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: true
+  use-alerts-api-filter: false
 
 authorisation:
   consumers:

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -71,3 +71,4 @@ feature-flag:
   use-historical-attendances-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: true
+  use-alerts-api-filter: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,6 +53,7 @@ feature-flag:
   use-historical-attendances-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: true
+  use-alerts-api-filter: true
 
 authorisation:
   consumers:

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -54,6 +54,7 @@ feature-flag:
   use-historical-attendances-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: false
+  use-alerts-api-filter: false
 
 authorisation:
   consumers:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,6 +54,7 @@ feature-flag:
   use-historical-attendances-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: false
+  use-alerts-api-filter: false
 
 authorisation:
   consumers:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -80,6 +80,7 @@ feature-flag:
   use-historical-attendances-endpoint: true
   use-suitability-endpoint: true
   use-waiting-list-endpoint: true
+  use-alerts-api-filter: false
 
 authorisation:
   consumers:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
@@ -1,0 +1,116 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.person
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.USE_ALERTS_API_FILTER
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
+
+class AlertsWithApiQueryFeatureIntegrationTest : IntegrationTestBase() {
+  @MockitoBean lateinit var featureFlagConfig: FeatureFlagConfig
+
+  @Nested
+  inner class GetAlerts {
+    val path = "$basePath/$nomsId/alerts"
+
+    @BeforeEach
+    fun setup() {
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
+    }
+
+    @Test
+    fun `returns alerts for a person`() {
+      callApi(path)
+        .andExpect(status().isOk)
+        .andExpect(content().json(getExpectedResponse("person-alerts")))
+    }
+
+    @Test
+    fun `returns a 400 if the hmppsId is invalid`() {
+      callApi("$basePath/$invalidNomsId/alerts")
+        .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `return a 404 for person in wrong prison`() {
+      callApiWithCN(path, limitedPrisonsCn)
+        .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `return a 404 when no prisons in filter`() {
+      callApiWithCN(path, noPrisonsCn)
+        .andExpect(status().isNotFound)
+    }
+  }
+
+  @Nested
+  inner class GetAlertsPnd {
+    val path = "$basePath/$nomsId/alerts/pnd"
+
+    @BeforeEach
+    fun setup() {
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
+    }
+
+    @Test
+    fun `returns PND alerts for a person`() {
+      callApi(path)
+        .andExpect(status().isOk)
+        .andExpect(content().json(getExpectedResponse("person-alerts-pnd")))
+    }
+
+    @Test
+    fun `returns a 400 if the hmppsId is invalid`() {
+      callApi("$basePath/$invalidNomsId/alerts/pnd")
+        .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `return a 404 for person in wrong prison`() {
+      callApiWithCN(path, limitedPrisonsCn)
+        .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `return a 404 when no prisons in filter`() {
+      callApiWithCN(path, noPrisonsCn)
+        .andExpect(status().isNotFound)
+    }
+  }
+
+  @Nested
+  inner class GetPndAlerts {
+    val path = "/v1/pnd/persons/$nomsId/alerts"
+
+    @Test
+    fun `returns PND alerts for a person`() {
+      callApi(path)
+        .andExpect(status().isOk)
+        .andExpect(content().json(getExpectedResponse("person-alerts-pnd")))
+    }
+
+    @Test
+    fun `returns a 400 if the hmppsId is invalid`() {
+      callApi("/v1/pnd/persons/$invalidNomsId/alerts")
+        .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `return a 404 for person in wrong prison`() {
+      callApiWithCN(path, limitedPrisonsCn)
+        .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `return a 404 when no prisons in filter`() {
+      callApiWithCN(path, noPrisonsCn)
+        .andExpect(status().isNotFound)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
@@ -20,7 +20,7 @@ class AlertsWithApiQueryFeatureIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setup() {
-      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(false)
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
     }
 
     @Test
@@ -55,7 +55,7 @@ class AlertsWithApiQueryFeatureIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setup() {
-      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(false)
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
@@ -20,7 +20,7 @@ class AlertsWithApiQueryFeatureIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setup() {
-      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(false)
     }
 
     @Test
@@ -50,54 +50,19 @@ class AlertsWithApiQueryFeatureIntegrationTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class GetAlertsPnd {
-    val path = "$basePath/$nomsId/alerts/pnd"
-
-    @BeforeEach
-    fun setup() {
-      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
-    }
-
-    @Test
-    fun `returns PND alerts for a person`() {
-      callApi(path)
-        .andExpect(status().isOk)
-        .andExpect(content().json(getExpectedResponse("person-alerts-pnd")))
-    }
-
-    @Test
-    fun `returns a 400 if the hmppsId is invalid`() {
-      callApi("$basePath/$invalidNomsId/alerts/pnd")
-        .andExpect(status().isBadRequest)
-    }
-
-    @Test
-    fun `return a 404 for person in wrong prison`() {
-      callApiWithCN(path, limitedPrisonsCn)
-        .andExpect(status().isNotFound)
-    }
-
-    @Test
-    fun `return a 404 when no prisons in filter`() {
-      callApiWithCN(path, noPrisonsCn)
-        .andExpect(status().isNotFound)
-    }
-  }
-
-  @Nested
   inner class GetPndAlerts {
     val path = "/v1/pnd/persons/$nomsId/alerts"
 
     @BeforeEach
     fun setup() {
-      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(false)
     }
 
     @Test
-    fun `returns PND alerts for a person`() {
+    fun `returns unfiltered PND alerts for a person`() {
       callApi(path)
         .andExpect(status().isOk)
-        .andExpect(content().json(getExpectedResponse("person-alerts-pnd")))
+        .andExpect(content().json(getExpectedResponse("person-alerts")))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsWithApiQueryFeatureIntegrationTest.kt
@@ -88,6 +88,11 @@ class AlertsWithApiQueryFeatureIntegrationTest : IntegrationTestBase() {
   inner class GetPndAlerts {
     val path = "/v1/pnd/persons/$nomsId/alerts"
 
+    @BeforeEach
+    fun setup() {
+      whenever(featureFlagConfig.isEnabled(USE_ALERTS_API_FILTER)).thenReturn(true)
+    }
+
     @Test
     fun `returns PND alerts for a person`() {
       callApi(path)


### PR DESCRIPTION
This PR will (behind a feature flag) pass the list of alert codes to the alerts api for filtering the PND alert code to be performed within the api.
e.g `https://alerts-api-preprod.hmpps.service.justice.gov.uk/prisoners/<id>/alerts?page=0&size=10&alertCode=BECTER,HA,XA,XCA,XEL,XELH,XER,XHT,XILLENT,XIS,XR,XRF,XSA,HA2,RCS,RDV,RKC,RPB,RPC,RSS,RST,RDP,REG,RLG,ROP,RRV,RTP,RYP,HS,SC`
This will keep the pagination intact and will reduce required number of calls from the client from 5 to 1 (in the example above)
If the feature flag is not enabled, then existing processing will be followed and the pagination for PND will continue to be broken
For non pnd requests the requests will continue as normal (without the codes in the query param)
FYI - i have tested the above URL in preprod and the filters work