### PR TITLE
HIA-826: Allow risk-management-plan to take a nomis id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/RiskManagementController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/RiskManagementController.kt
@@ -16,9 +16,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConf
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ForbiddenByUpstreamServiceException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.RiskManagementPlan
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetRiskManagementPlansForCrnService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetRiskManagementPlansService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.PaginatedResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.paginateWith
@@ -27,7 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.paginateWith
 @EnableConfigurationProperties(AuthorisationConfig::class)
 @Tag(name = "Risks")
 class RiskManagementController(
-  @Autowired val getRiskManagementPlansForCrnService: GetRiskManagementPlansForCrnService,
+  @Autowired val getRiskManagementPlansService: GetRiskManagementPlansService,
   @Autowired val auditService: AuditService,
 ) {
   @GetMapping("/v1/persons/{hmppsId}/risk-management-plan")
@@ -46,13 +45,13 @@ class RiskManagementController(
     @Parameter(description = "The page number (starting from 1)", schema = Schema(minimum = "1")) @RequestParam(required = false, defaultValue = "1", name = "page") page: Int,
     @Parameter(description = "The maximum number of results for a page", schema = Schema(minimum = "1")) @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
   ): PaginatedResponse<RiskManagementPlan> {
-    val response = getRiskManagementPlansForCrnService.execute(hmppsId)
+    val response = getRiskManagementPlansService.execute(hmppsId)
 
-    if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND, causedBy = UpstreamApi.RISK_MANAGEMENT_PLAN)) {
+    if (response.hasErrorCausedBy(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
       throw EntityNotFoundException("Could not find person with id: $hmppsId")
     }
 
-    if (response.hasErrorCausedBy(UpstreamApiError.Type.FORBIDDEN, causedBy = UpstreamApi.RISK_MANAGEMENT_PLAN)) {
+    if (response.hasErrorCausedBy(UpstreamApiError.Type.FORBIDDEN)) {
       throw ForbiddenByUpstreamServiceException("Upstream API service returned a forbidden error")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Response.kt
@@ -14,6 +14,8 @@ data class Response<T>(
     type: UpstreamApiError.Type,
     causedBy: UpstreamApi,
   ): Boolean = this.errors.any { it.type == type && it.causedBy == causedBy }
+
+  fun hasErrorCausedBy(type: UpstreamApiError.Type): Boolean = this.errors.any { it.type == type }
 }
 
 data class DataResponse<T>(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetRiskManagementPlansService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetRiskManagementPlansService.kt
@@ -5,13 +5,20 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.RiskManagementGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.RiskManagementPlan
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService.IdentifierType
 
 @Service
-class GetRiskManagementPlansForCrnService(
+class GetRiskManagementPlansService(
   @Autowired val riskManagementGateway: RiskManagementGateway,
+  @Autowired val getPersonService: GetPersonService,
 ) {
-  fun execute(crn: String): Response<List<RiskManagementPlan>?> {
-    val crnPlansResponse = riskManagementGateway.getRiskManagementPlansForCrn(crn)
+  fun execute(hmppsId: String): Response<List<RiskManagementPlan>?> {
+    val crnResponse = getPersonService.convert(hmppsId, IdentifierType.CRN)
+    if (crnResponse.data == null) {
+      return Response(data = null, errors = crnResponse.errors)
+    }
+
+    val crnPlansResponse = riskManagementGateway.getRiskManagementPlansForCrn(crnResponse.data)
 
     return Response(
       data = crnPlansResponse.data?.toRiskManagementPlans(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/RiskManagementControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/RiskManagementControllerTest.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.ndelius.CaseAccess
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.roles
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.testRoleWithLaoRedactions
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetRiskManagementPlansForCrnService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetRiskManagementPlansService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditService
 
 @WebMvcTest(controllers = [RiskManagementController::class])
@@ -40,7 +40,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.internal.AuditS
 @ActiveProfiles("test")
 class RiskManagementControllerTest(
   @Autowired var springMockMvc: MockMvc,
-  @MockitoBean val getRiskManagementService: GetRiskManagementPlansForCrnService,
+  @MockitoBean val getRiskManagementService: GetRiskManagementPlansService,
   @MockitoBean val auditService: AuditService,
   @MockitoBean val getCaseAccess: GetCaseAccess,
   @MockitoBean val featureFlagConfig: FeatureFlagConfig,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/RiskManagementIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/RiskManagementIntegrationTest.kt
@@ -12,4 +12,17 @@ class RiskManagementIntegrationTest : IntegrationTestBase() {
       .andExpect(status().isOk)
       .andExpect(content().json(getExpectedResponse("person-risk-plan")))
   }
+
+  @Test
+  fun `returns protected characteristics for a person for a nomis number`() {
+    callApi("$basePath/$nomsId/risk-management-plan")
+      .andExpect(status().isOk)
+      .andExpect(content().json(getExpectedResponse("person-risk-plan")))
+  }
+
+  @Test
+  fun `returns not found when a crn cannot be resolved for the supplied nomis number`() {
+    callApi("$basePath/A1234AB/risk-management-plan")
+      .andExpect(status().isNotFound)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetRiskManagementPlansServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetRiskManagementPlansServiceTest.kt
@@ -17,15 +17,18 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 
 @ContextConfiguration(
   initializers = [ConfigDataApplicationContextInitializer::class],
-  classes = [GetRiskManagementPlansForCrnService::class],
+  classes = [GetRiskManagementPlansService::class],
 )
-class GetRiskManagementPlansForCrnServiceTest(
+class GetRiskManagementPlansServiceTest(
   @MockitoBean val riskManagementGateway: RiskManagementGateway,
-  private val serviceUnderTest: GetRiskManagementPlansForCrnService,
+  @MockitoBean val getPersonService: GetPersonService,
+  private val serviceUnderTest: GetRiskManagementPlansService,
 ) : DescribeSpec({
 
     val crn = "D1974X"
     val badCrn = "Not a real CRN"
+    val nomisWithCrn = "A1234AA"
+    val nomisNoCrn = "A1234AB"
     val testPlan =
       CrnRiskManagementPlans(
         crn = crn,
@@ -104,6 +107,22 @@ class GetRiskManagementPlansForCrnServiceTest(
       whenever(riskManagementGateway.getRiskManagementPlansForCrn(badCrn)).thenReturn(
         Response(data = null, errors = testErrors),
       )
+
+      whenever(getPersonService.convert(crn, GetPersonService.IdentifierType.CRN)).thenReturn(
+        Response(data = crn, errors = emptyList()),
+      )
+
+      whenever(getPersonService.convert(badCrn, GetPersonService.IdentifierType.CRN)).thenReturn(
+        Response(data = null, errors = testErrors),
+      )
+
+      whenever(getPersonService.convert(nomisWithCrn, GetPersonService.IdentifierType.CRN)).thenReturn(
+        Response(data = crn, errors = emptyList()),
+      )
+
+      whenever(getPersonService.convert(nomisNoCrn, GetPersonService.IdentifierType.CRN)).thenReturn(
+        Response(data = null, errors = testErrors),
+      )
     }
 
     describe("Get risk management") {
@@ -116,7 +135,20 @@ class GetRiskManagementPlansForCrnServiceTest(
 
       it("Returns error without valid CRN") {
         val result = serviceUnderTest.execute(badCrn)
-        verify(riskManagementGateway, VerificationModeFactory.times(1)).getRiskManagementPlansForCrn(badCrn)
+        verify(getPersonService, VerificationModeFactory.times(1)).convert(badCrn, GetPersonService.IdentifierType.CRN)
+        result.data?.isEmpty()?.let { assert(it) }
+        assert(result.errors.isNotEmpty())
+      }
+
+      it("Converts nomis to valid CRN") {
+        val result = serviceUnderTest.execute(nomisWithCrn)
+        verify(getPersonService, VerificationModeFactory.times(1)).convert(nomisWithCrn, GetPersonService.IdentifierType.CRN)
+        assert(result.data?.size == 2)
+      }
+
+      it("Cannot convert nomis to valid CRN") {
+        val result = serviceUnderTest.execute(nomisNoCrn)
+        verify(getPersonService, VerificationModeFactory.times(1)).convert(nomisNoCrn, GetPersonService.IdentifierType.CRN)
         result.data?.isEmpty()?.let { assert(it) }
         assert(result.errors.isNotEmpty())
       }


### PR DESCRIPTION
The endpoint `/v1/persons/{hmppsId}/risk-management-plan` can currently only be used with a CRN.

This PR enables the hmppsId to be a nomis number and will convert the nomis to a CRN if required.