### PR TITLE
HI-837: Prisoner Search API Discriminator validation fix

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/PrisonerOffenderSearchGatewayTest.kt
@@ -372,8 +372,7 @@ class PrisonerOffenderSearchGatewayTest(
             .cellLocation
             .shouldBe(cellLocation)
 
-//          Need to look into the validation.request.body.schema.processingError causing issues on this test and associated DeactivateLocationIntegrationTest
-//          prisonerOffenderSearchApiMockServer.assertValidationPassed()
+          prisonerOffenderSearchApiMockServer.assertValidationPassed()
         }
 
         it("throws an exception when 400 BAD REQUEST is returned") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ApiMockServer.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers
 
+import com.atlassian.oai.validator.OpenApiInteractionValidator
+import com.atlassian.oai.validator.whitelist.ValidationErrorsWhitelist
+import com.atlassian.oai.validator.whitelist.rule.WhitelistRules
 import com.atlassian.oai.validator.wiremock.OpenApiValidationListener
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
@@ -9,6 +12,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.matching
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.stubbing.Scenario
+import io.swagger.v3.parser.OpenAPIV3Parser
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 
@@ -21,7 +25,7 @@ class ApiMockServer(
     fun create(upstreamApi: UpstreamApi): ApiMockServer {
       val apiMockerServerConfig =
         when (upstreamApi) {
-          UpstreamApi.PRISONER_OFFENDER_SEARCH -> ApiMockServerConfig(4000, "prisoner-search.json")
+          UpstreamApi.PRISONER_OFFENDER_SEARCH -> ApiMockServerConfig(4000, "prisoner-search.json", true)
           UpstreamApi.HEALTH_AND_MEDICATION -> ApiMockServerConfig(4001, "health-and-medication.json")
           UpstreamApi.MANAGE_POM_CASE -> ApiMockServerConfig(4002, "manage-POM.json")
           UpstreamApi.PLP -> ApiMockServerConfig(4003, "plp.json")
@@ -49,7 +53,37 @@ class ApiMockServer(
 
       if (apiMockerServerConfig.configPath != null) {
         val specPath = "src/test/resources/openapi-specs/${apiMockerServerConfig.configPath}"
-        val validationListener = OpenApiValidationListener(specPath)
+        /*
+          For schemas that use discriminators for inheritance, we must use the OpenAPIV3Parser to create the validator.
+          We must also set the bind-type system property to true.
+          This is to preserve the type of the discriminator, which is being overridden by the atlassian and swagger core libraries.
+          The discriminator type is essential when we are using the swagger-core-request-validator
+          For swagger core issue @see https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---OpenAPI-3.1#foreword
+          We set the bind-type to true to preserve the type in version 3.1 and prevent it being nulled in favour of the types array introduced in 3.1.
+          For atlassion code @see https://bitbucket.org/atlassian/swagger-request-validator/src/4e3e8fe412e99517a03e32a2c3217eb064c44823/swagger-request-validator-core/src/main/java/com/atlassian/oai/validator/util/OpenApiLoader.java?at=master#lines-55
+          We use OpenAPIV3Parser instead of atlassions OpenAPILoader for schemas that use discriminators to ensure the request is fully validated.
+         */
+        val openApiInteractionValidator =
+          if (apiMockerServerConfig.overrideBindType) {
+            // Adding a whitelist to ignore discriminator validation as currently the prisoner search api spec is unable to provide the discriminator mappings
+            val whitelist =
+              ValidationErrorsWhitelist
+                .create()
+                .withRule(
+                  "Ignore discriminator errors",
+                  WhitelistRules.allOf(NestedMessagesValidationRule.nestedMessageHasKey("validation.request.body.schema.discriminator")),
+                )
+            withBindTypeSet {
+              OpenApiInteractionValidator
+                .Builder()
+                .withWhitelist(whitelist)
+                .withApi(OpenAPIV3Parser().readLocation(specPath, null, null).openAPI)
+                .build()
+            }
+          } else {
+            OpenApiInteractionValidator.createFor(specPath).build()
+          }
+        val validationListener = BindTypeValidationListener(openApiInteractionValidator, apiMockerServerConfig.overrideBindType)
         return ApiMockServer(wireMockConfig.extensions(ResetValidationEventListener(validationListener)), validationListener)
       }
 
@@ -69,6 +103,10 @@ class ApiMockServer(
 
   fun assertValidationPassed() {
     this.validationListener?.assertValidationPassed()
+  }
+
+  fun assertValidationFailed() {
+    this.validationListener?.report?.hasErrors()
   }
 
   fun stubForGet(
@@ -154,4 +192,23 @@ class ApiMockServer(
         ),
     )
   }
+}
+
+inline fun <reified T> withBindTypeSet(block: () -> T): T {
+  val bindType =
+    try {
+      System.getProperty("bind-type")
+    } catch (e: NullPointerException) {
+      null
+    }
+  if (bindType == null || bindType == "false") {
+    System.setProperty("bind-type", "true")
+  }
+  val result = block.invoke()
+  if (bindType == null) {
+    System.clearProperty("bind-type")
+  } else {
+    System.setProperty("bind-type", bindType)
+  }
+  return result
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ApiMockServerConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/ApiMockServerConfig.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers
 data class ApiMockServerConfig(
   val port: Int,
   val configPath: String? = null,
+  val overrideBindType: Boolean = false,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/BindTypeValidationListener.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/BindTypeValidationListener.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator
+import com.atlassian.oai.validator.wiremock.OpenApiValidationListener
+import com.github.tomakehurst.wiremock.http.Request
+import com.github.tomakehurst.wiremock.http.Response
+
+/*
+ BindTypeValidationListener.
+ In Swagger Core 2.2.x, when processing OpenAPI 3.1 specifications, type field is mapped by Set<String> types
+ member (instead of String type) to also support the array data type.
+ This means that the foo.type in V31 schema versions is deserialized into a Schema class with populated types (foo.types)
+ member (while foo.type remains null).
+
+ This causes the discriminator validation to fail as the type is changed to null (with the following error).
+ 'discriminator' field 'type' must be defined as a string property
+
+ In order to allow for no change support of 3.1 processing by existing clients in specific limited scenarios,
+ users can set system property bind-type=true to have Schema.getType() return the value of the single item of Schema.types
+ in OAS 3.1 specifications with a non-array Schema.type.
+
+ */
+
+class BindTypeValidationListener(
+  openApiInteractionValidator: OpenApiInteractionValidator,
+  private val overrideBindType: Boolean,
+) : OpenApiValidationListener(openApiInteractionValidator) {
+  override fun requestReceived(
+    request: Request?,
+    response: Response?,
+  ) {
+    if (overrideBindType) {
+      withBindTypeSet { super.requestReceived(request, response) }
+    } else {
+      super.requestReceived(request, response)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NestedMessagesValidationRule.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/mockservers/NestedMessagesValidationRule.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers
+
+import com.atlassian.oai.validator.model.ApiOperation
+import com.atlassian.oai.validator.model.Request
+import com.atlassian.oai.validator.model.Response
+import com.atlassian.oai.validator.report.ValidationReport
+import com.atlassian.oai.validator.whitelist.rule.WhitelistRule
+
+/**
+ * Extra atlassian rule to check for nested validation messages for whitelisting
+ * Atlassian validation only allows for top level messages and does not check nested messages.
+ * This is required so we can perform more finegrained whitelisting. Namely checking for the discriminator errors
+ * that only appear in nested messages
+ *
+ */
+
+class NestedMessagesValidationRule(
+  val representation: String,
+  val function: WhitelistRule,
+) : WhitelistRule {
+  override fun matches(
+    message: ValidationReport.Message?,
+    operation: ApiOperation?,
+    request: Request?,
+    response: Response?,
+  ): Boolean = function.matches(message, operation, request, response)
+
+  companion object {
+    fun nestedMessageHasKey(key: String): WhitelistRule {
+      // Extract nested messages recursively
+      fun getAllNestedMessages(
+        message: ValidationReport.Message,
+        list: MutableList<ValidationReport.Message> = mutableListOf<ValidationReport.Message>(),
+      ): List<ValidationReport.Message> {
+        message.nestedMessages.map { nestedMessage ->
+          if (nestedMessage.nestedMessages.size > 0) {
+            list.addAll(nestedMessage.nestedMessages)
+            nestedMessage.nestedMessages.forEach { getAllNestedMessages(it, list) }
+          }
+        }
+        return list
+      }
+      // Check key exists in nested messages
+      return NestedMessagesValidationRule(
+        "Message with key: '$key'",
+      ) { message: ValidationReport.Message, _: ApiOperation?, _: Request?, _: Response? ->
+        getAllNestedMessages(message).any { key.equals(it.key, ignoreCase = true) }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Ticket [HIA-837](https://dsdmoj.atlassian.net/browse/HIA-837) raised the issue where the following error is encountered whilst validating the prisoner search Open API specification in the tests

`"'discriminator' field 'type' must be defined as a string property"`

Background

The prisoner search uses a 'discriminator' to support polymorphism in the API definition (i.e a shared Matcher definition for BooleanMatcher, StringMatcher, IntMatcher etc).

It is currently defined like this:

```
      "Matcher": {
        "type": "object",
        "discriminator": {
          "propertyName": "type",
        },
        "properties": {
          "type": {
            "type": "string"
          }
        },
        "required": ["type"]
      }
```

The discriminator section is therefore validated by the `com.atlassian.oai.validator.schema.keyword.DiscriminaterSyntaxChecker` which uses Swagger Core 2.X

Problem

Now why would we be getting the error "'discriminator' field 'type' must be defined as a string property" when we can clearly see that the discriminator 'type' property has its type set to 'string'.

Well, as we can see in the prisoner search api specification, the version of the schema is `"openapi": "3.1.0"`.

One of the differences between 3.0 and 3.1 is that version 3.1 allows for an array to be specified for the type.

After investigation it appears that there was a change in Swagger Core 2.X, when processing OpenAPI 3.1 specifications, the type field is mapped by Set<String> types member (instead of String type) to also support array data type.

Therefore the discriminator is deserialized into a Schema class with populated types member (while type remains null) and looks something like this.

```
    discriminator: {
       type: null,
       types: ["string"]
    }
```
Therefore whilst validating using `com.atlassian.oai.validator.schema.keyword.DiscriminaterSyntaxChecker` the error is more obvious.
`"'discriminator' field 'type' must be defined as a string property"`

Fix(es)

How do we fix this? Well the swagger wiki [Swagger-2.X---OpenAPI-3.1](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---OpenAPI-3.1#foreword) describes a workaround that has been implemented for this very issue to allow for a non breaking change.
If you set the system property bind-type=true, then this does not bind single value types to an array and leaves the functionality intact.

Therefore i have created a BindTypeValidationListener class that sets this flag around the requestReceived method of the com.atlassian.oai.validator.OpenApiInteractionValidator class (depending on whether it is an openApi V3.1.0 schema. This is used when creating each of the MockServers used in the tests and 

This fixes the above error.

However, this then unearthed a stream of other errors.

The reason for this is that the prisoner search Open API schema doesnt actually provide a mechanism for matching the discriminator value it uses in the request e.g ("String", "Int", "PNC" etc) and is also incorrect in places - for example using one.
Therefore, to get a fully working and validate-able schema, i needed to make the following changes.

1. Provide a mapping between the discriminator value and the Matcher schema

```
          "mapping": {
            "String": "StringMatcher",
            "Boolean": "BooleanMatcher",
            "Date": "DateMatcher",
            "DateTime": "DateTimeMatcher",
            "Int": "IntMatcher",
            "PNC": "PncMatcher"
          }
```
2. For the list of matchers in the query schema. Replace the oneOf block with the list of child classes with a single reference to Matcher parent class. Using a oneOf causes cyclic reference issues which causes complicated loops.

4. In each of the matchers provide an enum val to enforce that the matcher must have the discriminator value equal to the value of the enum. This will help any oneOf matchers to match to the correct child. It specifies that it must be the value in the description, so better to enforce it.
```
                "type": "string",
                "description": "Must be String",
                "enum": ["String"],
```
5. Finally remove the allOf references from the child back to the parent as there would be a cyclic reference causing infinite loops.

I think this may need to be passed to the prisons team to see if they will implement these changes

[HIA-837]: https://dsdmoj.atlassian.net/browse/HIA-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ