### PR TITLE
HMAI-694 Get activity schedule suitability criteria - AMEND MODELS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesPayRate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesPayRate.kt
@@ -21,5 +21,6 @@ data class ActivitiesPayRate(
       rate = this.rate,
       pieceRate = this.pieceRate,
       pieceRateItems = this.pieceRateItems,
+      startDate = this.startDate,
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesPayRate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesPayRate.kt
@@ -1,22 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.activities
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PayRate
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonPayBand
+import java.time.LocalDate
 
 data class ActivitiesPayRate(
   val id: Long,
   val incentiveNomisCode: String,
   val incentiveLevel: String,
-  val prisonPayBand: PrisonPayBand,
-  val rate: Int,
-  val pieceRate: Int,
-  val pieceRateItems: Int,
+  val prisonPayBand: ActivitiesPrisonPayBand,
+  val rate: Int?,
+  val pieceRate: Int?,
+  val pieceRateItems: Int?,
+  val startDate: LocalDate?,
 ) {
   fun toPayRate() =
     PayRate(
       incentiveCode = this.incentiveNomisCode,
       incentiveLevel = this.incentiveLevel,
-      prisonPayBand = this.prisonPayBand,
+      prisonPayBand = this.prisonPayBand.toPrisonPayBand(),
       rate = this.rate,
       pieceRate = this.pieceRate,
       pieceRateItems = this.pieceRateItems,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesSuitabilityCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesSuitabilityCriteria.kt
@@ -5,14 +5,14 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Suitability
 data class ActivitiesSuitabilityCriteria(
   val riskLevel: String,
   val isPaid: Boolean,
-  val payRate: List<ActivitiesPayRate>,
+  val payRates: List<ActivitiesPayRate>,
   val minimumEducationLevel: List<ActivitiesMinimumEducationLevel>,
 ) {
   fun toSuitabilityCriteria() =
     SuitabilityCriteria(
       riskLevel = this.riskLevel,
       isPaid = this.isPaid,
-      payRate = this.payRate.map { it.toPayRate() },
+      payRates = this.payRates.map { it.toPayRate() },
       minimumEducationLevel = this.minimumEducationLevel.map { it.toMinimumEducationLevel() },
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesSuitabilityCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/activities/ActivitiesSuitabilityCriteria.kt
@@ -5,14 +5,14 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Suitability
 data class ActivitiesSuitabilityCriteria(
   val riskLevel: String,
   val isPaid: Boolean,
-  val payRate: ActivitiesPayRate,
+  val payRate: List<ActivitiesPayRate>,
   val minimumEducationLevel: List<ActivitiesMinimumEducationLevel>,
 ) {
   fun toSuitabilityCriteria() =
     SuitabilityCriteria(
       riskLevel = this.riskLevel,
       isPaid = this.isPaid,
-      payRate = this.payRate.toPayRate(),
+      payRate = this.payRate.map { it.toPayRate() },
       minimumEducationLevel = this.minimumEducationLevel.map { it.toMinimumEducationLevel() },
     )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PayRate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PayRate.kt
@@ -10,9 +10,9 @@ data class PayRate(
   @Schema(description = "The pay band for this activity pay")
   val prisonPayBand: PrisonPayBand,
   @Schema(description = "The earning rate for one half day session for someone of this incentive level and pay band (in pence)", example = "150")
-  val rate: Int,
+  val rate: Int?,
   @Schema(description = "Where payment is related to produced amounts of a product, this indicates the payment rate (in pence) per pieceRateItems produced", example = "150")
-  val pieceRate: Int,
+  val pieceRate: Int?,
   @Schema(description = "Where payment is related to the number of items produced in a batch of a product, this is the batch size that attract 1 x pieceRate", example = "10")
-  val pieceRateItems: Int,
+  val pieceRateItems: Int?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PayRate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PayRate.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 data class PayRate(
   @Schema(description = "The code for the incentive/earned privilege level", example = "BAS")
@@ -15,4 +16,6 @@ data class PayRate(
   val pieceRate: Int?,
   @Schema(description = "Where payment is related to the number of items produced in a batch of a product, this is the batch size that attract 1 x pieceRate", example = "10")
   val pieceRateItems: Int?,
+  @Schema(description = "The effective start date for this pay rate", example = "2024-06-18")
+  val startDate: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/SuitabilityCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/SuitabilityCriteria.kt
@@ -8,7 +8,7 @@ data class SuitabilityCriteria(
   @Schema(description = "Whether the activity is a paid activity", example = "true")
   val isPaid: Boolean,
   @Schema(description = "The pay rate by incentive level and pay band that can apply to this activity")
-  val payRate: PayRate,
+  val payRate: List<PayRate>,
   @Schema(description = "The list of minimum education levels that can apply to this activity")
   val minimumEducationLevel: List<MinimumEducationLevel>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/SuitabilityCriteria.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/SuitabilityCriteria.kt
@@ -8,7 +8,7 @@ data class SuitabilityCriteria(
   @Schema(description = "Whether the activity is a paid activity", example = "true")
   val isPaid: Boolean,
   @Schema(description = "The pay rate by incentive level and pay band that can apply to this activity")
-  val payRate: List<PayRate>,
+  val payRates: List<PayRate>,
   @Schema(description = "The list of minimum education levels that can apply to this activity")
   val minimumEducationLevel: List<MinimumEducationLevel>,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ActivitiesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ActivitiesControllerTest.kt
@@ -354,18 +354,20 @@ class ActivitiesControllerTest(
             riskLevel = "medium",
             isPaid = true,
             payRate =
-              PayRate(
-                incentiveCode = "BAS",
-                incentiveLevel = "Basic",
-                prisonPayBand =
-                  PrisonPayBand(
-                    id = 123456L,
-                    alias = "Low",
-                    description = "Pay band 1",
-                  ),
-                rate = 150,
-                pieceRate = 150,
-                pieceRateItems = 10,
+              listOf(
+                PayRate(
+                  incentiveCode = "BAS",
+                  incentiveLevel = "Basic",
+                  prisonPayBand =
+                    PrisonPayBand(
+                      id = 123456L,
+                      alias = "Low",
+                      description = "Pay band 1",
+                    ),
+                  rate = 150,
+                  pieceRate = 150,
+                  pieceRateItems = 10,
+                ),
               ),
             minimumEducationLevel =
               listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ActivitiesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ActivitiesControllerTest.kt
@@ -353,7 +353,7 @@ class ActivitiesControllerTest(
           SuitabilityCriteria(
             riskLevel = "medium",
             isPaid = true,
-            payRate =
+            payRates =
               listOf(
                 PayRate(
                   incentiveCode = "BAS",
@@ -367,6 +367,7 @@ class ActivitiesControllerTest(
                   rate = 150,
                   pieceRate = 150,
                   pieceRateItems = 10,
+                  startDate = LocalDate.of(2021, 1, 1),
                 ),
               ),
             minimumEducationLevel =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetActivitySuitabilityCriteriaGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetActivitySuitabilityCriteriaGatewayTest.kt
@@ -63,7 +63,7 @@ class GetActivitySuitabilityCriteriaGatewayTest(
         result.errors.shouldBeEmpty()
         result.data.shouldNotBeNull()
         result.data.riskLevel.shouldBe("medium")
-        result.data.payRate[0]
+        result.data.payRates[0]
           .id
           .shouldBe(123456)
         result.data.minimumEducationLevel[0]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetActivitySuitabilityCriteriaGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetActivitySuitabilityCriteriaGatewayTest.kt
@@ -63,7 +63,8 @@ class GetActivitySuitabilityCriteriaGatewayTest(
         result.errors.shouldBeEmpty()
         result.data.shouldNotBeNull()
         result.data.riskLevel.shouldBe("medium")
-        result.data.payRate.id
+        result.data.payRate[0]
+          .id
           .shouldBe(123456)
         result.data.minimumEducationLevel[0]
           .id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitySuitabilityCriteria.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitySuitabilityCriteria.json
@@ -1,27 +1,29 @@
 {
   "riskLevel": "medium",
   "isPaid": true,
-  "payRate": [ {
-    "id": 123456,
-    "incentiveNomisCode": "BAS",
-    "incentiveLevel": "Basic",
-    "prisonPayBand": {
+  "payRate": [
+    {
       "id": 123456,
-      "displaySequence": 1,
-      "alias": "Low",
-      "description": "Pay band 1",
-      "nomisPayBand": 1,
-      "prisonCode": "MDI",
-      "createdTime": "2025-06-11T09:05:01.364Z",
-      "createdBy": "string",
-      "updatedTime": "2025-06-11T09:05:01.364Z",
-      "updatedBy": "string"
-    },
-    "rate": 150,
-    "pieceRate": 150,
-    "pieceRateItems": 10,
-    "startDate": "2022-09-29T11:20:00"
-  }],
+      "incentiveNomisCode": "BAS",
+      "incentiveLevel": "Basic",
+      "prisonPayBand": {
+        "id": 123456,
+        "displaySequence": 1,
+        "alias": "Low",
+        "description": "Pay band 1",
+        "nomisPayBand": 1,
+        "prisonCode": "MDI",
+        "createdTime": "2025-06-11T09:05:01.364Z",
+        "createdBy": "string",
+        "updatedTime": "2025-06-11T09:05:01.364Z",
+        "updatedBy": "string"
+      },
+      "rate": 150,
+      "pieceRate": 150,
+      "pieceRateItems": 10,
+      "startDate": "2022-09-29T11:20:00"
+    }
+  ],
   "minimumEducationLevel": [
     {
       "id": 123456,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitySuitabilityCriteria.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitySuitabilityCriteria.json
@@ -1,7 +1,7 @@
 {
   "riskLevel": "medium",
   "isPaid": true,
-  "payRate": [
+  "payRates": [
     {
       "id": 123456,
       "incentiveNomisCode": "BAS",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitySuitabilityCriteria.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetActivitySuitabilityCriteria.json
@@ -1,19 +1,27 @@
 {
   "riskLevel": "medium",
   "isPaid": true,
-  "payRate": {
+  "payRate": [ {
     "id": 123456,
     "incentiveNomisCode": "BAS",
     "incentiveLevel": "Basic",
     "prisonPayBand": {
       "id": 123456,
+      "displaySequence": 1,
       "alias": "Low",
-      "description": "Pay band 1"
+      "description": "Pay band 1",
+      "nomisPayBand": 1,
+      "prisonCode": "MDI",
+      "createdTime": "2025-06-11T09:05:01.364Z",
+      "createdBy": "string",
+      "updatedTime": "2025-06-11T09:05:01.364Z",
+      "updatedBy": "string"
     },
     "rate": 150,
     "pieceRate": 150,
-    "pieceRateItems": 10
-  },
+    "pieceRateItems": 10,
+    "startDate": "2022-09-29T11:20:00"
+  }],
   "minimumEducationLevel": [
     {
       "id": 123456,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetActivitiesSuitabilityCriteriaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetActivitiesSuitabilityCriteriaServiceTest.kt
@@ -225,7 +225,7 @@ class GetActivitiesSuitabilityCriteriaServiceTest(
         ActivitiesSuitabilityCriteria(
           riskLevel = "medium",
           isPaid = true,
-          payRate =
+          payRates =
             listOf(
               ActivitiesPayRate(
                 id = 123456L,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetActivitiesSuitabilityCriteriaServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetActivitiesSuitabilityCriteriaServiceTest.kt
@@ -24,12 +24,12 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.activities.Activi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.activities.ActivitiesPrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.activities.ActivitiesSlot
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.activities.ActivitiesSuitabilityCriteria
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import java.time.DayOfWeek
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @ContextConfiguration(
@@ -226,19 +226,29 @@ class GetActivitiesSuitabilityCriteriaServiceTest(
           riskLevel = "medium",
           isPaid = true,
           payRate =
-            ActivitiesPayRate(
-              id = 123456L,
-              incentiveNomisCode = "BAS",
-              incentiveLevel = "Basic",
-              prisonPayBand =
-                PrisonPayBand(
-                  id = 123456L,
-                  alias = "Low",
-                  description = "Pay band 1",
-                ),
-              rate = 150,
-              pieceRate = 150,
-              pieceRateItems = 10,
+            listOf(
+              ActivitiesPayRate(
+                id = 123456L,
+                incentiveNomisCode = "BAS",
+                incentiveLevel = "Basic",
+                prisonPayBand =
+                  ActivitiesPrisonPayBand(
+                    id = 123456,
+                    displaySequence = 1,
+                    alias = "Low",
+                    description = "Pay band 1",
+                    nomisPayBand = 1,
+                    prisonCode = "MDI",
+                    createdTime = "2025-06-11T09:05:01.364Z",
+                    createdBy = "string",
+                    updatedTime = "2025-06-11T09:05:01.364Z",
+                    updatedBy = "string",
+                  ),
+                rate = 150,
+                pieceRate = 150,
+                pieceRateItems = 10,
+                startDate = LocalDate.now(),
+              ),
             ),
           minimumEducationLevel =
             listOf(

--- a/src/test/resources/expected-responses/activities-suitability-criteria
+++ b/src/test/resources/expected-responses/activities-suitability-criteria
@@ -2,7 +2,7 @@
   "data": {
     "riskLevel": "medium",
     "isPaid": true,
-    "payRate": [{
+    "payRates": [{
       "incentiveCode": "BAS",
       "incentiveLevel": "Basic",
       "prisonPayBand": {
@@ -12,7 +12,8 @@
       },
       "rate": 150,
       "pieceRate": 150,
-      "pieceRateItems": 10
+      "pieceRateItems": 10,
+      "startDate": "2022-09-29"
     }],
     "minimumEducationLevel": [
       {

--- a/src/test/resources/expected-responses/activities-suitability-criteria
+++ b/src/test/resources/expected-responses/activities-suitability-criteria
@@ -2,7 +2,7 @@
   "data": {
     "riskLevel": "medium",
     "isPaid": true,
-    "payRate": {
+    "payRate": [{
       "incentiveCode": "BAS",
       "incentiveLevel": "Basic",
       "prisonPayBand": {
@@ -13,7 +13,7 @@
       "rate": 150,
       "pieceRate": 150,
       "pieceRateItems": 10
-    },
+    }],
     "minimumEducationLevel": [
       {
         "educationLevelCode": "Basic",


### PR DESCRIPTION
In the creation of the endpoint in the Activities API, we identified:

- Pay rates were actually returned as a list
- Pay rate includes a start date field
- PrisonPayBand is returned with more data so should use the ActivitiesPrisonPayBand model at the gateway level, before being transformed.

Tests have also been updated to reflect these changes.

