### PR TITLE
HMAI-711 - Add case load ID header to waiting list applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ActivitiesGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ActivitiesGateway.kt
@@ -382,12 +382,15 @@ class ActivitiesGateway(
     }
   }
 
-  fun getWaitingListApplicationsByScheduleId(scheduleId: Long): Response<List<ActivitiesWaitingListApplication>?> {
+  fun getWaitingListApplicationsByScheduleId(
+    scheduleId: Long,
+    prisonCode: String,
+  ): Response<List<ActivitiesWaitingListApplication>?> {
     val result =
       webClient.requestList<ActivitiesWaitingListApplication>(
         HttpMethod.GET,
         "/schedules/$scheduleId/waiting-list-applications",
-        authenticationHeader(),
+        authenticationHeader() + mapOf("Caseload-Id" to prisonCode),
         UpstreamApi.ACTIVITIES,
         badRequestAsError = true,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetWaitingListApplicationsByScheduleIdService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetWaitingListApplicationsByScheduleIdService.kt
@@ -2,26 +2,37 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.common.ConsumerPrisonAccessService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ActivitiesGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.WaitingListApplication
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 
 @Service
 class GetWaitingListApplicationsByScheduleIdService(
   @Autowired val activitiesGateway: ActivitiesGateway,
-  @Autowired val getScheduleDetailsService: GetScheduleDetailsService,
+  @Autowired val consumerPrisonAccessService: ConsumerPrisonAccessService,
 ) {
   fun execute(
     scheduleId: Long,
     filters: ConsumerFilters?,
   ): Response<List<WaitingListApplication>?> {
-    val checkPrisonCode = getScheduleDetailsService.execute(scheduleId, filters)
-    if (checkPrisonCode.errors.isNotEmpty()) {
-      return Response(data = null, errors = checkPrisonCode.errors)
+    val scheduleDetailsResponse = activitiesGateway.getActivityScheduleById(scheduleId)
+    if (scheduleDetailsResponse.errors.isNotEmpty()) {
+      return Response(data = null, errors = scheduleDetailsResponse.errors)
     }
 
-    val waitingListApplicationResponse = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId)
+    val prisonCode =
+      scheduleDetailsResponse.data
+        ?.activity
+        ?.prisonCode!!
+    val consumerPrisonFilterCheck = consumerPrisonAccessService.checkConsumerHasPrisonAccess<List<WaitingListApplication>>(prisonCode, filters, upstreamServiceType = UpstreamApi.ACTIVITIES)
+    if (consumerPrisonFilterCheck.errors.isNotEmpty()) {
+      return consumerPrisonFilterCheck
+    }
+
+    val waitingListApplicationResponse = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
     if (waitingListApplicationResponse.errors.isNotEmpty()) {
       return Response(
         data = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetWaitingListApplicationsByScheduleIdGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetWaitingListApplicationsByScheduleIdGatewayTest.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.activities
 
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -59,7 +62,8 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
       }
 
       it("Returns a waiting list application") {
-        mockServer.stubForGet("/schedules/$scheduleId/waiting-list-applications", File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.OK)
+        val path = "/schedules/$scheduleId/waiting-list-applications"
+        mockServer.stubForGet(path, File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.OK)
 
         val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
         result.errors.shouldBeEmpty()
@@ -96,6 +100,11 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
               nonAssociations = true,
             ),
           ),
+        )
+
+        mockServer.verify(
+          getRequestedFor(urlEqualTo(path))
+            .withHeader("Caseload-Id", equalTo(prisonCode)),
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetWaitingListApplicationsByScheduleIdGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetWaitingListApplicationsByScheduleIdGatewayTest.kt
@@ -37,6 +37,7 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
     {
       val mockServer = ApiMockServer.create(UpstreamApi.ACTIVITIES)
       val scheduleId = 123456L
+      val prisonCode = "MDI"
 
       beforeEach {
         mockServer.start()
@@ -52,7 +53,7 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
       }
 
       it("authenticates using HMPPS Auth with credentials") {
-        activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId)
+        activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
 
         verify(hmppsAuthGateway, times(1)).getClientToken("ACTIVITIES")
       }
@@ -60,7 +61,7 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
       it("Returns a waiting list application") {
         mockServer.stubForGet("/schedules/$scheduleId/waiting-list-applications", File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.OK)
 
-        val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId)
+        val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
         result.errors.shouldBeEmpty()
         result.data.shouldNotBeNull()
         result.data.shouldBe(
@@ -101,7 +102,7 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
       it("Returns a bad request error") {
         mockServer.stubForGet("/schedules/$scheduleId/waiting-list-applications", File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.BAD_REQUEST)
 
-        val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId)
+        val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
         result.errors.shouldBe(listOf(UpstreamApiError(causedBy = UpstreamApi.ACTIVITIES, type = UpstreamApiError.Type.BAD_REQUEST)))
       }
     },


### PR DESCRIPTION
A `CaseLoad-ID` header is required on the upstream waiting list applications request. This PR adds this.