### PR TITLE
HIA-873: Send prometheus alerts to the correct channel

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -30,7 +30,7 @@ generic-service:
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-integration-api-alerts
   sqsAlertsQueueNames:
     - "book-a-prison-visit-dev-hmpps_prison_visits_write_events_queue"
     - "book-a-prison-visit-dev-hmpps_prison_visits_write_events_dlq"


### PR DESCRIPTION
Currently the dev, preprod and prod prometheus alert channel is set to a channel that does not exist. Therefore everything is dumped in the dps-alerts channel.
This PR corrects this to send to the prometheus alerts to the dedicated channel in dev only