### PR TITLE
[ESWE-1420] HIA-875 Fix Get Person API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -117,7 +117,7 @@ class PersonController(
     return response.data.paginateWith(page, perPage)
   }
 
-  @GetMapping("{encodedHmppsId}")
+  @GetMapping("{hmppsId}")
   @Operation(
     summary = "Returns a person.",
     responses = [
@@ -128,8 +128,8 @@ class PersonController(
     ],
   )
   fun getPerson(
-    @Parameter(description = "A URL-encoded HMPPS identifier", example = "2008%2F0545166T") @PathVariable encodedHmppsId: String,
-    @RequestAttribute clientName: String,
+    @Parameter(description = "A HMPPS identifier", example = "X00001") @PathVariable("hmppsId") encodedHmppsId: String,
+    @RequestAttribute clientName: String?,
   ): ResponseEntity<DataResponse<OffenderSearchResponse>> {
     val hmppsId = encodedHmppsId.decodeUrlCharacters()
     val response = getPersonService.getCombinedDataForPerson(hmppsId)
@@ -148,7 +148,7 @@ class PersonController(
         ResponseEntity
           .status(HttpStatus.SEE_OTHER)
           .header("Location", response.data.redirectUrl)
-          .body(DataResponse(response.data))
+          .build()
       }
       is OffenderSearchResult -> {
         val redactedData =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Person.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Person.kt
@@ -24,7 +24,7 @@ open class Person(
   val identifiers: Identifiers = Identifiers(),
   @Schema(description = "An identifier from the Police National Computer (PNC)")
   val pncId: String? = null,
-  @Schema(description = "HMPPS identifier", example = "2008/0545166T")
+  @Schema(description = "HMPPS identifier", example = "X00001")
   val hmppsId: String? = null,
   val contactDetails: ContactDetailsWithEmailAndPhone? = null,
   val currentRestriction: Boolean? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -362,8 +362,7 @@ internal class PersonControllerTest(
                      "currentExclusion": true,
                      "exclusionMessage": "An exclusion exists"
                   }
-               },
-               "errors":[]
+               }
             }
             """.removeWhitespaceAndNewlines(),
           )
@@ -421,8 +420,7 @@ internal class PersonControllerTest(
                         "currentExclusion": true,
                         "exclusionMessage": "An exclusion exists"
                     }
-                },
-                "errors":[]
+                }
             }
             """.asResponseTrimmed()
 
@@ -452,8 +450,7 @@ internal class PersonControllerTest(
                         "exclusionMessage": "**REDACTED**"
                     },
                     "probationOffenderSearch": null
-                },
-                "errors":[]
+                }
             }
             """.asResponseTrimmed()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PersonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PersonIntegrationTest.kt
@@ -118,7 +118,6 @@ class PersonIntegrationTest : IntegrationTestBase() {
         callApi("$basePath/$nomsId")
           .andExpect(status().is3xxRedirection)
           .andExpect(header().string("Location", Matchers.containsString("/v1/persons/A1234AA")))
-          .andExpect(content().json(getExpectedResponse("person-offender-and-probation-search-redirect-response")))
 
         // Need to look into the validation.request.body.schema.processingError causing issues on this test and associated DeactivateLocationIntegrationTest
         // prisonerOffenderSearchApiMockServer.assertValidationPassed()

--- a/src/test/resources/expected-responses/person-offender-and-probation-search-redirect-response
+++ b/src/test/resources/expected-responses/person-offender-and-probation-search-redirect-response
@@ -1,6 +1,0 @@
-{
-  "data": {
-    "prisonerNumber": "A1234AA",
-    "removedPrisonerNumber": "G2996UX"
-  }
-}


### PR DESCRIPTION
Changes

1. Fix `200` response
    - restore response model (OpenAPI spec)
    - remove `errors` (at runtime)
3. Rename request (path) parameter `hmppsId` (was `encoodedHmppsId`, OpenAPI spec)
5. Revise `303` response
    - remove body (at runtime)