### PR TITLE
HMAI-713 - Correct usage of waiting list applications on allocation endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ActivitiesGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/ActivitiesGateway.kt
@@ -389,7 +389,7 @@ class ActivitiesGateway(
     val result =
       webClient.requestList<ActivitiesWaitingListApplication>(
         HttpMethod.GET,
-        "/schedules/$scheduleId/waiting-list-applications",
+        "/integration-api/schedules/$scheduleId/waiting-list-applications",
         authenticationHeader() + mapOf("Caseload-Id" to prisonCode),
         UpstreamApi.ACTIVITIES,
         badRequestAsError = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetWaitingListApplicationsByScheduleIdGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/GetWaitingListApplicationsByScheduleIdGatewayTest.kt
@@ -62,7 +62,7 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
       }
 
       it("Returns a waiting list application") {
-        val path = "/schedules/$scheduleId/waiting-list-applications"
+        val path = "/integration-api/schedules/$scheduleId/waiting-list-applications"
         mockServer.stubForGet(path, File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.OK)
 
         val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
@@ -109,7 +109,7 @@ class GetWaitingListApplicationsByScheduleIdGatewayTest(
       }
 
       it("Returns a bad request error") {
-        mockServer.stubForGet("/schedules/$scheduleId/waiting-list-applications", File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.BAD_REQUEST)
+        mockServer.stubForGet("/integration-api/schedules/$scheduleId/waiting-list-applications", File("src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(), HttpStatus.BAD_REQUEST)
 
         val result = activitiesGateway.getWaitingListApplicationsByScheduleId(scheduleId, prisonCode)
         result.errors.shouldBe(listOf(UpstreamApiError(causedBy = UpstreamApi.ACTIVITIES, type = UpstreamApiError.Type.BAD_REQUEST)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleIdMultipleApproved.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/activities/fixtures/GetWaitingListApplicationsByScheduleIdMultipleApproved.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": 111111,
+    "activityId": 1000,
+    "scheduleId": 222222,
+    "allocationId": 333333,
+    "prisonCode": "MDI",
+    "prisonerNumber": "G2996UX",
+    "bookingId": 10001,
+    "status": "APPROVED",
+    "statusUpdatedTime": "2023-06-04T16:30:00",
+    "requestedDate": "2023-06-23",
+    "requestedBy": "Fred Bloggs",
+    "comments": "The prisoner has specifically requested to attend this activity",
+    "declinedReason": "The prisoner has specifically requested to attend this activity",
+    "creationTime": "2023-01-03T12:00:00",
+    "createdBy": "Jon Doe",
+    "updatedTime": "2023-01-04T16:30:00",
+    "updatedBy": "Jane Doe",
+    "earliestReleaseDate": {
+      "releaseDate": "2027-09-20",
+      "isTariffDate": true,
+      "isIndeterminateSentence": true,
+      "isImmigrationDetainee": true,
+      "isConvictedUnsentenced": true,
+      "isRemand": true
+    },
+    "nonAssociations": true
+  },
+  {
+    "id": 111111,
+    "activityId": 1000,
+    "scheduleId": 222222,
+    "allocationId": 333333,
+    "prisonCode": "MDI",
+    "prisonerNumber": "G2996UX",
+    "bookingId": 10001,
+    "status": "APPROVED",
+    "statusUpdatedTime": "2023-06-04T16:30:00",
+    "requestedDate": "2023-06-23",
+    "requestedBy": "Fred Bloggs",
+    "comments": "The prisoner has specifically requested to attend this activity",
+    "declinedReason": "The prisoner has specifically requested to attend this activity",
+    "creationTime": "2023-01-03T12:00:00",
+    "createdBy": "Jon Doe",
+    "updatedTime": "2023-01-04T16:30:00",
+    "updatedBy": "Jane Doe",
+    "earliestReleaseDate": {
+      "releaseDate": "2027-09-20",
+      "isTariffDate": true,
+      "isIndeterminateSentence": true,
+      "isImmigrationDetainee": true,
+      "isConvictedUnsentenced": true,
+      "isRemand": true
+    },
+    "nonAssociations": true
+  }
+]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/ActivitiesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/ActivitiesIntegrationTest.kt
@@ -550,26 +550,9 @@ class ActivitiesIntegrationTest : IntegrationTestWithQueueBase("activities") {
         File("$gatewaysFolder/activities/fixtures/GetPrisonPayBands.json").readText(),
       )
 
-      activitiesMockServer.stubForPost(
-        "/waiting-list-applications/$prisonCode/search?page=0&pageSize=50",
-        """
-        {
-          "prisonerNumbers": ["$nomsId"],
-          "status": ["PENDING"]
-        }
-        """.trimIndent(),
-        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplicationsEmpty.json").readText(),
-      )
-
-      activitiesMockServer.stubForPost(
-        "/waiting-list-applications/$prisonCode/search?page=0&pageSize=50",
-        """
-        {
-          "prisonerNumbers": ["$nomsId"],
-          "status": ["APPROVED"]
-        }
-        """.trimIndent(),
-        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplications.json").readText().replace("\"status\": \"PENDING\"", "\"status\": \"APPROVED\""),
+      activitiesMockServer.stubForGet(
+        "/integration-api/schedules/$scheduleId/waiting-list-applications",
+        "[]",
       )
 
       val requestBody = asJsonString(prisonerAllocationRequest)
@@ -886,26 +869,9 @@ class ActivitiesIntegrationTest : IntegrationTestWithQueueBase("activities") {
         File("$gatewaysFolder/activities/fixtures/GetPrisonPayBands.json").readText(),
       )
 
-      activitiesMockServer.stubForPost(
-        "/waiting-list-applications/$prisonCode/search?page=0&pageSize=50",
-        """
-        {
-          "prisonerNumbers": ["$nomsId"],
-          "status": ["PENDING"]
-        }
-        """.trimIndent(),
-        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplications.json").readText(),
-      )
-
-      activitiesMockServer.stubForPost(
-        "/waiting-list-applications/$prisonCode/search?page=0&pageSize=50",
-        """
-        {
-          "prisonerNumbers": ["$nomsId"],
-          "status": ["APPROVED"]
-        }
-        """.trimIndent(),
-        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplications.json").readText().replace("\"status\": \"PENDING\"", "\"status\": \"APPROVED\""),
+      activitiesMockServer.stubForGet(
+        "/integration-api/schedules/$scheduleId/waiting-list-applications",
+        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(),
       )
 
       val requestBody =
@@ -939,25 +905,9 @@ class ActivitiesIntegrationTest : IntegrationTestWithQueueBase("activities") {
         File("$gatewaysFolder/activities/fixtures/GetPrisonPayBands.json").readText(),
       )
 
-      activitiesMockServer.stubForPost(
-        "/waiting-list-applications/$prisonCode/search?page=0&pageSize=50",
-        """
-        {
-          "prisonerNumbers": ["$nomsId"],
-          "status": ["PENDING"]
-        }
-        """.trimIndent(),
-        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplicationsEmpty.json").readText(),
-      )
-
-      val responseBody =
-        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplicationsMultipleApproved.json")
-          .readText()
-
-      activitiesMockServer.stubForPost(
-        "/waiting-list-applications/$prisonCode/search?page=0&pageSize=50",
-        """{ "prisonerNumbers": ["$nomsId"], "status": ["APPROVED"] }""",
-        responseBody,
+      activitiesMockServer.stubForGet(
+        "/integration-api/schedules/$scheduleId/waiting-list-applications",
+        File("$gatewaysFolder/activities/fixtures/GetWaitingListApplicationsByScheduleIdMultipleApproved.json").readText(),
       )
 
       val requestBody =
@@ -1022,7 +972,7 @@ class ActivitiesIntegrationTest : IntegrationTestWithQueueBase("activities") {
       )
 
       activitiesMockServer.stubForGet(
-        "/schedules/$scheduleId/waiting-list-applications",
+        "/integration-api/schedules/$scheduleId/waiting-list-applications",
         File("$gatewaysFolder/activities/fixtures/GetWaitingListApplicationsByScheduleId.json").readText(),
       )
 
@@ -1031,7 +981,7 @@ class ActivitiesIntegrationTest : IntegrationTestWithQueueBase("activities") {
         .andExpect(MockMvcResultMatchers.content().json(getExpectedResponse("waiting-list-applications-response")))
 
       activitiesMockServer.verify(
-        getRequestedFor(urlEqualTo("/schedules/$scheduleId/waiting-list-applications"))
+        getRequestedFor(urlEqualTo("/integration-api/schedules/$scheduleId/waiting-list-applications"))
           .withHeader("Caseload-Id", equalTo(prisonCode)),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ActivitiesQueueServiceTest.kt
@@ -39,7 +39,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.EarliestRel
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Exclusion
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsMessage
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.HmppsMessageResponse
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedWaitingListApplications
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PersonInPrison
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PrisonerAllocationRequest
@@ -49,7 +48,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Slot
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.WaitingListApplication
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.WaitingListSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.personas.personInProbationAndNomisPersona
 import uk.gov.justice.hmpps.sqs.HmppsQueue
@@ -71,7 +69,7 @@ class ActivitiesQueueServiceTest(
   @MockitoBean val getAttendanceByIdService: GetAttendanceByIdService,
   @MockitoBean private val getScheduleDetailsService: GetScheduleDetailsService,
   @MockitoBean private val getPrisonPayBandsService: GetPrisonPayBandsService,
-  @MockitoBean private val getWaitingListApplicationsService: GetWaitingListApplicationsService,
+  @MockitoBean private val getWaitingListApplicationsByScheduleIdService: GetWaitingListApplicationsByScheduleIdService,
   @MockitoBean private val activitiesGateway: ActivitiesGateway,
 ) : DescribeSpec(
     {
@@ -520,48 +518,33 @@ class ActivitiesQueueServiceTest(
             ),
           )
 
-        val paginatedWaitingListApplications =
-          PaginatedWaitingListApplications(
-            content =
-              listOf(
-                WaitingListApplication(
-                  id = 1L,
-                  activityId = 100L,
-                  scheduleId = 200L,
-                  allocationId = null,
-                  prisonId = prisonId,
-                  prisonerNumber = prisonerNumber,
-                  bookingId = 300L,
-                  status = "PENDING",
-                  statusUpdatedTime = null,
-                  requestedDate = LocalDate.now(),
-                  comments = null,
-                  declinedReason = null,
-                  creationTime = LocalDateTime.now(),
-                  updatedTime = null,
-                  earliestReleaseDate =
-                    EarliestReleaseDate(
-                      releaseDate = LocalDate.now().plusMonths(6).toString(),
-                      isTariffDate = false,
-                      isIndeterminateSentence = false,
-                      isImmigrationDetainee = false,
-                      isConvictedUnsentenced = false,
-                      isRemand = false,
-                    ),
-                  nonAssociations = null,
-                ),
+        val pendingWaitingApplication =
+          WaitingListApplication(
+            id = 1L,
+            activityId = 100L,
+            scheduleId = 200L,
+            allocationId = null,
+            prisonId = prisonId,
+            prisonerNumber = prisonerNumber,
+            bookingId = 300L,
+            status = "PENDING",
+            statusUpdatedTime = null,
+            requestedDate = LocalDate.now(),
+            comments = null,
+            declinedReason = null,
+            creationTime = LocalDateTime.now(),
+            updatedTime = null,
+            earliestReleaseDate =
+              EarliestReleaseDate(
+                releaseDate = LocalDate.now().plusMonths(6).toString(),
+                isTariffDate = false,
+                isIndeterminateSentence = false,
+                isImmigrationDetainee = false,
+                isConvictedUnsentenced = false,
+                isRemand = false,
               ),
-            totalPages = 1,
-            totalCount = 1L,
-            isLastPage = true,
-            count = 1,
-            page = 1,
-            perPage = 10,
+            nonAssociations = null,
           )
-
-        val pendingWaitingListSearchRequest = WaitingListSearchRequest(prisonerNumbers = listOf(prisonerNumber), status = listOf("PENDING"))
-        val approvedWaitingListSearchRequest = WaitingListSearchRequest(prisonerNumbers = listOf(prisonerNumber), status = listOf("APPROVED"))
-        val waitingListResponse = paginatedWaitingListApplications.copy(content = emptyList(), totalPages = 0, totalCount = 0L, count = 0)
 
         beforeTest {
           Mockito.reset(getPersonService, activitiesGateway, getPrisonPayBandsService)
@@ -576,11 +559,8 @@ class ActivitiesQueueServiceTest(
           whenever(getPrisonPayBandsService.execute(prisonId, filters))
             .thenReturn(Response(data = prisonPayBand))
 
-          whenever(getWaitingListApplicationsService.execute(prisonId, pendingWaitingListSearchRequest, filters))
-            .thenReturn(Response(data = waitingListResponse))
-
-          whenever(getWaitingListApplicationsService.execute(prisonId, approvedWaitingListSearchRequest, filters))
-            .thenReturn(Response(data = waitingListResponse))
+          whenever(getWaitingListApplicationsByScheduleIdService.execute(scheduleId, filters))
+            .thenReturn(Response(data = emptyList()))
         }
 
         it("Returns an error if allocation start date is in the past") {
@@ -913,13 +893,12 @@ class ActivitiesQueueServiceTest(
         }
 
         it("Returns an error if getWaitingListApplicationsService returns an error") {
-          val pendingWaitingListSearchRequest = WaitingListSearchRequest(prisonerNumbers = listOf(prisonerNumber), status = listOf("PENDING"))
           val error = UpstreamApiError(UpstreamApi.ACTIVITIES, UpstreamApiError.Type.BAD_REQUEST, "error from getWaitingListApplicationsService")
 
           whenever(activitiesGateway.getActivityScheduleById(scheduleId))
             .thenReturn(Response(data = activitiesActivityScheduleDetailed))
 
-          whenever(getWaitingListApplicationsService.execute(prisonId, pendingWaitingListSearchRequest, filters))
+          whenever(getWaitingListApplicationsByScheduleIdService.execute(scheduleId, filters))
             .thenReturn(Response(data = null, errors = listOf(error)))
 
           val result = activitiesQueueService.sendPrisonerAllocationRequest(scheduleId, allocationRequest, who, filters)
@@ -928,18 +907,13 @@ class ActivitiesQueueServiceTest(
         }
 
         it("Returns an error if prisoner has a PENDING waiting list application") {
-          val pendingWaitingListSearchRequest = WaitingListSearchRequest(prisonerNumbers = listOf(prisonerNumber), status = listOf("PENDING"))
-          val approvedWaitingListSearchRequest = WaitingListSearchRequest(prisonerNumbers = listOf(prisonerNumber), status = listOf("APPROVED"))
           val error = UpstreamApiError(UpstreamApi.ACTIVITIES, UpstreamApiError.Type.CONFLICT, "Prisoner has a PENDING waiting list application. It must be APPROVED before they can be allocated.")
 
           whenever(activitiesGateway.getActivityScheduleById(scheduleId))
             .thenReturn(Response(data = activitiesActivityScheduleDetailed))
 
-          whenever(getWaitingListApplicationsService.execute(prisonId, pendingWaitingListSearchRequest, filters))
-            .thenReturn(Response(data = paginatedWaitingListApplications))
-
-          whenever(getWaitingListApplicationsService.execute(prisonId, approvedWaitingListSearchRequest, filters))
-            .thenReturn(Response(data = null))
+          whenever(getWaitingListApplicationsByScheduleIdService.execute(scheduleId, filters))
+            .thenReturn(Response(data = listOf(pendingWaitingApplication)))
 
           val result = activitiesQueueService.sendPrisonerAllocationRequest(scheduleId, allocationRequest, who, filters)
           result.data.shouldBeNull()
@@ -947,20 +921,14 @@ class ActivitiesQueueServiceTest(
         }
 
         it("Returns an error if prisoner has more than one APPROVED waiting list application") {
-          val pendingResponse = paginatedWaitingListApplications.copy(content = emptyList(), totalPages = 0, totalCount = 0L, count = 0)
-          val approvedResponse =
-            paginatedWaitingListApplications.copy(
-              content =
-                listOf(
-                  paginatedWaitingListApplications.content.first().copy(status = "APPROVED"),
-                  paginatedWaitingListApplications.content.first().copy(id = 2L, status = "APPROVED"),
-                ),
+          val approvedWaitingListApplications =
+            listOf(
+              pendingWaitingApplication.copy(status = "APPROVED"),
+              pendingWaitingApplication.copy(id = 2L, status = "APPROVED"),
             )
-          whenever(getWaitingListApplicationsService.execute(prisonId, pendingWaitingListSearchRequest, filters))
-            .thenReturn(Response(data = pendingResponse))
 
-          whenever(getWaitingListApplicationsService.execute(prisonId, approvedWaitingListSearchRequest, filters))
-            .thenReturn(Response(data = approvedResponse))
+          whenever(getWaitingListApplicationsByScheduleIdService.execute(scheduleId, filters))
+            .thenReturn(Response(data = approvedWaitingListApplications))
 
           val error = UpstreamApiError(UpstreamApi.ACTIVITIES, UpstreamApiError.Type.CONFLICT, "Prisoner has more than one APPROVED waiting list application. A prisoner can only have one approved waiting list application.")
           val result = activitiesQueueService.sendPrisonerAllocationRequest(scheduleId, allocationRequest, who, filters)


### PR DESCRIPTION
The allocation endpoint now checks for waiting list applications for the prisoner by schedule ID (using the service that already exists for our waiting list applications endpoint to do this). Previously it checked for **any** waiting list applications for a prisoner.