### PR TITLE
MAP-2341 Add CaseNotes filter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesController.kt
@@ -61,7 +61,7 @@ class CaseNotesController(
     @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
     @RequestAttribute filters: ConsumerFilters?,
   ): PaginatedResponse<CaseNote> {
-    val response = getCaseNoteForPersonService.execute(CaseNoteFilter(hmppsId, startDate, endDate, page, perPage), filters)
+    val response = getCaseNoteForPersonService.execute(CaseNoteFilter(hmppsId, startDate, endDate, filters?.caseNotes, page, perPage), filters)
 
     if (response.hasError(UpstreamApiError.Type.BAD_REQUEST)) {
       throw ValidationException("Invalid id: $hmppsId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesController.kt
@@ -38,7 +38,7 @@ class CaseNotesController(
   @GetMapping("{hmppsId}/case-notes")
   @Operation(
     summary = "Returns case notes associated with a person.",
-    description = "<b>Applicable filters</b>: <ul><li>prisons</li></ul>",
+    description = "<b>Applicable filters</b>: <ul><li>prisons</li><li>caseNotes</li></ul>",
     responses = [
       ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully found case notes for a person with the provided HMPPS ID."),
       ApiResponse(responseCode = "400", content = [Content(schema = Schema(ref = "#/components/schemas/BadRequest"))]),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/ConsumerConfigConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/ConsumerConfigConverter.kt
@@ -10,5 +10,5 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 @ConfigurationPropertiesBinding
 class ConsumerConfigConverter : Converter<String, ConsumerConfig> {
   // Specifically used in the case where there is a consumer config with no fields
-  override fun convert(source: String): ConsumerConfig? = ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = emptyList())
+  override fun convert(source: String): ConsumerConfig? = ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null, caseNotes = null), roles = emptyList())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/ConsumerFilterConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/ConsumerFilterConverter.kt
@@ -8,5 +8,5 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 @Component
 @ConfigurationPropertiesBinding
 class ConsumerFilterConverter : Converter<String, ConsumerFilters> {
-  override fun convert(source: String): ConsumerFilters? = ConsumerFilters(prisons = null)
+  override fun convert(source: String): ConsumerFilters? = ConsumerFilters(prisons = null, caseNotes = null)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CaseNotesGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CaseNotesGateway.kt
@@ -24,7 +24,6 @@ class CaseNotesGateway(
   fun getCaseNotesForPerson(
     id: String,
     filter: CaseNoteFilter,
-    caseNoteTypes: List<String>? = null,
   ): Response<OCNCaseNote?> {
     val requestBody =
       CNSearchNotesRequest(
@@ -33,7 +32,7 @@ class CaseNotesGateway(
         occurredTo = filter.endDate?.let { it.toString() + "Z" },
         page = filter.page,
         size = filter.size,
-        typeSubTypes = caseNoteTypes?.map { CNTypeSubType(it) },
+        typeSubTypes = filter.caseNoteTypes?.map { CNTypeSubType(it) },
       )
 
     val result =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CaseNotesGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CaseNotesGateway.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.caseNotes.CNSearchNotesRequest
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.caseNotes.CNTypeSubType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.filters.CaseNoteFilter
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -23,6 +24,7 @@ class CaseNotesGateway(
   fun getCaseNotesForPerson(
     id: String,
     filter: CaseNoteFilter,
+    caseNoteTypes: List<String>? = null,
   ): Response<OCNCaseNote?> {
     val requestBody =
       CNSearchNotesRequest(
@@ -31,6 +33,7 @@ class CaseNotesGateway(
         occurredTo = filter.endDate?.let { it.toString() + "Z" },
         page = filter.page,
         size = filter.size,
+        typeSubTypes = caseNoteTypes?.map { CNTypeSubType(it) },
       )
 
     val result =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/caseNotes/CNSearchNotesRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/caseNotes/CNSearchNotesRequest.kt
@@ -4,6 +4,7 @@ data class CNSearchNotesRequest(
   val includeSensitive: Boolean? = true,
   val occurredFrom: String? = null,
   val occurredTo: String? = null,
+  val typeSubTypes: List<CNTypeSubType>? = null,
   val page: Int? = null,
   val size: Int? = null,
 ) {
@@ -18,12 +19,27 @@ data class CNSearchNotesRequest(
     if (occurredTo != null) {
       map["occurredTo"] = occurredTo
     }
+    if (typeSubTypes != null) {
+      map["typeSubTypes"] = typeSubTypes.map { it.toApiConformingMap() }
+    }
     if (page != null) {
       map["page"] = page.toInt()
     }
     if (size != null) {
       map["size"] = size.toInt()
     }
+    return map
+  }
+}
+
+data class CNTypeSubType(
+  val type: String,
+  val subTypes: List<String> = emptyList(),
+) {
+  fun toApiConformingMap(): Map<String, Any> {
+    val map = mutableMapOf<String, Any>()
+    map["type"] = type
+    map["subTypes"] = subTypes
     return map
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/filters/CaseNoteFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/filters/CaseNoteFilter.kt
@@ -6,6 +6,7 @@ data class CaseNoteFilter(
   val hmppsId: String,
   val startDate: LocalDateTime? = null,
   val endDate: LocalDateTime? = null,
+  val caseNoteTypes: List<String>? = null,
   val page: Int = 1,
   val size: Int = 10,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/roleconfig/ConsumerFilters.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/roleconfig/ConsumerFilters.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig
 
 data class ConsumerFilters(
   val prisons: List<String>?,
+  val caseNotes: List<String>? = null,
 ) {
   fun matchesPrison(prisonId: String?): Boolean = matchesFilterList(prisons, prisonId)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCaseNotesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCaseNotesForPersonService.kt
@@ -26,7 +26,7 @@ class GetCaseNotesForPersonService(
 
     val nomisNumber = personResponse.data?.nomisNumber ?: return Response(data = null, errors = listOf(UpstreamApiError(UpstreamApi.PRISON_API, UpstreamApiError.Type.ENTITY_NOT_FOUND)))
 
-    val caseNotes = caseNotesGateway.getCaseNotesForPerson(id = nomisNumber, filter)
+    val caseNotes = caseNotesGateway.getCaseNotesForPerson(id = nomisNumber, filter, filters?.caseNotes)
 
     val paginatedCaseNotes = caseNotes.data?.toPaginatedCaseNotes()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCaseNotesForPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetCaseNotesForPersonService.kt
@@ -26,7 +26,7 @@ class GetCaseNotesForPersonService(
 
     val nomisNumber = personResponse.data?.nomisNumber ?: return Response(data = null, errors = listOf(UpstreamApiError(UpstreamApi.PRISON_API, UpstreamApiError.Type.ENTITY_NOT_FOUND)))
 
-    val caseNotes = caseNotesGateway.getCaseNotesForPerson(id = nomisNumber, filter, filters?.caseNotes)
+    val caseNotes = caseNotesGateway.getCaseNotesForPerson(id = nomisNumber, filter)
 
     val paginatedCaseNotes = caseNotes.data?.toPaginatedCaseNotes()
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -271,6 +271,12 @@ authorisation:
     geoamey:
       include:
       filters:
+        case-notes:
+          - "CAB"
+          - "NEG"
+          - "CVM"
+          - "INTERVENTION"
+          - "POS"
       roles:
         - "prisoner-escort-custody-service"
     zkhan:

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -134,6 +134,12 @@ authorisation:
         - "private-prison"
       include:
       filters:
+    limited-case-notes:
+      roles:
+        - "full-access"
+      filters:
+        case-notes:
+          - "CAB"
     reference-data-only-user:
       roles:
         - "reference-data-only"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -125,6 +125,12 @@ authorisation:
         - "private-prison"
       include:
       filters:
+    limited-case-notes:
+      roles:
+        - "full-access"
+      filters:
+        case-notes:
+          - "CAB"
     redacted-client:
       include:
         - "/v1/persons/[^/]*$"

--- a/src/main/resources/globals.yml
+++ b/src/main/resources/globals.yml
@@ -172,6 +172,7 @@ globals:
     prisoner-escort-custody-service:
       include:
         - "/v1/status"
+        - "/v1/persons/.*/case-notes"
     mappa:
       include:
         - "/v1/persons"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesControllerTest.kt
@@ -76,7 +76,7 @@ class CaseNotesControllerTest(
           ).createEvent("GET_CASE_NOTES", mapOf("hmppsId" to hmppsId))
         }
 
-        it("passes filters into service") {
+        it("passes prison filters into service") {
           mockMvc.performAuthorisedWithCN(path, "limited-prisons")
 
           verify(
@@ -85,6 +85,18 @@ class CaseNotesControllerTest(
           ).execute(
             caseNoteFilter,
             ConsumerFilters(prisons = listOf("XYZ")),
+          )
+        }
+
+        it("passes case notes filters into service") {
+          mockMvc.performAuthorisedWithCN(path, "limited-case-notes")
+
+          verify(
+            getCaseNotesForPersonService,
+            times(1),
+          ).execute(
+            caseNoteFilter,
+            ConsumerFilters(prisons = null, caseNotes = listOf("CAB")),
           )
         }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesControllerTest.kt
@@ -90,12 +90,13 @@ class CaseNotesControllerTest(
 
         it("passes case notes filters into service") {
           mockMvc.performAuthorisedWithCN(path, "limited-case-notes")
+          val specificCaseNoteFilter = CaseNoteFilter(hmppsId, startDate, endDate, listOf("CAB"))
 
           verify(
             getCaseNotesForPersonService,
             times(1),
           ).execute(
-            caseNoteFilter,
+            specificCaseNoteFilter,
             ConsumerFilters(prisons = null, caseNotes = listOf("CAB")),
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/caseNotes/CaseNotesGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/caseNotes/CaseNotesGatewayTest.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.caseNotes
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldExist
@@ -21,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGatewa
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.caseNotes.CNSearchNotesRequest
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.caseNotes.CNTypeSubType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.filters.CaseNoteFilter
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
@@ -134,6 +139,42 @@ class CaseNotesGatewayTest(
           .count()
           .shouldBe(1)
         response.data!!.content.shouldExist { it.caseNoteId == id }
+      }
+
+      it("requests specific caseNote types") {
+        val caseNoteRequest = CNSearchNotesRequest(page = 1, size = 10, typeSubTypes = listOf(CNTypeSubType("KA"), CNTypeSubType("CAB")))
+        val jsonRequest = objectMapper.writeValueAsString(caseNoteRequest.toApiConformingMap())
+        caseNotesApiMockServer.stubForPost(pathNoParams, jsonRequest, responseJson, HttpStatus.OK)
+
+        val response = caseNotesGateway.getCaseNotesForPerson(id = id, caseNoteFilter, listOf("KA", "CAB"))
+        response.data
+          ?.content!!
+          .count()
+          .shouldBe(1)
+        response.data!!.content.shouldExist { it.caseNoteId == id }
+
+        caseNotesApiMockServer.verify(
+          postRequestedFor(urlEqualTo(pathNoParams))
+            .withRequestBody(
+              equalToJson(
+                """
+                {
+                  "includeSensitive" : true,
+                  "typeSubTypes" : [ {
+                    "type" : "KA",
+                    "subTypes" : []
+                  },
+                  {
+                    "type" : "CAB",
+                    "subTypes" : []
+                  }],
+                  "page" : 1,
+                  "size" : 10
+                }
+                """.trimIndent(),
+              ),
+            ).withHeader("Content-Type", equalTo("application/json")),
+        )
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/caseNotes/CaseNotesGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/caseNotes/CaseNotesGatewayTest.kt
@@ -145,8 +145,8 @@ class CaseNotesGatewayTest(
         val caseNoteRequest = CNSearchNotesRequest(page = 1, size = 10, typeSubTypes = listOf(CNTypeSubType("KA"), CNTypeSubType("CAB")))
         val jsonRequest = objectMapper.writeValueAsString(caseNoteRequest.toApiConformingMap())
         caseNotesApiMockServer.stubForPost(pathNoParams, jsonRequest, responseJson, HttpStatus.OK)
-
-        val response = caseNotesGateway.getCaseNotesForPerson(id = id, caseNoteFilter, listOf("KA", "CAB"))
+        val specificTypeCaseNoteFilter = CaseNoteFilter(hmppsId = id, caseNoteTypes = listOf("KA", "CAB"))
+        val response = caseNotesGateway.getCaseNotesForPerson(id = id, specificTypeCaseNoteFilter)
         response.data
           ?.content!!
           .count()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
@@ -39,6 +39,7 @@ abstract class IntegrationTestBase {
   final val crn = "AB123123"
   final val specificPrisonCn = "specific-prison"
   final val limitedPrisonsCn = "limited-prisons"
+  final val limitedCaseNotesCn = "limited-case-notes"
   final val noPrisonsCn = "no-prisons"
   final val emptyPrisonsCn = "empty-prisons"
   final val contactId = 123456L

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/CaseNotesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/CaseNotesIntegrationTest.kt
@@ -43,4 +43,11 @@ class CaseNotesIntegrationTest : IntegrationTestBase() {
     callApiWithCN(path, limitedPrisonsCn)
       .andExpect(status().isNotFound)
   }
+
+  @Test
+  fun `returns specific case note types for a person`() {
+    callApiWithCN(path, limitedCaseNotesCn)
+      .andExpect(status().isOk)
+      .andExpect(content().json(getExpectedResponse("person-case-notes")))
+  }
 }


### PR DESCRIPTION
 To restrict access to defined top-level Case Notes types

Also provides geoamey client in dev access to Case Notes endpoint with limited types 