### PR TITLE
HIA-1120 Non-static access to defined roles by Auth Filter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/AuthorisationConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/AuthorisationConfig.kt
@@ -20,6 +20,7 @@ import kotlin.collections.map
 class AuthorisationConfig {
   var consumers: Map<String, ConsumerConfig?> = emptyMap()
   var certificateRevocationList: List<String> = emptyList()
+  var definedRoles = roles
 
   /**
    * Returns true if the consumer has access to the endpoint.
@@ -46,7 +47,7 @@ class AuthorisationConfig {
     val merged = mutableSetOf<String>()
     merged.addAll(consumers[consumerName]?.permissions().orEmpty())
     for (roleName in consumers[consumerName]?.roles ?: emptyList()) {
-      merged.addAll(roles[roleName]?.permissions.orEmpty())
+      merged.addAll(definedRoles[roleName]?.permissions.orEmpty())
     }
     return merged.toList().sorted()
   }
@@ -93,7 +94,7 @@ class AuthorisationConfig {
     val consumerConfig: ConsumerConfig? = consumers[consumerName]
     val roles: List<Role>? =
       consumerConfig?.roles?.mapNotNull {
-        uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.roles[it]
+        definedRoles[it]
       }
     return allFilters(consumerConfig, roles)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -185,8 +185,6 @@ internal class PersonControllerTest(
         }
 
         it("passes supervision status filters from consumer config to service") {
-//          mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
-//          every { roles[any()] } returns role("test-role") { permissions { -fullAccess.permissions!! } }
           authorisationConfig.definedRoles = mapOf("test-role" to role("test-role") { permissions { -fullAccess.permissions!! } })
           mockMvc.performAuthorised("$basePath?first_name=$firstName&pnc_number=$pncNumber")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -5,8 +5,6 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
-import io.mockk.every
-import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
@@ -21,6 +19,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.WebMvcTestConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
@@ -84,6 +83,7 @@ internal class PersonControllerTest(
   @MockitoBean val getLanguagesForPersonService: GetLanguagesForPersonService,
   @MockitoBean val getPrisonerEducationService: GetPrisonerEducationService,
   @MockitoBean val featureFlagConfig: FeatureFlagConfig,
+  @Autowired val authorisationConfig: AuthorisationConfig,
 ) : DescribeSpec(
     {
       val mockMvc = IntegrationAPIMockMvc(springMockMvc)
@@ -171,28 +171,33 @@ internal class PersonControllerTest(
         }
 
         it("calls attribute search when prisons filter is present and pnc number in search") {
-          mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
-          every { roles[any()] } returns testRoleWithPrisonFilters
+          authorisationConfig.definedRoles = mapOf("full-access" to testRoleWithPrisonFilters)
           mockMvc.performAuthorised("$basePath?first_name=$firstName&pnc_number=$pncNumber")
           verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, pncNumber, null, consumerFilters = testRoleWithPrisonFilters.filters)
+          authorisationConfig.definedRoles = roles
         }
 
         it("calls attribute search when prisons filter is present and pnc number in search") {
-          mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
-          every { roles[any()] } returns testRoleWithPrisonFilters
+          authorisationConfig.definedRoles = mapOf("full-access" to testRoleWithPrisonFilters)
           mockMvc.performAuthorised("$basePath?first_name=$firstName&pnc_number=$pncNumber")
           verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, pncNumber, null, consumerFilters = testRoleWithPrisonFilters.filters)
+          authorisationConfig.definedRoles = roles
         }
 
         it("passes supervision status filters from consumer config to service") {
-          mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
-          every { roles[any()] } returns role("test-role") { permissions { -fullAccess.permissions!! } }
+//          mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
+//          every { roles[any()] } returns role("test-role") { permissions { -fullAccess.permissions!! } }
+          authorisationConfig.definedRoles = mapOf("test-role" to role("test-role") { permissions { -fullAccess.permissions!! } })
+          mockMvc.performAuthorised("$basePath?first_name=$firstName&pnc_number=$pncNumber")
+
           val expectedFilters = ConsumerFilters(supervisionStatuses = listOf("PRISONS"))
           whenever(getPersonsService.personAttributeSearch(firstName, null, pncNumber, null, false, expectedFilters)).thenReturn(Response(data = emptyList()))
 
           mockMvc.performAuthorisedWithCN("$basePath?first_name=$firstName&pnc_number=$pncNumber", "supervision-status-prison-only")
 
           verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, pncNumber, null, false, expectedFilters)
+
+          authorisationConfig.definedRoles = roles
         }
 
         it("gets a person with matching search criteria") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/FiltersExtractionFilterTest.kt
@@ -1,12 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -17,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.roles
 
 class FiltersExtractionFilterTest {
   private var authorisationConfig: AuthorisationConfig = AuthorisationConfig()
@@ -28,12 +23,9 @@ class FiltersExtractionFilterTest {
 
   @BeforeEach
   fun setUp() {
-    mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
-  }
-
-  @AfterEach
-  fun after() {
-    unmockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
+    val testRole = Role(permissions = null, filters = ConsumerFilters(prisons = listOf("filter-1", "filter-2")))
+    authorisationConfig.definedRoles =
+      listOf(testRole).associateBy { it.name }
   }
 
   @Test
@@ -66,7 +58,7 @@ class FiltersExtractionFilterTest {
     val expectedFilters = ConsumerFilters(prisons = listOf("filter-1", "filter-2"))
     val testRole = Role(permissions = null, filters = expectedFilters)
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = null), roles = listOf("test-role")))
-    every { roles } returns mapOf("test-role" to testRole)
+    authorisationConfig.definedRoles = mapOf("test-role" to testRole)
 
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -87,7 +79,7 @@ class FiltersExtractionFilterTest {
     val expectedFilters = ConsumerFilters(prisons = listOf("filter-1", "filter-2"))
     val testRole = Role(permissions = null, filters = expectedFilters)
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = null), roles = listOf("test-role")))
-    every { roles } returns mapOf("test-role" to testRole)
+    authorisationConfig.definedRoles = mapOf("test-role" to testRole)
 
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -108,7 +100,7 @@ class FiltersExtractionFilterTest {
     val expectedFilters = ConsumerFilters(prisons = listOf("consumer-filter", "role-filter"))
     val testRole = Role(permissions = null, filters = ConsumerFilters(prisons = listOf("role-filter")))
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = listOf("consumer-filter")), roles = listOf("test-role")))
-    every { roles } returns mapOf("test-role" to testRole)
+    authorisationConfig.definedRoles = mapOf("test-role" to testRole)
 
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -147,8 +139,8 @@ class FiltersExtractionFilterTest {
 
     val expectedFilters = ConsumerFilters(prisons = null, caseNotes = listOf("filter-1", "filter-2"))
     val testRole = Role(permissions = null, filters = expectedFilters)
+    authorisationConfig.definedRoles = mapOf("test-role" to testRole)
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = null), roles = listOf("test-role")))
-    every { roles } returns mapOf("test-role" to testRole)
 
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -169,7 +161,7 @@ class FiltersExtractionFilterTest {
     val expectedFilters = ConsumerFilters(prisons = null, caseNotes = listOf("consumer-filter", "role-filter"))
     val testRole = Role(permissions = null, filters = ConsumerFilters(prisons = null, caseNotes = listOf("role-filter")))
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = null, caseNotes = listOf("consumer-filter")), roles = listOf("test-role")))
-    every { roles } returns mapOf("test-role" to testRole)
+    authorisationConfig.definedRoles = mapOf("test-role" to testRole)
 
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -190,7 +182,7 @@ class FiltersExtractionFilterTest {
     val expectedFilters = ConsumerFilters(prisons = listOf("consumer-filter", "role-filter"), caseNotes = listOf("consumer-filter", "role-filter"))
     val testRole = Role(permissions = null, filters = ConsumerFilters(prisons = listOf("role-filter"), caseNotes = listOf("role-filter")))
     authorisationConfig.consumers = mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = listOf("consumer-filter"), caseNotes = listOf("consumer-filter")), roles = listOf("test-role")))
-    every { roles } returns mapOf("test-role" to testRole)
+    authorisationConfig.definedRoles = mapOf("test-role" to testRole)
 
     // Act
     filtersExtractionFilter.doFilter(mockRequest, mockResponse, mockChain)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.roles
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.fullAccess
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.testRoleWithLaoRedactions
@@ -59,7 +60,8 @@ class AlertsIntegrationTest : IntegrationTestBase() {
 
     @Test
     fun `returns alerts for a person with alert filters`() {
-      authorisationConfig.definedRoles = mapOf("automated-test-client" to testRoleWithPndAlerts)
+      authorisationConfig.definedRoles = listOf(testRoleWithPndAlerts).associateBy { it.name }
+      authorisationConfig.consumers = mapOf("automated-test-client" to ConsumerConfig(roles = listOf(testRoleWithPndAlerts.name!!)))
       callApi(path)
         .andExpect(status().isOk)
         .andExpect(content().json(getExpectedResponse("person-alerts")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/AlertsIntegrationTest.kt
@@ -28,13 +28,15 @@ class AlertsIntegrationTest : IntegrationTestBase() {
 
     @BeforeEach
     fun setup() {
-      mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
-      every { roles.get(any()) } returns fullAccess
+//      mockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
+//      every { roles.get(any()) } returns fullAccess
+//      authorisationConfig.definedRoles = mapOf("automated-test-client" to fullAccess)
     }
 
     @AfterEach
     fun tearDown() {
-      unmockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
+//      unmockkStatic("uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.RoleKt")
+      authorisationConfig.definedRoles = roles
     }
 
     @Test
@@ -57,7 +59,7 @@ class AlertsIntegrationTest : IntegrationTestBase() {
 
     @Test
     fun `returns alerts for a person with alert filters`() {
-      every { roles.get(any()) } returns testRoleWithPndAlerts
+      authorisationConfig.definedRoles = mapOf("automated-test-client" to testRoleWithPndAlerts)
       callApi(path)
         .andExpect(status().isOk)
         .andExpect(content().json(getExpectedResponse("person-alerts")))


### PR DESCRIPTION
The `AuthorisationFilter` made direct use of the static `roles` list when matching consumers to roles which made it more difficult to test alternative role definitions. In order to minimise the need for static mocking, this PR switches to a non-static copy of the defined roles map.