### PR TITLE
HIA-964: GHA push docker image step

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,7 +2,7 @@ name: Pipeline
 on:
   push:
     branches:
-      - 'main'
+      - 'HIA-964-gha-push-image'
   workflow_dispatch:
     inputs:
       additional_docker_tag:
@@ -29,3 +29,15 @@ jobs:
     secrets: inherit
     needs:
       - helm_lint
+  build:
+    name: Build docker image from hmpps-github-actions
+    if: github.ref == 'refs/heads/HIA-964-gha-push-image'
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
+    needs:
+      - test
+    with:
+      docker_registry: 'ghcr.io'
+      registry_org: 'ministryofjustice'
+      additional_docker_tag: ${{ inputs.additional_docker_tag }}
+      push: ${{ inputs.push || true }}
+      docker_multiplatform: false

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,7 +2,7 @@ name: Pipeline
 on:
   push:
     branches:
-      - 'HIA-964-gha-push-image'
+      - 'main'
   workflow_dispatch:
     inputs:
       additional_docker_tag:
@@ -31,7 +31,7 @@ jobs:
       - helm_lint
   build:
     name: Build docker image from hmpps-github-actions
-    if: github.ref == 'refs/heads/HIA-964-gha-push-image'
+    if: github.ref == 'main'
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2 # WORKFLOW_VERSION
     needs:
       - test


### PR DESCRIPTION
See [this Actions Run](https://github.com/ministryofjustice/hmpps-integration-api/actions/runs/18316080521/job/52157375575) for successful build and push of image to ghcr.io/ministryofjustice/hmpps-integration-api