### PR TITLE
HMAI-661 Set sensible connect and response timeouts to all upstream requests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
+import io.netty.channel.ChannelOption
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
+import reactor.netty.http.client.HttpClient
 import reactor.util.retry.Retry
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
@@ -22,10 +25,17 @@ class WebClientWrapper(
   val MAX_RETRY_ATTEMPTS = 3L
   val MIN_BACKOFF_DURATION = Duration.ofSeconds(3)
 
+  val httpClient =
+    HttpClient
+      .create()
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+      .responseTimeout(Duration.ofSeconds(15))
+
   val client: WebClient =
     WebClient
       .builder()
       .baseUrl(baseUrl)
+      .clientConnector(ReactorClientHttpConnector(httpClient))
       .exchangeStrategies(
         ExchangeStrategies
           .builder()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -20,6 +20,8 @@ import java.time.Duration
 @Suppress("ktlint:standard:property-naming")
 class WebClientWrapper(
   val baseUrl: String,
+  connectTimeoutMillis: Int = 10_000,
+  responseTimeoutSeconds: Long = 15,
 ) {
   val CREATE_TRANSACTION_RETRY_HTTP_CODES = listOf(502, 503, 504, 522, 599, 499, 408)
   val MAX_RETRY_ATTEMPTS = 3L
@@ -28,8 +30,8 @@ class WebClientWrapper(
   val httpClient =
     HttpClient
       .create()
-      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
-      .responseTimeout(Duration.ofSeconds(15))
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis)
+      .responseTimeout(Duration.ofSeconds(responseTimeoutSeconds))
 
   val client: WebClient =
     WebClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -53,7 +53,12 @@ class WebClientWrapperTest :
 
     beforeEach {
       mockServer.start()
-      webClient = WebClientWrapper(baseUrl = mockServer.baseUrl())
+      webClient =
+        WebClientWrapper(
+          baseUrl = mockServer.baseUrl(),
+          connectTimeoutMillis = 500,
+          responseTimeoutSeconds = 1,
+        )
     }
 
     afterTest {
@@ -298,7 +303,7 @@ class WebClientWrapperTest :
       }
 
       it("throws a timeout error if response is too slow") {
-        mockServer.stubGetTest(getPath, """{"result": "timeout"}""", delayMillis = 20000)
+        mockServer.stubGetTest(getPath, """{"result": "timeout"}""", delayMillis = 2000)
 
         val exception =
           shouldThrow<WebClientRequestException> {
@@ -308,7 +313,12 @@ class WebClientWrapperTest :
       }
 
       it("throws a connect timeout error if server is unreachable") {
-        val timeoutWebClient = WebClientWrapper("http://10.255.255.1:81")
+        val timeoutWebClient =
+          WebClientWrapper(
+            "http://10.255.255.1:81",
+            connectTimeoutMillis = 300,
+            responseTimeoutSeconds = 2,
+          )
 
         val exception =
           shouldThrow<WebClientRequestException> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/TestApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/TestApiMockServer.kt
@@ -13,6 +13,7 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
     path: String,
     body: String,
     status: HttpStatus = HttpStatus.OK,
+    delayMillis: Int = 0,
   ) {
     stubFor(
       WireMock
@@ -22,7 +23,8 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
             .aResponse()
             .withHeader("Content-Type", "application/json")
             .withStatus(status.value())
-            .withBody(body.trimIndent()),
+            .withBody(body.trimIndent())
+            .withFixedDelay(delayMillis),
         ),
     )
   }
@@ -31,6 +33,7 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
     path: String,
     body: String,
     status: HttpStatus = HttpStatus.OK,
+    delayMillis: Int = 0,
   ) {
     stubFor(
       WireMock.post(path).willReturn(
@@ -38,7 +41,8 @@ class TestApiMockServer : WireMockServer(WIREMOCK_PORT) {
           .aResponse()
           .withHeader("Content-Type", "application/json")
           .withStatus(status.value())
-          .withBody(body.trimIndent()),
+          .withBody(body.trimIndent())
+          .withFixedDelay(delayMillis),
       ),
     )
   }


### PR DESCRIPTION
* Added configurable connect and response timeouts to `WebClientWrapper`.
* Extended `TestApiMockServer.stubGetTest` and `stubPostTest` to support response delays for timeout testing.
* Added a test for response timeout using WireMock delay.
* Added a test for connect timeout by targeting an unroutable IP address.
