### PR TITLE
HIA-1269: Remove unused CPR models to prevent breaking changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/cpr/CorePersonRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/cpr/CorePersonRecord.kt
@@ -2,21 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.cpr
 
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.CprResultException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService.IdentifierType
-import java.time.LocalDate
 
 data class CorePersonRecord(
-  val cprUUID: String? = null,
-  val firstName: String? = null,
-  val middleNames: String? = null,
-  val lastName: String? = null,
-  val dateOfBirth: String? = null,
-  val title: Title? = null,
-  val sex: Sex? = null,
-  val religion: Religion? = null,
-  val ethnicity: Ethnicity? = null,
-  val aliases: List<Alias> = emptyList(),
-  var nationalities: List<Nationality> = emptyList(),
-  val addresses: List<Address> = emptyList(),
   val identifiers: Identifiers? = null,
 ) {
   fun getIdentifier(identifierType: IdentifierType): String? =
@@ -39,58 +26,6 @@ data class CorePersonRecord(
       else -> emptyList()
     }
 }
-
-data class Title(
-  val code: String? = null,
-  val description: String? = null,
-)
-
-data class Sex(
-  val code: String? = null,
-  val description: String? = null,
-)
-
-data class Religion(
-  val code: String? = null,
-  val description: String? = null,
-)
-
-data class Ethnicity(
-  val code: String? = null,
-  val description: String? = null,
-)
-
-data class Alias(
-  val firstName: String? = null,
-  val lastName: String? = null,
-  val middleNames: String? = null,
-  val title: Title? = null,
-  val sex: Sex? = null,
-)
-
-data class Nationality(
-  val code: String? = null,
-  val description: String? = null,
-  val startDate: LocalDate? = null,
-  val endDate: LocalDate? = null,
-  val notes: String? = null,
-)
-
-data class Address(
-  val noFixedAbode: Boolean? = null,
-  val startDate: String? = null,
-  val endDate: String? = null,
-  val postcode: String? = null,
-  val subBuildingName: String? = null,
-  val buildingName: String? = null,
-  val buildingNumber: String? = null,
-  val thoroughfareName: String? = null,
-  val dependentLocality: String? = null,
-  val postTown: String? = null,
-  val county: String? = null,
-  val country: String? = null,
-  val uprn: String? = null,
-)
 
 data class Identifiers(
   val crns: List<String> = emptyList(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/cpr/CorePersonRecordGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/cpr/CorePersonRecordGatewayTest.kt
@@ -23,13 +23,13 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFound
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.CorePersonRecordGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase.Companion.gatewaysFolder
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.cpr.CorePersonRecord
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.cpr.Identifiers
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonService.IdentifierType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.TestConstants.DEFAULT_CRN
+import java.io.File
 
 @ActiveProfiles("test")
 @ContextConfiguration(
@@ -52,8 +52,20 @@ class CorePersonRecordGatewayTest(
         whenever(hmppsAuthGateway.getClientToken("CORE_PERSON_RECORD")).thenReturn(
           HmppsAuthMockServer.Companion.TOKEN,
         )
-        cprMockServer.stubForGet("/person/probation/$crn", objectMapper.writeValueAsString(CorePersonRecord(identifiers = Identifiers(prisonNumbers = listOf(nomsId)))), HttpStatus.OK)
-        cprMockServer.stubForGet("/person/prison/$nomsId", objectMapper.writeValueAsString(CorePersonRecord(identifiers = Identifiers(crns = listOf(crn)))), HttpStatus.OK)
+        cprMockServer.stubForGet(
+          "/person/probation/$crn",
+          File(
+            "$gatewaysFolder/cpr/fixtures/core-person-record-response.json",
+          ).readText(),
+          HttpStatus.OK,
+        )
+        cprMockServer.stubForGet(
+          "/person/prison/$nomsId",
+          File(
+            "$gatewaysFolder/cpr/fixtures/core-person-record-response.json",
+          ).readText(),
+          HttpStatus.OK,
+        )
       }
 
       afterTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/cpr/fixtures/core-person-record-response.json
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/cpr/fixtures/core-person-record-response.json
@@ -22,6 +22,10 @@
   },
   "aliases": [
     {
+      "sex": {
+        "code": "M",
+        "description": "Male"
+      },
       "firstName": "Jon",
       "lastName": "do",
       "middleNames": "Morgain",


### PR DESCRIPTION
While working on the open api spec updates i identfied that there were some breaking changes for models in Dev that we currently have, but are not using.
To avoid breaking changes for unused models, this PR removes these.
We only use the identifiers model at the moment