### PR TITLE
HIA-889 Enable pod disruption budget in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,7 +13,7 @@ generic-service:
       nginx.ingress.kubernetes.io/auth-tls-secret: "hmpps-integration-api-dev/client-certificate-auth"
 
   poddisruptionbudget:
-    enabled: false
+    enabled: true
 
   env:
     SPRING_PROFILES_ACTIVE: dev


### PR DESCRIPTION
Enable pod disruption budget (PDB) in dev.

The PDB tells the cluster to always keep a minimum number of pods available when moving pods around between nodes, etc. For example, if we have all the pods on a single node, and the cluster wants to replace that node, it would have to first move some of the pods to a different node.
