### PR TITLE
HIA-840: Return address type reference data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ReferenceDataController.kt
@@ -28,6 +28,7 @@ class ReferenceDataController(
     responses = [
       ApiResponse(
         responseCode = "200",
+        useReturnTypeSchema = true,
         description = "Successfully returned prison and probation reference data.",
         content = [
           Content(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ReferenceDataService.kt
@@ -33,14 +33,16 @@ class ReferenceDataService(
         .probationReferenceData
 
     val prisonReferenceData =
-      NomisReferenceDataType.entries
-        .flatMap {
-          val rd = prisonReferenceData(it.name)
-          if (rd.errors.isNotEmpty()) {
-            return Response(data = null, errors = rd.errors)
+      NomisReferenceDataType.entries.associate {
+        it.name to
+          it.categories.flatMap { name ->
+            val rd = prisonReferenceData(name)
+            if (rd.errors.isNotEmpty()) {
+              return Response(data = null, errors = rd.errors)
+            }
+            rd.data!!.map { rdItem -> ReferenceDataItem(rdItem.code!!, rdItem.description!!) }
           }
-          rd.data!!
-        }.groupByTo(LinkedHashMap(), { NomisReferenceDataType.valueOf(it.domain!!).category }, { ReferenceDataItem(it.code!!, it.description!!) })
+      }
 
     return Response(data = ReferenceData(prisonReferenceData, probationReferenceData))
   }
@@ -77,10 +79,11 @@ class ReferenceDataService(
 }
 
 enum class NomisReferenceDataType(
-  val category: String,
+  val categories: List<String>,
 ) {
-  PHONE_USAGE("PHONE_TYPE"),
-  ALERT("ALERT_TYPE"),
-  ETHNICITY("ETHNICITY"),
-  SEX("GENDER"),
+  PHONE_TYPE(listOf("PHONE_USAGE")),
+  ALERT_TYPE(listOf("ALERT")),
+  ETHNICITY(listOf("ETHNICITY")),
+  GENDER(listOf("SEX")),
+  ADDRESS_TYPE(listOf("ADDRESS_TYPE", "ADDR_TYPE")),
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RolesIncludeIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RolesIncludeIntegrationTest.kt
@@ -18,13 +18,8 @@ class RolesIncludeIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `reference-data-only should be able to access reference data`() {
-    // There is a defect (HIA-788) in the reference data service / NOMIS prism
-    // mock that results in an internal server error. The expected response for
-    // this test should be changed to 200 as part of fixing that defect.
-    // In the meantime, the 500 demonstrates that the client is able to invoke
-    // the endpoint, which is the purpose of this test.
     callApiWithCN("/v1/hmpps/reference-data", "reference-data-only-user")
-      .andExpect(status().isInternalServerError)
+      .andExpect(status().isOk)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ReferenceDataServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/ReferenceDataServiceTest.kt
@@ -48,6 +48,16 @@ class ReferenceDataServiceTest(
                    "code": "F",
                    "description": "Female"
                   }
+                ],
+                "ADDRESS_TYPE": [
+                  {
+                   "code": "A1",
+                   "description": "Delius address status 1"
+                  },
+                  {
+                   "code": "A2",
+                   "description": "Delius address status 2"
+                  }
                 ]
               }
             }
@@ -97,6 +107,28 @@ class ReferenceDataServiceTest(
             {"domain":"SEX", "code":"a", "description":"desc_a"},
             {"domain":"SEX", "code":"b", "description":"desc_b"},
             {"domain":"SEX", "code":"c", "description":"desc_c"}
+          ]
+        """,
+        )
+
+        nomisApiMockServer.stubForGet(
+          "/api/reference-domains/domains/ADDRESS_TYPE",
+          """
+          [
+            {"domain":"ADDRESS_TYPE", "code":"a", "description":"prison ADDRESS_TYPE_a"},
+            {"domain":"ADDRESS_TYPE", "code":"b", "description":"prison ADDRESS_TYPE_b"},
+            {"domain":"ADDRESS_TYPE", "code":"c", "description":"prison ADDRESS_TYPE_c"}
+          ]
+        """,
+        )
+
+        nomisApiMockServer.stubForGet(
+          "/api/reference-domains/domains/ADDR_TYPE",
+          """
+          [
+            {"domain":"ADDR_TYPE", "code":"ta", "description":"prison ADDR_TYPE_ta"},
+            {"domain":"ADDR_TYPE", "code":"tb", "description":"prison ADDR_TYPE_tb"},
+            {"domain":"ADDR_TYPE", "code":"tc", "description":"prison ADDR_TYPE_tc"}
           ]
         """,
         )
@@ -209,6 +241,31 @@ class ReferenceDataServiceTest(
                     "code": "c",
                     "description": "desc_c"
                   }
+                ],
+                "ADDRESS_TYPE": [
+                  {
+                    "code":"a",
+                    "description":"prison ADDRESS_TYPE_a"
+                  },
+                  {
+                    "code":"b",
+                    "description":"prison ADDRESS_TYPE_b"
+                  },
+                  {
+                    "code":"c",
+                    "description":"prison ADDRESS_TYPE_c"
+                  },
+                  {
+                    "code":"ta",
+                    "description":"prison ADDR_TYPE_ta"
+                  },
+                  {
+                    "code":"tb",
+                    "description":"prison ADDR_TYPE_tb"},
+                  {
+                    "code":"tc",
+                    "description":"prison ADDR_TYPE_tc"
+                  }
                 ]
               },
               "probationReferenceData": {
@@ -220,6 +277,16 @@ class ReferenceDataServiceTest(
                   {
                     "code": "F",
                     "description": "Female"
+                  }
+                ],
+                "ADDRESS_TYPE": [
+                  {
+                   "code": "A1",
+                   "description": "Delius address status 1"
+                  },
+                  {
+                   "code": "A2",
+                   "description": "Delius address status 2"
                   }
                 ]
               }


### PR DESCRIPTION
Also fixes HIA-788 and HIA-789 (by adding `useReturnTypeSchema = true` to the ReferenceData controller)