### PR TITLE
HIA-1330: Upgrade to spring boot 4 retaining jackson 2 settings

### DIFF
--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -1,8 +1,5 @@
 name: Security OWASP dependency check
 on:
-  push:
-    branches:
-      - 'HIA-1330-spring-boot4-upgrade-retain-jackson2-config'
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * MON-FRI" # Every weekday at 05:00 UTC

--- a/.github/workflows/security_owasp.yml
+++ b/.github/workflows/security_owasp.yml
@@ -1,5 +1,8 @@
 name: Security OWASP dependency check
 on:
+  push:
+    branches:
+      - 'HIA-1330-spring-boot4-upgrade-retain-jackson2-config'
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * MON-FRI" # Every weekday at 05:00 UTC

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.3.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.1.2"
   kotlin("plugin.spring") version "2.3.20"
   id("dev.detekt") version "2.0.0-alpha.2"
   id("org.jetbrains.kotlinx.kover") version "0.9.8"
@@ -22,39 +22,6 @@ configurations {
   }
 }
 
-configurations.all {
-  resolutionStrategy.eachDependency {
-    if (requested.group == "org.apache.logging.log4j") {
-      useVersion("2.25.3")
-      because("Fix CVE-2025-68161")
-    }
-    if (requested.group == "ch.qos.logback") {
-      useVersion("1.5.25")
-      because("Fix CVE-2026-1225")
-    }
-    if (requested.group == "org.apache.tomcat.embed") {
-      useVersion("10.1.52")
-      because("Fix CVE-2026-1225")
-    }
-    if (requested.group == "org.springframework") {
-      useVersion("6.2.17")
-      because("Fix CVE-2026-22737")
-    }
-    if (requested.group == "org.springframework.boot") {
-      useVersion("3.5.12")
-      because("Fix CVE-2026-22733")
-    }
-    if (requested.group == "org.webjars" && requested.name == "swagger-ui") {
-      useVersion("5.32.1")
-      because("Fix CVE-2026-0540")
-    }
-    if (requested.group == "io.netty") {
-      useVersion("4.1.132.Final")
-      because("Fix VE-2026-33870")
-    }
-  }
-}
-
 dependencies {
   runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
   runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
@@ -64,13 +31,15 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-jdbc")
+  runtimeOnly("org.springframework.boot:spring-boot-starter-flyway")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
   implementation("io.sentry:sentry-spring-boot-starter-jakarta:8.38.0")
   implementation("io.sentry:sentry-logback:8.38.0")
   implementation("org.springframework.data:spring-data-commons")
   implementation("org.springframework:spring-aop")
   implementation("org.aspectj:aspectjweaver")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.6.3") {
+  implementation("tools.jackson.module:jackson-module-kotlin:3.0.3")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.0") {
     exclude("org.springframework.security", "spring-security-config")
     exclude("org.springframework.security", "spring-security-core")
     exclude("org.springframework.security", "spring-security-crypto")
@@ -83,6 +52,8 @@ dependencies {
   implementation("com.jayway.jsonpath:json-path:2.10.0")
   implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
 
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
+  testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
   testImplementation("io.kotest:kotest-assertions-json-jvm:6.1.11")
   testImplementation("io.kotest:kotest-runner-junit5-jvm:6.1.11")
   testImplementation("io.kotest:kotest-assertions-core-jvm:6.1.11")
@@ -90,7 +61,6 @@ dependencies {
   add("koverCli", "org.jetbrains.kotlinx:kover-cli:0.9.8")
   testImplementation("org.wiremock:wiremock-standalone:3.13.2")
   testImplementation("org.mockito:mockito-core:5.23.0")
-  testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.21.2")
   testImplementation("org.awaitility:awaitility-kotlin:4.3.0")
   testImplementation("com.atlassian.oai:swagger-request-validator-wiremock:2.46.1") {
     // Exclude WireMock artifacts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/HmppsIntegrationApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/HmppsIntegrationApi.kt
@@ -3,11 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
-import org.springframework.cache.annotation.EnableCaching
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 
 @SpringBootApplication
-@EnableCaching
 @EnableConfigurationProperties(FeatureFlagConfig::class)
 class HmppsIntegrationApi
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/TomcatConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/TomcatConfig.kt
@@ -2,8 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.config
 
 import org.apache.catalina.connector.Connector
 import org.apache.tomcat.util.buf.EncodedSolidusHandling
-import org.springframework.boot.web.embedded.tomcat.TomcatConnectorCustomizer
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory
 import org.springframework.boot.web.server.WebServerFactoryCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -14,7 +13,7 @@ class TomcatConfig {
   fun tomcatCustomizer(): WebServerFactoryCustomizer<TomcatServletWebServerFactory> =
     WebServerFactoryCustomizer { factory: TomcatServletWebServerFactory ->
       factory.addConnectorCustomizers(
-        TomcatConnectorCustomizer { connector: Connector ->
+        { connector: Connector ->
           connector.encodedSolidusHandling = EncodedSolidusHandling.PASS_THROUGH.value
         },
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/WebClientWrapper.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.netty.channel.ChannelOption
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.http.codec.json.JacksonJsonDecoder
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.ExchangeStrategies
@@ -13,6 +15,9 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
 import reactor.util.retry.Retry
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -35,20 +40,34 @@ class WebClientWrapper(
       .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis)
       .responseTimeout(Duration.ofSeconds(responseTimeoutSeconds))
 
+  val mapper: JsonMapper =
+    JsonMapper
+      .builder()
+      .configureForJackson2()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+      .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+      .changeDefaultPropertyInclusion { it.withContentInclusion(JsonInclude.Include.NON_NULL) }
+      .addModule(KotlinModule.Builder().build())
+      .build()
+
+  val strategies =
+    ExchangeStrategies
+      .builder()
+      .codecs { configurer ->
+        configurer
+          .defaultCodecs()
+          .jacksonJsonDecoder(JacksonJsonDecoder(mapper))
+        configurer.defaultCodecs().maxInMemorySize(-1)
+      }.build()
+
   val client: WebClient =
     WebClient
       .builder()
       .baseUrl(baseUrl)
       .clientConnector(ReactorClientHttpConnector(httpClient))
-      .exchangeStrategies(
-        ExchangeStrategies
-          .builder()
-          .codecs { configurer ->
-            configurer
-              .defaultCodecs()
-              .maxInMemorySize(-1)
-          }.build(),
-      ).build()
+      .exchangeStrategies(strategies)
+      .build()
 
   sealed class WebClientWrapperResponse<out T> {
     data class Success<T>(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/health/ExternalHealthIndicator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/health/ExternalHealthIndicator.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.health
 
 import org.slf4j.LoggerFactory
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/health/HealthInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/health/HealthInfo.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.health
 
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.info.BuildProperties
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/InductionSchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/InductionSchedule.kt
@@ -2,12 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.annotation.JsonDeserialize
 import java.time.Instant
 import java.time.LocalDate
 
@@ -160,26 +160,26 @@ data class InductionSchedule(
   val version: Int? = null,
 )
 
-class InductionScheduleDeserializer : JsonDeserializer<InductionSchedule>() {
+class InductionScheduleDeserializer : ValueDeserializer<InductionSchedule>() {
   override fun deserialize(
     parser: JsonParser,
     ctxt: DeserializationContext,
   ): InductionSchedule {
-    val node = parser.codec.readTree<JsonNode>(parser)
-    val nomisNumber = node["prisonNumber"]?.asText()
-    val deadlineDate = node["deadlineDate"]?.asText()?.let { LocalDate.parse(it) }
-    val scheduleStatus = node["scheduleStatus"]?.asText()
-    val scheduleCalculationRule = node["scheduleCalculationRule"]?.asText()
-    val systemUpdatedBy = node["updatedByDisplayName"]?.asText()
-    val systemUpdatedAt = node["updatedAt"]?.asText()?.let { Instant.parse(it) }
-    val systemUpdatedAtPrison = node["updatedAtPrison"]?.asText()
-    val systemCreatedBy = node["createdByDisplayName"]?.asText()
-    val systemCreatedAt = node["createdAt"]?.asText()?.let { Instant.parse(it) }
-    val systemCreatedAtPrison = node["createdAtPrison"]?.asText()
-    val inductionPerformedBy = node["inductionPerformedBy"]?.takeUnless { it.isNull }?.asText()
-    val inductionPerformedAt = node["inductionPerformedAt"]?.takeUnless { it.isNull }?.asText()?.let { LocalDate.parse(it) }
-    val inductionPerformedByRole = node["inductionPerformedByRole"]?.takeUnless { it.isNull }?.asText()
-    val inductionPerformedAtPrison = node["inductionPerformedAtPrison"]?.takeUnless { it.isNull }?.asText()
+    val node = parser.objectReadContext().readTree<JsonNode>(parser)
+    val nomisNumber = node["prisonNumber"]?.asString()
+    val deadlineDate = node["deadlineDate"]?.asString()?.let { LocalDate.parse(it) }
+    val scheduleStatus = node["scheduleStatus"]?.asString()
+    val scheduleCalculationRule = node["scheduleCalculationRule"]?.asString()
+    val systemUpdatedBy = node["updatedByDisplayName"]?.asString()
+    val systemUpdatedAt = node["updatedAt"]?.asString()?.let { Instant.parse(it) }
+    val systemUpdatedAtPrison = node["updatedAtPrison"]?.asString()
+    val systemCreatedBy = node["createdByDisplayName"]?.asString()
+    val systemCreatedAt = node["createdAt"]?.asString()?.let { Instant.parse(it) }
+    val systemCreatedAtPrison = node["createdAtPrison"]?.asString()
+    val inductionPerformedBy = node["inductionPerformedBy"]?.takeUnless { it.isNull }?.asString()
+    val inductionPerformedAt = node["inductionPerformedAt"]?.takeUnless { it.isNull }?.asString()?.let { LocalDate.parse(it) }
+    val inductionPerformedByRole = node["inductionPerformedByRole"]?.takeUnless { it.isNull }?.asString()
+    val inductionPerformedAtPrison = node["inductionPerformedAtPrison"]?.takeUnless { it.isNull }?.asString()
     val version = node["version"]?.asInt()
     val exemptionReason = node["exemptionReason"]?.takeUnless { it.isNull }?.asText()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PlanCreationSchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PlanCreationSchedule.kt
@@ -2,12 +2,12 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.annotation.JsonDeserialize
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -69,35 +69,35 @@ data class PlanCreationSchedule(
   val version: Int? = null,
 )
 
-class PlanCreationScheduleDeserializer : JsonDeserializer<PlanCreationSchedule>() {
+class PlanCreationScheduleDeserializer : ValueDeserializer<PlanCreationSchedule>() {
   override fun deserialize(
     parser: JsonParser,
     ctxt: DeserializationContext,
   ): PlanCreationSchedule {
-    val node = parser.codec.readTree<JsonNode>(parser)
+    val node = parser.objectReadContext().readTree<JsonNode>(parser)
 
     return PlanCreationSchedule(
-      reference = UUID.fromString(node["reference"].asText()),
-      status = PlanCreationStatus.valueOf(node["status"].asText()),
-      createdBy = node["createdBy"].asText(),
-      createdByDisplayName = node["createdByDisplayName"].asText(),
-      createdAt = OffsetDateTime.parse(node["createdAt"].asText()),
-      createdAtPrison = node["createdAtPrison"].asText(),
-      updatedBy = node["updatedBy"].asText(),
-      updatedByDisplayName = node["updatedByDisplayName"].asText(),
-      updatedAt = OffsetDateTime.parse(node["updatedAt"].asText()),
-      updatedAtPrison = node["updatedAtPrison"].asText(),
-      deadlineDate = node["deadlineDate"]?.takeUnless { it.isNull }?.asText()?.let { LocalDate.parse(it) },
-      exemptionReason = node["exemptionReason"]?.takeUnless { it.isNull }?.asText(),
-      exemptionDetail = node["exemptionDetail"]?.takeUnless { it.isNull }?.asText(),
+      reference = UUID.fromString(node["reference"].asString()),
+      status = PlanCreationStatus.valueOf(node["status"].asString()),
+      createdBy = node["createdBy"].asString(),
+      createdByDisplayName = node["createdByDisplayName"].asString(),
+      createdAt = OffsetDateTime.parse(node["createdAt"].asString()),
+      createdAtPrison = node["createdAtPrison"].asString(),
+      updatedBy = node["updatedBy"].asString(),
+      updatedByDisplayName = node["updatedByDisplayName"].asString(),
+      updatedAt = OffsetDateTime.parse(node["updatedAt"].asString()),
+      updatedAtPrison = node["updatedAtPrison"].asString(),
+      deadlineDate = node["deadlineDate"]?.takeUnless { it.isNull }?.asString()?.let { LocalDate.parse(it) },
+      exemptionReason = node["exemptionReason"]?.takeUnless { it.isNull }?.asString(),
+      exemptionDetail = node["exemptionDetail"]?.takeUnless { it.isNull }?.asString(),
       needSources =
         node["needSources"]?.takeUnless { it.isNull }?.mapNotNull { ns ->
-          ns?.asText()?.let { NeedSource.valueOf(it) }
+          ns?.asString()?.let { NeedSource.valueOf(it) }
         },
-      planKeyedInBy = node["planKeyedInBy"]?.takeUnless { it.isNull }?.asText(),
-      planCompletedDate = node["planCompletedDate"]?.takeUnless { it.isNull }?.asText()?.let { LocalDate.parse(it) },
-      planCompletedBy = node["planCompletedBy"]?.takeUnless { it.isNull }?.asText(),
-      planCompletedByJobRole = node["planCompletedByJobRole"]?.takeUnless { it.isNull }?.asText(),
+      planKeyedInBy = node["planKeyedInBy"]?.takeUnless { it.isNull }?.asString(),
+      planCompletedDate = node["planCompletedDate"]?.takeUnless { it.isNull }?.asString()?.let { LocalDate.parse(it) },
+      planCompletedBy = node["planCompletedBy"]?.takeUnless { it.isNull }?.asString(),
+      planCompletedByJobRole = node["planCompletedByJobRole"]?.takeUnless { it.isNull }?.asString(),
       version = node["version"]?.takeUnless { it.isNull }?.asInt(),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PlanReviewSchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/PlanReviewSchedule.kt
@@ -3,13 +3,13 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.annotation.JsonDeserialize
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -92,30 +92,30 @@ data class PlanReviewSchedule(
   @get:JsonProperty("version") val version: Int? = null,
 )
 
-class ReviewScheduleDeserializer : JsonDeserializer<PlanReviewSchedule>() {
+class ReviewScheduleDeserializer : ValueDeserializer<PlanReviewSchedule>() {
   override fun deserialize(
     parser: JsonParser,
     ctxt: DeserializationContext,
   ): PlanReviewSchedule {
-    val node = parser.codec.readTree<JsonNode>(parser)
+    val node = parser.objectReadContext().readTree<JsonNode>(parser)
 
     return PlanReviewSchedule(
-      reference = UUID.fromString(node["reference"].asText()),
-      status = PlanReviewScheduleStatus.valueOf(node["status"].asText()),
-      createdBy = node["createdBy"].asText(),
-      createdByDisplayName = node["createdByDisplayName"].asText(),
-      createdAt = OffsetDateTime.parse(node["createdAt"].asText()),
-      createdAtPrison = node["createdAtPrison"].asText(),
-      updatedBy = node["updatedBy"].asText(),
-      updatedByDisplayName = node["updatedByDisplayName"].asText(),
-      updatedAt = OffsetDateTime.parse(node["updatedAt"].asText()),
-      updatedAtPrison = node["updatedAtPrison"].asText(),
-      deadlineDate = node["deadlineDate"]?.takeUnless { it.isNull }?.asText()?.let { LocalDate.parse(it) },
-      exemptionReason = node["exemptionReason"]?.takeUnless { it.isNull }?.asText(),
-      reviewKeyedInBy = node["reviewKeyedInBy"]?.takeUnless { it.isNull }?.asText(),
-      reviewCompletedDate = node["reviewCompletedDate"]?.takeUnless { it.isNull }?.asText()?.let { LocalDate.parse(it) },
-      reviewCompletedBy = node["reviewCompletedBy"]?.takeUnless { it.isNull }?.asText(),
-      reviewCompletedByJobRole = node["reviewCompletedByJobRole"]?.takeUnless { it.isNull }?.asText(),
+      reference = UUID.fromString(node["reference"].asString()),
+      status = PlanReviewScheduleStatus.valueOf(node["status"].asString()),
+      createdBy = node["createdBy"].asString(),
+      createdByDisplayName = node["createdByDisplayName"].asString(),
+      createdAt = OffsetDateTime.parse(node["createdAt"].asString()),
+      createdAtPrison = node["createdAtPrison"].asString(),
+      updatedBy = node["updatedBy"].asString(),
+      updatedByDisplayName = node["updatedByDisplayName"].asString(),
+      updatedAt = OffsetDateTime.parse(node["updatedAt"].asString()),
+      updatedAtPrison = node["updatedAtPrison"].asString(),
+      deadlineDate = node["deadlineDate"]?.takeUnless { it.isNull }?.asString()?.let { LocalDate.parse(it) },
+      exemptionReason = node["exemptionReason"]?.takeUnless { it.isNull }?.asString(),
+      reviewKeyedInBy = node["reviewKeyedInBy"]?.takeUnless { it.isNull }?.asString(),
+      reviewCompletedDate = node["reviewCompletedDate"]?.takeUnless { it.isNull }?.asString()?.let { LocalDate.parse(it) },
+      reviewCompletedBy = node["reviewCompletedBy"]?.takeUnless { it.isNull }?.asString(),
+      reviewCompletedByJobRole = node["reviewCompletedByJobRole"]?.takeUnless { it.isNull }?.asString(),
       version = node["version"]?.takeUnless { it.isNull }?.asInt(),
     )
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,24 +19,6 @@ spring:
       max-in-memory-size: 10MB
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
-#    use-jackson2-defaults: true
-#    default-leniency: true
-#    deserialization:
-#      fail-on-unknown-properties: false
-#      fail-on-missing-creator-properties: false
-#      fail-on-null-creator-properties: false
-#      fail-on-null-for-primitives: false
-#      fail-on-missing-external-type-id-property: false
-#      fail-on-unresolved-object-ids: false
-#    default-property-inclusion: always
-#  jackson2:
-#    date-format: "yyyy-MM-dd HH:mm:ss"
-#    deserialization:
-#      fail-on-unknown-properties: false
-#      fail-on-missing-creator-properties: false
-#      fail-on-null-creator-properties: false
-#      fail-on-null-for-primitives: false
-#    default-property-inclusion: always
   profiles:
     group:
       test:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,6 @@ info.app:
 spring:
   application:
     name: hmpps-integration-api
-  codec:
-    max-in-memory-size: 10MB
   datasource:
     url: "jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=prefer"
     username: ${DB_USER}
@@ -16,12 +14,29 @@ spring:
     user: ${spring.datasource.username}
     password: ${spring.datasource.password}
     enabled: true
-
+  http:
+    codecs:
+      max-in-memory-size: 10MB
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"
-    serialization:
-      WRITE_DATES_AS_TIMESTAMPS: false
-
+#    use-jackson2-defaults: true
+#    default-leniency: true
+#    deserialization:
+#      fail-on-unknown-properties: false
+#      fail-on-missing-creator-properties: false
+#      fail-on-null-creator-properties: false
+#      fail-on-null-for-primitives: false
+#      fail-on-missing-external-type-id-property: false
+#      fail-on-unresolved-object-ids: false
+#    default-property-inclusion: always
+#  jackson2:
+#    date-format: "yyyy-MM-dd HH:mm:ss"
+#    deserialization:
+#      fail-on-unknown-properties: false
+#      fail-on-missing-creator-properties: false
+#      fail-on-null-creator-properties: false
+#      fail-on-null-for-primitives: false
+#    default-property-inclusion: always
   profiles:
     group:
       test:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ActivitiesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ActivitiesControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/BalancesControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsControllerTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/EPFPersonDetailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/EPFPersonDetailControllerTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/EducationCourseControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/EducationCourseControllerTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/HmppsIdControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ImageControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ImageControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/OffenderRestrictionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/OffenderRestrictionsControllerTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ReferenceDataControllerTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ReferenceDataControllerTests.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/RiskManagementControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/RiskManagementControllerTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/StatusControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/StatusControllerTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/TransactionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/TransactionsControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/VisitsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/VisitsControllerTest.kt
@@ -7,7 +7,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AdjudicationsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AdjudicationsControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AlertsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/AlertsControllerTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CaseNotesControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CellLocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/CellLocationControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/ContactEventsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/ContactEventsControllerTest.kt
@@ -7,7 +7,7 @@ import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/DynamicRisksControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/DynamicRisksControllerTest.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/EducationAssessmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/EducationAssessmentsControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/ExpressionInterestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/ExpressionInterestControllerTest.kt
@@ -7,7 +7,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/FutureVisitsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/FutureVisitsControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/HealthAndDietControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/HealthAndDietControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/InductionScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/InductionScheduleTest.kt
@@ -1,23 +1,27 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.controllers.v1.person
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.annotation.JsonInclude
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.InductionSchedule
 import java.time.Instant
 import java.time.LocalDate
 
 class InductionScheduleTest {
   private val objectMapper =
-    ObjectMapper().apply {
-      // Register the custom deserializer
-      registerModule(
-        com.fasterxml.jackson.module.kotlin.KotlinModule
-          .Builder()
-          .build(),
-      )
-    }
+    JsonMapper
+      .builder()
+      .configureForJackson2()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+      .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+      .changeDefaultPropertyInclusion { it.withContentInclusion(JsonInclude.Include.NON_NULL) }
+      .addModule(KotlinModule.Builder().build())
+      .build()
 
   @Test
   fun `should deserialize JSON into InductionSchedule object`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/LicenceConditionControllerTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/LicenceConditionControllerTests.kt
@@ -13,7 +13,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/MappaDetailControllerTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/NeedsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/NeedsControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/OffencesControllerTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -8,13 +8,14 @@ import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import net.javacrumbs.jsonunit.assertj.JsonAssertions
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
@@ -380,7 +381,8 @@ internal class PersonControllerTest(
 
         it("returns a person with the matching ID") {
           val result = mockMvc.performAuthorised("$basePath/$hmppsId")
-          result.response.contentAsString.shouldBe(
+
+          JsonAssertions.assertThatJson(result.response.contentAsString).isEqualTo(
             """
              {
                "data": {
@@ -790,7 +792,8 @@ internal class PersonControllerTest(
         it("returns a 200 OK status code with data") {
           val result = mockMvc.performAuthorised(path)
           result.response.status.shouldBe(HttpStatus.OK.value())
-          result.response.contentAsString.shouldBe(
+
+          JsonAssertions.assertThatJson(result.response.contentAsString).isEqualTo(
             """
             {
               "data":{

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonResponsibleOfficerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonResponsibleOfficerControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PrisonerBaseLocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PrisonerBaseLocationControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PrisonerContactsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PrisonerContactsControllerTest.kt
@@ -7,7 +7,7 @@ import org.mockito.internal.verification.VerificationModeFactory.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/ProtectedCharacteristicsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/ProtectedCharacteristicsControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RiskCategoriesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RiskCategoriesControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RiskPredictorScoresControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RiskPredictorScoresControllerTest.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RiskSeriousHarmControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/RiskSeriousHarmControllerTest.kt
@@ -13,7 +13,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/StatusInformationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/StatusInformationControllerTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/VisitRestrictionsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/VisitRestrictionsControllerTest.kt
@@ -7,7 +7,7 @@ import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/AddressControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/AddressControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/LatestSentenceKeyDatesAndAdjustmentsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/LatestSentenceKeyDatesAndAdjustmentsControllerTest.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/SentencesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/sentences/SentencesControllerTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/LocationControllerTest.kt
@@ -7,7 +7,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonActivitiesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonActivitiesControllerTest.kt
@@ -8,7 +8,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/prison/PrisonControllerTest.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v2/prison/ConfigControllerTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v2/prison/ConfigControllerTests.kt
@@ -11,7 +11,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/IntegrationAPIMockMvc.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/helpers/IntegrationAPIMockMvc.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/CertificateRevocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/CertificateRevocationIntegrationTest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import kotlin.test.Test
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FiltersIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FiltersIntegrationTest.kt
@@ -11,7 +11,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.FiltersExtractionFilter
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.reset
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.cache.CacheManager
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/ContactEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/ContactEventsIntegrationTest.kt
@@ -4,6 +4,8 @@ import com.jayway.jsonpath.JsonPath
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.core.io.ClassPathResource
 import org.springframework.http.HttpStatus
@@ -20,6 +22,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.NDeliusCommunityManager
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.NDeliusMappaDetail
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.NDeliusSupervisions
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.PaginatedResponse
 import java.io.File
 import java.nio.charset.Charset
@@ -36,6 +40,7 @@ class ContactEventsIntegrationTest : IntegrationTestBase() {
   fun resetMocks() {
     nDeliusMockServer.resetAll()
     whenever(featureFlagConfig.getConfigFlagValue(USE_CONTACT_EVENTS_ENDPOINT)).thenReturn(true)
+    whenever(authorisationConfig.allFilters(any(), anyList())).thenReturn(ConsumerFilters(mappaCategories = listOf(MappaCategory.CAT4)))
     prisonerOffenderSearchMockServer.stubForGet(
       "/prisoner/$nomsId",
       File(


### PR DESCRIPTION
This PR upgrades `hmpps.gradle-spring-boot` to version `10.1.2` and `hmpps-sqs-spring-boot-starter` to version `7.3.0`
These are the latest spring boot 4 packages.

The main change here apart from changing package locations is that the `WebClientWrapper` is now configured to use a Jackson 3 `JsonMapper` with Jackson 2 `objectmapper` settings to retain the current functionality