### PR TITLE
Add compiler option to remove warnings on annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.1"
@@ -63,9 +64,10 @@ tasks {
     }
   }
 
-  withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  withType<KotlinCompile> {
     compilerOptions {
       jvmTarget = JvmTarget.JVM_21
+      freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
   }
 }


### PR DESCRIPTION
Since updating IntelliJ, we have been getting lots of warnings like:

```
This annotation is currently applied to the value parameter only, but in the future it will also be applied to 'field'. 
See https://youtrack.jetbrains.com/issue/KT-73255 for more details. To remove this warning, use the '@param:' annotation target.
```

This compiler argument removes these warnings by setting the behaviour