### PR TITLE
Remove usernames from GET /v1/contacts/{contactId} endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/DetailedContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/DetailedContact.kt
@@ -86,12 +86,8 @@ data class ContactAddress(
   val comments: String?,
   @Schema(description = "Phone numbers that are related to this address")
   val phoneNumbers: List<ContactPhoneNumber>,
-  @Schema(description = "The id of the user who created the contact", example = "JD000001")
-  val createdBy: String,
   @Schema(description = "The timestamp of when the contact was created", example = "2024-01-01T00:00:00Z")
   val createdTime: String,
-  @Schema(description = "The id of the user who created the contact address", example = "JD000001")
-  val updatedBy: String?,
   @Schema(description = "The timestamp of when the contact address was last updated", example = "2024-01-01T00:00:00Z")
   val updatedTime: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRDetailedContact.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRDetailedContact.kt
@@ -102,9 +102,7 @@ data class Address(
       noFixedAddress = this.noFixedAddress,
       comments = this.comments,
       phoneNumbers = this.phoneNumbers.map { it.toContactPhoneNumber() },
-      createdBy = this.createdBy,
       createdTime = this.createdTime,
-      updatedBy = this.updatedBy,
       updatedTime = this.updatedTime,
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/ContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/ContactsIntegrationTest.kt
@@ -58,9 +58,7 @@ class ContactsIntegrationTest : IntegrationTestBase() {
                       "extNumber": "123"
                     }
                   ],
-                  "createdBy": "JD000001",
                   "createdTime": "2024-01-01T00:00:00Z",
-                  "updatedBy": "JD000001",
                   "updatedTime": "2024-01-01T00:00:00Z"
                 }
               ],


### PR DESCRIPTION
We don't want to expose user fields on our endpoints