### PR TITLE
HIA-1300: Added a supervision status by hmppsId function

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/services/domain/DomainEventIdentitiesResolver.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/services/domain/DomainEventIdentitiesResolver.kt
@@ -1,18 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.services.domain
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.models.HmppsDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.services.GetPrisonIdService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.UpstreamApiException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.SupervisionStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 
 @Service
 class DomainEventIdentitiesResolver(
@@ -20,12 +15,7 @@ class DomainEventIdentitiesResolver(
   @Autowired val getPrisonIdService: GetPrisonIdService,
   private val personService: GetPersonService,
   private val featureFlagService: FeatureFlagConfig,
-  private val telemetryService: TelemetryService,
 ) {
-  companion object {
-    val log = LoggerFactory.getLogger(this::class.java)
-  }
-
   /**
    * The hmpps id is an id that the end client will use in ongoing processing.
    * In the future when we have a core person record it will be that id
@@ -90,34 +80,7 @@ class DomainEventIdentitiesResolver(
     if (!featureFlagService.isEnabled(FeatureFlagConfig.INCLUDE_SUPERVISION_STATUS_ATTRIBUTE)) {
       return null
     }
-
-    val nomisId =
-      hmppsId?.let {
-        personService.convert(it, GetPersonService.IdentifierType.NOMS).data
-      }
-
-    if (nomisId == null) {
-      log.info("Cant determine supervision status for the message with hmppsId $hmppsId because a prison id cannot be found. Returning ${SupervisionStatus.UNKNOWN.name}")
-      return SupervisionStatus.UNKNOWN.name
-    }
-
-    val supervisionStatus =
-      try {
-        personService.getPersonSupervisionStatus(nomisId)
-      } catch (ex: UpstreamApiException) {
-        when (ex.errorType) {
-          UpstreamApiError.Type.ENTITY_NOT_FOUND -> {
-            SupervisionStatus.UNKNOWN.name
-          }
-          else -> {
-            log.error("An error occurred while determining the supervision status for the message with hmppsId $hmppsId")
-            telemetryService.captureException(ex)
-            throw ex
-          }
-        }
-      }
-    log.info("Supervision status of $supervisionStatus has been found for the message with hmppsId $hmppsId")
-    return supervisionStatus
+    return personService.getSupervisionStatus(hmppsId).name
   }
 
   private fun getNomisNumber(hmppsEvent: HmppsDomainEvent): String? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonService.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.common.ConsumerPrisonAccessService
@@ -30,6 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffenders
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffendersearch.POSPrisoner
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.probationintegrationepf.LimitedAccess
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.SupervisionStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 
 @Service
@@ -41,6 +44,10 @@ class GetPersonService(
   @Autowired val telemetryService: TelemetryService,
   private val deliusGateway: NDeliusGateway,
 ) {
+  companion object {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
   fun execute(hmppsId: String): Response<Person?> {
     val probationResponse = getProbationResponse(hmppsId)
     if (identifyHmppsId(hmppsId) == IdentifierType.NOMS && probationResponse.data == null) {
@@ -269,6 +276,39 @@ class GetPersonService(
         throw FilterViolationException("SupervisionStatus filter restricts access to the requested prisoner's supervision status")
       }
     }
+  }
+
+  fun getSupervisionStatus(hmppsId: String?): SupervisionStatus {
+    // If the hmppsId is not found (or encounters an error) in NDelius (even if it is either a nomis or crn), then return UNKNOWN
+    val offender =
+      try {
+        getPersonFromDelius(hmppsId, true).data!!
+      } catch (ex: Exception) {
+        logger.info("Cant determine supervision status for the hmppsId $hmppsId because NDelius encountered the following error: ${ex.message}. Returning ${SupervisionStatus.UNKNOWN.name}")
+        return SupervisionStatus.UNKNOWN
+      }
+
+    val posPrisoner =
+      offender.identifiers.nomisNumber?.let { nomisNumber ->
+        // if there is a nomis id in delius and the call to get the nomis number from prisoner offender search is not found (or returns an error) then return UNKNOWN
+        try {
+          getPersonFromPrisonerOffenderSearch(nomisNumber)
+        } catch (ex: Exception) {
+          logger.info("Cant determine supervision status for hmppsId $hmppsId because prisoner search encountered the following error for nomis id $nomisNumber: ${ex.message}. Returning ${SupervisionStatus.UNKNOWN.name}")
+          return SupervisionStatus.UNKNOWN
+        }
+      }
+
+    val supervisionStatus =
+      if (posPrisoner != null && posPrisoner.status?.startsWith("ACTIVE") == true) {
+        SupervisionStatus.PRISONS
+      } else if (offender.underActiveSupervision) {
+        SupervisionStatus.PROBATION
+      } else {
+        SupervisionStatus.NONE
+      }
+    logger.info("Supervision status of $supervisionStatus has been found for hmppsId $hmppsId")
+    return supervisionStatus
   }
 
   fun getPersonSupervisionStatus(nomisId: String): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/listener/DomainEventMetadataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/listener/DomainEventMetadataIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.events.list
 
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
-import io.kotest.matchers.shouldBe
 import org.awaitility.Awaitility
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -126,7 +125,7 @@ class DomainEventMetadataIntegrationTest : IntegrationTestWithEventsQueueBase() 
   }
 
   @Test
-  fun `will send the event to the DLQ prisoner offender search returns a 500`() {
+  fun `will create a message containing supervision status of UNKNOWN when prisoner offender search returns a 500`() {
     // Clear cache
     prisonerOffenderSearchMockServer.stubForGet(
       "/prisoner/$nomsIdNotActiveInPrison",
@@ -140,13 +139,12 @@ class DomainEventMetadataIntegrationTest : IntegrationTestWithEventsQueueBase() 
       )
     sendDomainSqsMessage(rawMessage)
 
-    Awaitility.await().until {
-      getNumberOfMessagesCurrentlyOndomainEventsDeadLetterQueue() > 0
+    Awaitility.await().untilAsserted {
+      eventNotificationRepository.findAll().isNotEmpty()
+      val savedEvents: List<EventNotification> = eventNotificationRepository.findByHmppsIdIsIn(listOf(crnActiveInProbation))
+      savedEvents.shouldNotBeEmpty().shouldHaveSize(1)
+      assertEquals("UNKNOWN", savedEvents.first().metadata?.supervisionStatus)
     }
-
-    val deadLetterQueueMessage = geMessagesCurrentlyOnDomainEventsDeadLetterQueue()
-    val message = deadLetterQueueMessage.messages().first()
-    message.body().shouldBe(rawMessage)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -1079,7 +1079,7 @@ internal class GetPersonServiceTest(
           result.shouldBe(SupervisionStatus.PROBATION)
         }
 
-        it("HmppsId resolves to a supervision status of PROBATION") {
+        it("HmppsId resolves to a supervision status of NONE") {
           whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = Offender("Test", "Test", activeProbationManagedSentence = false, otherIds = OtherIds(crn = crnNumber, nomsNumber = nomsNumber))))
           val result = getPersonService.getSupervisionStatus(crnNumber)
           result.shouldBe(SupervisionStatus.NONE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -1071,5 +1071,61 @@ internal class GetPersonServiceTest(
           result.errors.shouldNotBeEmpty()
         }
       }
+
+      describe("get Supervision Status by hmppsId") {
+        it("HmppsId resolves to a supervision status of PROBATION") {
+          whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = Offender("Test", "Test", activeProbationManagedSentence = true, otherIds = OtherIds(crn = crnNumber, nomsNumber = nomsNumber))))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.PROBATION)
+        }
+
+        it("HmppsId resolves to a supervision status of PROBATION") {
+          whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = Offender("Test", "Test", activeProbationManagedSentence = false, otherIds = OtherIds(crn = crnNumber, nomsNumber = nomsNumber))))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.NONE)
+        }
+
+        it("HmppsId resolves to a supervision status of PRISONS") {
+          whenever(prisonerOffenderSearchGateway.getPrisonOffender(any())).thenReturn(Response(data = prisonerWithPrisonId, errors = emptyList()))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.PRISONS)
+        }
+
+        it("HmppsId resolves to a supervision status of UNKNOWN when there is a nomis in delius but it is not found by prison offender search") {
+          whenever(prisonerOffenderSearchGateway.getPrisonOffender(any())).thenReturn(Response(data = null, errors = listOf(UpstreamApiError(causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH, type = UpstreamApiError.Type.ENTITY_NOT_FOUND))))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.UNKNOWN)
+        }
+
+        it("HmppsId resolves to a supervision status of UNKNOWN when the hmmpsId can not be found in delius") {
+          whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = null, errors = listOf(UpstreamApiError(causedBy = UpstreamApi.NDELIUS, type = UpstreamApiError.Type.ENTITY_NOT_FOUND))))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.UNKNOWN)
+        }
+
+        it("HmppsId resolves to a supervision status of UNKNOWN when there is a nomis in delius but a technical error occurs retrieving it from prison offender search") {
+          whenever(prisonerOffenderSearchGateway.getPrisonOffender(any())).thenReturn(Response(data = null, errors = listOf(UpstreamApiError(causedBy = UpstreamApi.PRISONER_OFFENDER_SEARCH, type = UpstreamApiError.Type.INTERNAL_SERVER_ERROR))))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.UNKNOWN)
+        }
+
+        it("HmppsId resolves to a supervision status of UNKNOWN when there is a technical error trying to find the hmmpsId can not be found in delius") {
+          whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = null, errors = listOf(UpstreamApiError(causedBy = UpstreamApi.NDELIUS, type = UpstreamApiError.Type.INTERNAL_SERVER_ERROR))))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.UNKNOWN)
+        }
+
+        it("HmppsId resolves to a supervision status of PROBATION when the hmmpsId does not have a nomis in delius but has a activeProbationManagedSentence in delius") {
+          whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = Offender("Test", "Test", activeProbationManagedSentence = true, otherIds = OtherIds())))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.PROBATION)
+        }
+
+        it("HmppsId resolves to a supervision status of NONE when the hmmpsId does not have a nomis in delius and does NOT have a activeProbationManagedSentence in delius") {
+          whenever(deliusGateway.getOffender(any())).thenReturn(Response(data = Offender("Test", "Test", activeProbationManagedSentence = false, otherIds = OtherIds())))
+          val result = getPersonService.getSupervisionStatus(crnNumber)
+          result.shouldBe(SupervisionStatus.NONE)
+        }
+      }
     },
   )


### PR DESCRIPTION
We are currently running the events supervision checks in "logging only" in DEV only so we can check that the events are resolving to the correct supervision status before we turn it on in dev.

We found that the supervision status is NOT being determined correctly.
Therefore Steve created the following pseudo code here: https://dsdmoj.atlassian.net/wiki/spaces/HIA/pages/5983084466/Supervision+Status#Supervision-Status-derivation-(tactical)

This PR introduces a new function in GetPersonService (getSupervisionStatus(hmppsId) which will get the supervision status for a given hmppsId

This is now as follows:
```
FETCH Offender FROM NDeliusGateway
IF we have a NOMIS number
  FETCH POSPrisoner FROM PrisonerOffenderSearchGateway
IF POSPrisoner exists AND POSPrisoner.status starts with "ACTIVE" 
  SupervisionStatus = "PRISONS"
ELSE IF Offender.activeProbationManagedSentence IS TRUE
  SupervisionStatus = "PROBATION"
ELSE 
  SupervisionStatus = "NONE"
If we cannot access the required fields for the offender but need to proceed anyway then we set SupervisionStatus to “UNKNOWN”.
```