### PR TITLE
review deadline date can be null

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PlanReviewSchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PlanReviewSchedule.kt
@@ -55,7 +55,7 @@ data class PlanReviewSchedule(
   @get:JsonProperty("reference", required = true) val reference: UUID,
   @field:Valid
   @Schema(example = "2023-11-19", required = true, description = "An ISO-8601 date representing date that the Review is due. ")
-  @get:JsonProperty("deadlineDate", required = true) val deadlineDate: LocalDate,
+  @get:JsonProperty("deadlineDate", required = false) val deadlineDate: LocalDate,
   @field:Valid
   @Schema(example = "null", required = true, description = "")
   @get:JsonProperty("status", required = true) val status: PlanReviewScheduleStatus,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetReviewSchedulesForPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetReviewSchedulesForPrisonerTest.kt
@@ -91,7 +91,7 @@ class GetReviewSchedulesForPrisonerTest(
 
         val schedule = schedules.first()
         schedule.reference.shouldBe(UUID.fromString("39ee07c2-1607-42af-a2e8-af6215505ad9"))
-        schedule.deadlineDate.toString().shouldBe("2025-07-24")
+        schedule.deadlineDate!!.toString().shouldBe("2025-07-24")
         schedule.status.shouldBe(PlanReviewScheduleStatus.SCHEDULED)
         schedule.createdBy.shouldBe("SMCALLISTER_GEN")
         schedule.createdByDisplayName.shouldBe("Stephen Mcallister")


### PR DESCRIPTION
In certain circumstances the review deadline date can be null. This is the case where someone has an old Education support plan but for whatever reason the need that the person had at the time has gone away. 

For example the person was in education and had a cataract which meant they had a visual support need.  The ELSP was created for the person. At some point in the future the cataract was removed and so the plan was updated removing this need education ends for this person. Then the person is enrolled in education once again. After enrolling a new need is identified (say) ADHD then the plan will have a review schedule generated but because the person had already started education the deadline date will be blank and therefore the review is optional and not subject to the KPI requirements. 