### PR TITLE
HIA-1370: Change GHA ruby version to 3.3 for upgrades

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
           working-directory: tech-docs
       - name: Build Docs


### PR DESCRIPTION
Since we had a few dependency upgrades we now need to change the version of ruby we use in GHA from 3.2 to 3.3
This is failing on main here - https://github.com/ministryofjustice/hmpps-integration-api/actions/runs/24727030581/job/72331279168

See passing branch build - https://github.com/ministryofjustice/hmpps-integration-api/actions/runs/24729837575