### PR TITLE
HIA-928: Retry on webclient request exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -7,6 +7,7 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
@@ -100,19 +101,22 @@ class WebClientWrapper(
       val responseData =
         getResponseBodySpec(method, uri, headers, requestBody)
           .retrieve()
-          .onStatus({ status -> status.value() in CREATE_TRANSACTION_RETRY_HTTP_CODES }) { response -> Mono.error(ResponseException(null, response.statusCode().value())) }
-          .bodyToMono(T::class.java)
+          .onStatus({ status -> status.value() in CREATE_TRANSACTION_RETRY_HTTP_CODES }) { response ->
+            Mono.error(ResponseException(null, response.statusCode().value()))
+          }.bodyToMono(T::class.java)
           .retryWhen(
             Retry
               .backoff(MAX_RETRY_ATTEMPTS, MIN_BACKOFF_DURATION)
-              .filter { throwable -> throwable is ResponseException }
-              .onRetryExhaustedThrow { _, retrySignal -> throw ResponseException("External Service failed to process after max retries", HttpStatus.SERVICE_UNAVAILABLE.value()) },
+              .filter { throwable -> retryWhen(throwable) }
+              .onRetryExhaustedThrow { _, _ -> throw ResponseException("External Service failed to process after max retries", HttpStatus.SERVICE_UNAVAILABLE.value()) },
           ).block()!!
 
       WebClientWrapperResponse.Success(responseData)
     } catch (exception: WebClientResponseException) {
       getErrorType(exception, upstreamApi, forbiddenAsError, badRequestAsError)
     }
+
+  fun retryWhen(throwable: Throwable) = throwable is ResponseException || throwable is WebClientRequestException
 
   inline fun <reified T> requestList(
     method: HttpMethod,
@@ -159,8 +163,8 @@ class WebClientWrapper(
           .retryWhen(
             Retry
               .backoff(MAX_RETRY_ATTEMPTS, MIN_BACKOFF_DURATION)
-              .filter { throwable -> throwable is ResponseException }
-              .onRetryExhaustedThrow { _, retrySignal -> throw ResponseException("External Service failed to process after max retries", HttpStatus.SERVICE_UNAVAILABLE.value()) },
+              .filter { throwable -> retryWhen(throwable) }
+              .onRetryExhaustedThrow { _, _ -> throw ResponseException("External Service failed to process after max retries", HttpStatus.SERVICE_UNAVAILABLE.value()) },
           ).collectList()
           .block() as List<T>
 


### PR DESCRIPTION
We are getting several webclientrequest exceptions due to intermittent requests to cloudplatform.
[See sentry issue](https://ministryofjustice.sentry.io/issues/6754682540/events/a24a29f51e0741ea9e838f3040aa6d4a/)

This PR invokes the retry on these exceptions
