### PR TITLE
HIA-851: Do not update last_modified_datetime on conflict

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/EventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/EventNotificationRepository.kt
@@ -24,7 +24,7 @@ interface EventNotificationRepository {
     claimId: String,
   ): Int
 
-  fun insertOrUpdate(match: EventNotification)
+  fun insert(event: EventNotification)
 
   // Delete
   fun deleteEvents(dateTime: LocalDateTime): Int

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/JdbcTemplateEventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/JdbcTemplateEventNotificationRepository.kt
@@ -115,14 +115,14 @@ class JdbcTemplateEventNotificationRepository(
     return jdbcTemplate.update(setProcessingQuery, claimId, fiveMinutesAgo, EVENT_NOTIFICATION_BATCH_LIMIT)
   }
 
-  override fun insertOrUpdate(event: EventNotification) {
-    val insertOrUpdateQuery = """
+  override fun insert(event: EventNotification) {
+    val insertQuery = """
       insert into event_notification (url, event_type, hmpps_id, prison_id, status, metadata, last_modified_datetime)
         select ?,?,?,?,?,?,?
         where not exists (select 1 from event_notification where url = ? and event_type = ? and (status = 'PENDING' or status = NULL))
     """
     jdbcTemplate.update(
-      insertOrUpdateQuery,
+      insertQuery,
       event.url,
       event.eventType,
       event.hmppsId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/JdbcTemplateEventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/JdbcTemplateEventNotificationRepository.kt
@@ -115,14 +115,24 @@ class JdbcTemplateEventNotificationRepository(
     return jdbcTemplate.update(setProcessingQuery, claimId, fiveMinutesAgo, EVENT_NOTIFICATION_BATCH_LIMIT)
   }
 
-  override fun insertOrUpdate(match: EventNotification) {
+  override fun insertOrUpdate(event: EventNotification) {
     val insertOrUpdateQuery = """
       insert into event_notification (url, event_type, hmpps_id, prison_id, status, metadata, last_modified_datetime)
-        values (?,?,?,?,?,?,?)
-      on conflict(url, event_type) where status = 'PENDING' or status = NULL
-        do nothing
+        select ?,?,?,?,?,?,?
+        where not exists (select 1 from event_notification where url = ? and event_type = ? and (status = 'PENDING' or status = NULL))
     """
-    jdbcTemplate.update(insertOrUpdateQuery, match.url, match.eventType, match.hmppsId, match.prisonId, match.status, conversionService.convert(match.metadata, String::class.java), match.lastModifiedDatetime)
+    jdbcTemplate.update(
+      insertOrUpdateQuery,
+      event.url,
+      event.eventType,
+      event.hmppsId,
+      event.prisonId,
+      event.status,
+      conversionService.convert(event.metadata, String::class.java),
+      event.lastModifiedDatetime,
+      event.url,
+      event.eventType,
+    )
   }
 
   fun saveAll(events: List<EventNotification>): List<EventNotification> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/JdbcTemplateEventNotificationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/repository/JdbcTemplateEventNotificationRepository.kt
@@ -120,9 +120,9 @@ class JdbcTemplateEventNotificationRepository(
       insert into event_notification (url, event_type, hmpps_id, prison_id, status, metadata, last_modified_datetime)
         values (?,?,?,?,?,?,?)
       on conflict(url, event_type) where status = 'PENDING' or status = NULL
-        do update set last_modified_datetime = ?
+        do nothing
     """
-    jdbcTemplate.update(insertOrUpdateQuery, match.url, match.eventType, match.hmppsId, match.prisonId, match.status, conversionService.convert(match.metadata, String::class.java), match.lastModifiedDatetime, match.lastModifiedDatetime)
+    jdbcTemplate.update(insertOrUpdateQuery, match.url, match.eventType, match.hmppsId, match.prisonId, match.status, conversionService.convert(match.metadata, String::class.java), match.lastModifiedDatetime)
   }
 
   fun saveAll(events: List<EventNotification>): List<EventNotification> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/services/domain/DeduplicationDomainEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/services/domain/DeduplicationDomainEventService.kt
@@ -52,7 +52,7 @@ class DeduplicationDomainEventService(
               supervisionStatus?.let { Metadata(supervisionStatus = supervisionStatus) },
             )
 
-          eventNotificationRepository.insertOrUpdate(eventNotification)
+          eventNotificationRepository.insert(eventNotification)
         } catch (ume: UnmappableUrlException) {
           log.warn(ume.message)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DeduplicationDomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DeduplicationDomainEventsListenerTest.kt
@@ -227,7 +227,7 @@ class DeduplicationDomainEventsListenerTest : DomainEventsListenerTestCase() {
 
     domainEventsListener.onDomainEvent(rawMessage)
 
-    verify(exactly = 1) { eventNotificationRepository.insertOrUpdate(match { it.eventType == expectedEvent }) }
+    verify(exactly = 1) { eventNotificationRepository.insert(match { it.eventType == expectedEvent }) }
   }
 }
 
@@ -276,7 +276,7 @@ abstract class DomainEventsListenerTestCase {
 
     featureFlagTestConfig.assumeFeatureFlag(FeatureFlagConfig.DEDUPLICATE_EVENTS, true)
 
-    every { eventNotificationRepository.insertOrUpdate(any()) } returnsArgument 0
+    every { eventNotificationRepository.insert(any()) } returnsArgument 0
 
     every { telemetryService.captureException(any()) } just Runs
   }
@@ -309,7 +309,7 @@ abstract class DomainEventsListenerTestCase {
 
     // Assert
     expectedNotificationType.forEach { expectedEventType ->
-      verify(exactly = 1) { eventNotificationRepository.insertOrUpdate(match { it.eventType == expectedEventType }) }
+      verify(exactly = 1) { eventNotificationRepository.insert(match { it.eventType == expectedEventType }) }
     }
   }
 
@@ -331,7 +331,7 @@ abstract class DomainEventsListenerTestCase {
     // Assert
     expectedEventNotifications.forEach { expectedNotification ->
       // Verify all expected event notifications persisted via repository
-      verify(exactly = 1) { eventNotificationRepository.insertOrUpdate(expectedNotification) }
+      verify(exactly = 1) { eventNotificationRepository.insert(expectedNotification) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventServiceFeatureFlagTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventServiceFeatureFlagTest.kt
@@ -133,7 +133,7 @@ class DomainEventServiceFeatureFlagTest : DomainEventsListenerTestCase() {
 
       // Assert (expected events)
       expectedNotificationTypes.forEach { expectedNotificationType ->
-        verify(exactly = 1) { eventNotificationRepository.insertOrUpdate(match { it.eventType == expectedNotificationType.toString() }) }
+        verify(exactly = 1) { eventNotificationRepository.insert(match { it.eventType == expectedNotificationType.toString() }) }
       }
     }
 
@@ -163,7 +163,7 @@ class DomainEventServiceFeatureFlagTest : DomainEventsListenerTestCase() {
     // Assert
     // Verify no unexpected event notifications persisted via repository
     unexpectedNotificationTypes.forEach { unexpectedNotificationType ->
-      verify(exactly = 0) { eventNotificationRepository.insertOrUpdate(match { it.eventType == unexpectedNotificationType.toString() }) }
+      verify(exactly = 0) { eventNotificationRepository.insert(match { it.eventType == unexpectedNotificationType.toString() }) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/repository/EventNotificationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/repository/EventNotificationRepositoryTest.kt
@@ -38,7 +38,7 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `updates timestamp on an existing record`() {
+  fun `on a conflict with a duplicate event, it does not update the timestamp on the existing record`() {
     val eventNotification =
       EventNotification(
         eventType = IntegrationEventType.MAPPA_DETAIL_CHANGED.name,
@@ -53,12 +53,12 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
     val eventNotifications = eventNotificationRepository.findAll()
     assertThat(eventNotifications).hasSize(1)
 
-    val updatedEventNotification = eventNotification.copy(lastModifiedDatetime = LocalDateTime.now())
-    eventNotificationRepository.insertOrUpdate(updatedEventNotification)
+    val duplicatedEventNotification = eventNotification.copy(lastModifiedDatetime = LocalDateTime.now())
+    eventNotificationRepository.insertOrUpdate(duplicatedEventNotification)
 
     val updatedEventNotifications = eventNotificationRepository.findAll()
     assertThat(updatedEventNotifications).hasSize(1)
-    assertThat(updatedEventNotifications[0].lastModifiedDatetime?.truncatedTo(ChronoUnit.MINUTES)).isEqualTo(updatedEventNotification.lastModifiedDatetime?.truncatedTo(ChronoUnit.MINUTES))
+    assertThat(updatedEventNotifications[0].lastModifiedDatetime).isEqualTo(eventNotification.lastModifiedDatetime)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/repository/EventNotificationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/repository/EventNotificationRepositoryTest.kt
@@ -58,7 +58,7 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
 
     val updatedEventNotifications = eventNotificationRepository.findAll()
     assertThat(updatedEventNotifications).hasSize(1)
-    assertThat(updatedEventNotifications[0].lastModifiedDatetime).isEqualTo(eventNotification.lastModifiedDatetime)
+    assertThat(updatedEventNotifications[0].lastModifiedDatetime?.truncatedTo(ChronoUnit.SECONDS)).isEqualTo(eventNotification.lastModifiedDatetime?.truncatedTo(ChronoUnit.SECONDS))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/repository/EventNotificationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/repository/EventNotificationRepositoryTest.kt
@@ -26,7 +26,7 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
         url = "MockUrl",
         lastModifiedDatetime = LocalDateTime.now().minusMinutes(6),
       )
-    eventNotificationRepository.insertOrUpdate(eventNotification)
+    eventNotificationRepository.insert(eventNotification)
 
     val eventNotifications = eventNotificationRepository.findAll()
     assertThat(eventNotifications).hasSize(1)
@@ -48,13 +48,13 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
         metadata = Metadata(supervisionStatus = "PRISONS"),
         lastModifiedDatetime = LocalDateTime.now().minusMinutes(6),
       )
-    eventNotificationRepository.insertOrUpdate(eventNotification)
+    eventNotificationRepository.insert(eventNotification)
 
     val eventNotifications = eventNotificationRepository.findAll()
     assertThat(eventNotifications).hasSize(1)
 
     val duplicatedEventNotification = eventNotification.copy(lastModifiedDatetime = LocalDateTime.now())
-    eventNotificationRepository.insertOrUpdate(duplicatedEventNotification)
+    eventNotificationRepository.insert(duplicatedEventNotification)
 
     val updatedEventNotifications = eventNotificationRepository.findAll()
     assertThat(updatedEventNotifications).hasSize(1)
@@ -72,7 +72,7 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
         metadata = Metadata(supervisionStatus = "PROBATION"),
         lastModifiedDatetime = LocalDateTime.now().minusMinutes(6),
       )
-    eventNotificationRepository.insertOrUpdate(eventNotification)
+    eventNotificationRepository.insert(eventNotification)
     val notifications = eventNotificationRepository.findAll()
     assertThat(notifications).hasSize(1)
     val notification = notifications[0]
@@ -90,7 +90,7 @@ class EventNotificationRepositoryTest : IntegrationTestBase() {
         metadata = null,
         lastModifiedDatetime = LocalDateTime.now().minusMinutes(6),
       )
-    eventNotificationRepository.insertOrUpdate(eventNotification)
+    eventNotificationRepository.insert(eventNotification)
     val notifications = eventNotificationRepository.findAll()
     assertThat(notifications).hasSize(1)
     val notification = notifications[0]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/services/DatabaseConstraintTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/events/services/DatabaseConstraintTest.kt
@@ -28,9 +28,9 @@ class DatabaseConstraintTest : IntegrationTestBase() {
   @Test
   fun `does not create a new record when url, event type and status are all the same and all records are pending`() {
     Assertions.assertThat(eventNotificationRepository.count()).isEqualTo(0)
-    eventNotificationRepository.insertOrUpdate(makeEvent("MockUrl1"))
+    eventNotificationRepository.insert(makeEvent("MockUrl1"))
     Assertions.assertThat(eventNotificationRepository.count()).isEqualTo(1)
-    eventNotificationRepository.insertOrUpdate(makeEvent("MockUrl1"))
+    eventNotificationRepository.insert(makeEvent("MockUrl1"))
     Assertions.assertThat(eventNotificationRepository.count()).isEqualTo(1)
   }
 
@@ -38,11 +38,11 @@ class DatabaseConstraintTest : IntegrationTestBase() {
   fun `creates a new record when url, event type are same, but status is different`() {
     Assertions.assertThat(eventNotificationRepository.count()).isEqualTo(0)
     val claimId = UUID.randomUUID().toString()
-    eventNotificationRepository.insertOrUpdate(makeEvent("MockUrl1"))
+    eventNotificationRepository.insert(makeEvent("MockUrl1"))
     Assertions.assertThat(eventNotificationRepository.count()).isEqualTo(1)
     // Move status to processing
     eventNotificationRepository.setProcessing(LocalDateTime.now().minusMinutes(5), claimId)
-    eventNotificationRepository.insertOrUpdate(makeEvent("MockUrl1"))
+    eventNotificationRepository.insert(makeEvent("MockUrl1"))
     Assertions.assertThat(eventNotificationRepository.count()).isEqualTo(2)
   }
 
@@ -50,12 +50,12 @@ class DatabaseConstraintTest : IntegrationTestBase() {
   fun `allows another record with the same url and event type to be set to PROCESSING`() {
     // Put an event in the processing state
     val claimId1 = UUID.randomUUID().toString()
-    eventNotificationRepository.insertOrUpdate(makeEvent("MockUrl1"))
+    eventNotificationRepository.insert(makeEvent("MockUrl1"))
     eventNotificationRepository.setProcessing(LocalDateTime.now().minusMinutes(5), claimId1)
 
     // Put an event in the processing state
     val claimId2 = UUID.randomUUID().toString()
-    eventNotificationRepository.insertOrUpdate(makeEvent("MockUrl1"))
+    eventNotificationRepository.insert(makeEvent("MockUrl1"))
     eventNotificationRepository.setProcessing(LocalDateTime.now().minusMinutes(5), claimId2)
 
     val events = eventNotificationRepository.findAll()


### PR DESCRIPTION
Currently, when a duplicate notification is received, the `last_updated_datetime` DB field is being updated with the current time.
This means that the delay of sending the notification increases when a user makes multiple updates within a 5 minute period.
To prevent sending of the notifications being delayed further, caused by multiple updates in the 5 minute period, this PR removes the setting of the DB field when a conflict is found.