### PR TITLE
HIA-928: Set a read time out on webclient

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import io.netty.channel.ChannelOption
+import io.netty.handler.timeout.ReadTimeoutHandler
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
@@ -16,12 +17,14 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 
 @Suppress("ktlint:standard:property-naming")
 class WebClientWrapper(
   val baseUrl: String,
   connectTimeoutMillis: Int = 10_000,
   responseTimeoutSeconds: Long = 15,
+  readTimeoutSeconds: Long = 5,
 ) {
   val CREATE_TRANSACTION_RETRY_HTTP_CODES = listOf(502, 503, 504, 522, 599, 499, 408)
   val MAX_RETRY_ATTEMPTS = 3L
@@ -30,6 +33,7 @@ class WebClientWrapper(
   val httpClient =
     HttpClient
       .create()
+      .doOnConnected { connection -> connection.addHandlerFirst(ReadTimeoutHandler(readTimeoutSeconds, TimeUnit.SECONDS)) }
       .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis)
       .responseTimeout(Duration.ofSeconds(responseTimeoutSeconds))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -63,8 +63,9 @@ class WebClientWrapperTest :
       webClient =
         WebClientWrapper(
           baseUrl = mockServer.baseUrl(),
-          connectTimeoutMillis = 500,
+          connectTimeoutMillis = 300000,
           responseTimeoutSeconds = 1,
+          readTimeoutSeconds = 1,
         )
       wrapper = spy(webClient)
       whenever(wrapper.MIN_BACKOFF_DURATION).thenReturn(Duration.ofSeconds(0L))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapperTest.kt
@@ -63,7 +63,7 @@ class WebClientWrapperTest :
       webClient =
         WebClientWrapper(
           baseUrl = mockServer.baseUrl(),
-          connectTimeoutMillis = 300000,
+          connectTimeoutMillis = 500,
           responseTimeoutSeconds = 1,
           readTimeoutSeconds = 1,
         )


### PR DESCRIPTION
The readtime out is not set and seems to be defaulting to 1 second.
The existing readtime out test in WebClientWrapperTest sets a fixed delay of 2 seconds which causes a ReadTimeout exception, but this is never configured anywhere.

This leads me to believe that the [exceptions](https://ministryofjustice.sentry.io/issues/6910794415/?project=4505210060931072&query=is%3Aunresolved&referrer=issue-stream) that state ReadTimeoutExceptions are caused by this. 

This PR increases the readtimeout exception to 5 seconds to see if this solves this issue