### PR TITLE
HIA-842: Setting JVM args in build.gradle for int tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ parameters:
   releases-slack-channel:
     type: string
     default: hmpps-integration-api-alerts
+  java-options:
+    type: string
+    default: -Xmx2g -XX:MaxMetaspaceSize=1g -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process -Dorg.gradle.workers.max=1
 
 slack-fail-post-step: &slack-fail-post-step
   post-steps:
@@ -84,6 +87,7 @@ jobs:
     executor:
       name: hmpps/java
       tag: "21.0"
+      java_options: << pipeline.parameters.java-options >>
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,10 @@ tasks {
   }
 }
 
+kotlin {
+  kotlinDaemonJvmArgs = listOf("-Xmx2g")
+}
+
 testlogger {
   theme = com.adarshr.gradle.testlogger.theme.ThemeType.MOCHA
 }


### PR DESCRIPTION
Increasing the jvm memory to 2 gig for running the integration tests.
Also needed to change the java options for the circle CI executer to handle the memory increase. Taken from other projects that have had the same issue. e.g hmpps-education-and-work-plan-api