### PR TITLE
Changed the value of scheduleId on smoke tests

### DIFF
--- a/scripts/K6/full-access-smoke-tests.js
+++ b/scripts/K6/full-access-smoke-tests.js
@@ -10,7 +10,7 @@ export const options = {
   tlsAuth: [
     {
       domains: ["dev.integration-api.hmpps.service.justice.gov.uk"],
-                      cert,
+      cert,
       key,
     },
   ],
@@ -33,7 +33,7 @@ const contactId = "1898610";
 const imageId = "1988315";
 const locationIdKey = "MKI-A";
 const activityId = 1162
-const scheduleId = 1
+const scheduleId = 518
 const today = new Date();
 const year = today.getFullYear();
 const month = (today.getMonth() + 1).toString().padStart(2, '0');


### PR DESCRIPTION
The smoke tests for `/v1/activities/schedule/{scheduleId}/waiting-list-applications` were failing due to the schedule ID causing a 403. Have changed this to one that works for all endpoints