### PR TITLE
HIA-1410: Log cert expiry date in app insights request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -25,13 +25,6 @@ class AuthorisationFilter(
   private val telemetryService: TelemetryService,
   private val roleService: RoleService,
 ) : Filter {
-  companion object {
-    const val SDN_HEADER = "subject-distinguished-name"
-    const val CERT_SERIAL_NUMBER_HEADER = "cert-serial-number"
-    const val CERT_EXPIRY_DATE_HEADER = "cert-expiry-date"
-    const val OBO_HEADER = "X-On-Behalf-Of"
-  }
-
   @Throws(IOException::class, ServletException::class)
   override fun doFilter(
     request: ServletRequest,
@@ -42,7 +35,7 @@ class AuthorisationFilter(
     val res = response as HttpServletResponse
 
     // Get the consumer Name from the SDN
-    val subjectDistinguishedName = req.getHeader(SDN_HEADER)
+    val subjectDistinguishedName = req.getHeader("subject-distinguished-name")
     val clientName = extractConsumerName(subjectDistinguishedName)
 
     if (clientName == null) {
@@ -53,17 +46,17 @@ class AuthorisationFilter(
     req.setAttribute("clientName", clientName)
 
     // Get the cert serial number
-    val certificateSerialNumber = extractCertificateSerialNumber(req.getHeader(CERT_SERIAL_NUMBER_HEADER))
+    val certificateSerialNumber = extractCertificateSerialNumber(req.getHeader("cert-serial-number"))
     if (certificateSerialNumber != null && certificateRevoked(authorisationService.certificateRevocationList(), certificateSerialNumber, clientName)) {
       res.sendError(HttpServletResponse.SC_FORBIDDEN, "Certificate with serial number $certificateSerialNumber has been revoked")
       return
     }
 
     // Get certificate expiry date
-    val certificateExpiryDate = req.getHeader(CERT_EXPIRY_DATE_HEADER)
+    val certificateExpiryDate = req.getHeader("cert-expiry-date")
 
     // Get the on behalf of token
-    val onBehalfOf = req.getHeader(OBO_HEADER)
+    val onBehalfOf = req.getHeader("X-On-Behalf-Of")
 
     // Set App insights request attributes
     setSpanAttributes(clientName, certificateSerialNumber, onBehalfOf, certificateExpiryDate)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -25,6 +25,13 @@ class AuthorisationFilter(
   private val telemetryService: TelemetryService,
   private val roleService: RoleService,
 ) : Filter {
+  companion object {
+    const val SDN_HEADER = "subject-distinguished-name"
+    const val CERT_SERIAL_NUMBER_HEADER = "cert-serial-number"
+    const val CERT_EXPIRY_DATE_HEADER = "cert-expiry-date"
+    const val OBO_HEADER = "X-On-Behalf-Of"
+  }
+
   @Throws(IOException::class, ServletException::class)
   override fun doFilter(
     request: ServletRequest,
@@ -35,7 +42,7 @@ class AuthorisationFilter(
     val res = response as HttpServletResponse
 
     // Get the consumer Name from the SDN
-    val subjectDistinguishedName = req.getHeader("subject-distinguished-name")
+    val subjectDistinguishedName = req.getHeader(SDN_HEADER)
     val clientName = extractConsumerName(subjectDistinguishedName)
 
     if (clientName == null) {
@@ -46,17 +53,20 @@ class AuthorisationFilter(
     req.setAttribute("clientName", clientName)
 
     // Get the cert serial number
-    val certificateSerialNumber = extractCertificateSerialNumber(req.getHeader("cert-serial-number"))
+    val certificateSerialNumber = extractCertificateSerialNumber(req.getHeader(CERT_SERIAL_NUMBER_HEADER))
     if (certificateSerialNumber != null && certificateRevoked(authorisationService.certificateRevocationList(), certificateSerialNumber, clientName)) {
       res.sendError(HttpServletResponse.SC_FORBIDDEN, "Certificate with serial number $certificateSerialNumber has been revoked")
       return
     }
 
+    // Get certificate expiry date
+    val certificateExpiryDate = req.getHeader(CERT_EXPIRY_DATE_HEADER)
+
     // Get the on behalf of token
-    val onBehalfOf = req.getHeader("X-On-Behalf-Of")
+    val onBehalfOf = req.getHeader(OBO_HEADER)
 
     // Set App insights request attributes
-    setSpanAttributes(clientName, certificateSerialNumber, onBehalfOf)
+    setSpanAttributes(clientName, certificateSerialNumber, onBehalfOf, certificateExpiryDate)
 
     // Set filters
     val consumerConfig: ConsumerConfig? = authorisationService.consumers()[clientName]
@@ -186,9 +196,11 @@ class AuthorisationFilter(
     clientId: String,
     certSerialNumber: String?,
     onBehalfOf: String?,
+    certExpiryDate: String?,
   ) {
     telemetryService.setSpanAttribute("clientId", clientId)
     certSerialNumber?.let { telemetryService.setSpanAttribute("certSerialNumber", certSerialNumber) }
+    certExpiryDate?.let { telemetryService.setSpanAttribute("certExpiryDate", certExpiryDate) }
     onBehalfOf?.let { telemetryService.setSpanAttribute("onBehalfOf", it) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -22,6 +22,10 @@ import org.springframework.mock.web.MockHttpServletResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.LimitedAccessException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.CERT_EXPIRY_DATE_HEADER
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.CERT_SERIAL_NUMBER_HEADER
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.OBO_HEADER
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.SDN_HEADER
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
@@ -56,9 +60,9 @@ class AuthorisationFilterTest {
     reset(mockChain)
     reset(featureFlagConfig)
     whenever(mockRequest.requestURI).thenReturn(examplePath)
-    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(exampleSubjectDistinguishedName)
-    whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(CERT_SERIAL_RAW)
-    whenever(mockRequest.getHeader("X-On-Behalf-Of")).thenReturn("TEST_BEHALF_OF")
+    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(exampleSubjectDistinguishedName)
+    whenever(mockRequest.getHeader(CERT_SERIAL_NUMBER_HEADER)).thenReturn(CERT_SERIAL_RAW)
+    whenever(mockRequest.getHeader(OBO_HEADER)).thenReturn("TEST_BEHALF_OF")
     whenever(mockRoleService.getRoles()).thenReturn(mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)))
   }
 
@@ -69,8 +73,8 @@ class AuthorisationFilterTest {
     certificateSerialNumber: String = CERT_SERIAL_RAW,
   ): HttpServletRequest {
     val req = MockHttpServletRequest(method, path)
-    req.addHeader("subject-distinguished-name", subjectDistinguishedName)
-    req.addHeader("cert-serial-number", certificateSerialNumber)
+    req.addHeader(SDN_HEADER, subjectDistinguishedName)
+    req.addHeader(CERT_SERIAL_NUMBER_HEADER, certificateSerialNumber)
     return req
   }
 
@@ -158,7 +162,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `generates error when subject distinguished name is null in the request`() {
-    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
+    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
 
@@ -319,7 +323,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles missing clientName attribute`() {
-    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
+    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -336,7 +340,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a NULL certificate serial number header`() {
-    whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(null)
+    whenever(mockRequest.getHeader(CERT_SERIAL_NUMBER_HEADER)).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -353,7 +357,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a NULL on behalf of header`() {
-    whenever(mockRequest.getHeader("X-On-Behalf-Of")).thenReturn(null)
+    whenever(mockRequest.getHeader(OBO_HEADER)).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -362,11 +366,29 @@ class AuthorisationFilterTest {
 
   @Test
   fun `returns the default consumer name when there is a default consumer name and no subject distinguished name`() {
-    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
+    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(null)
     whenever(authorisationService.defaultConsumerName()).thenReturn("defaultConsumerName")
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(1)).setSpanAttribute("clientId", "defaultConsumerName")
+  }
+
+  @Test
+  fun `handles a cert-expiry-date header `() {
+    whenever(mockRequest.getHeader(CERT_EXPIRY_DATE_HEADER)).thenReturn("Aug 5 00:28:21 2026 GMT")
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
+    val finalFilter = mock(Filter::class.java)
+    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
+    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "Aug 5 00:28:21 2026 GMT")
+  }
+
+  @Test
+  fun `handles a null cert-expiry-date header `() {
+    whenever(mockRequest.getHeader(CERT_EXPIRY_DATE_HEADER)).thenReturn(null)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
+    val finalFilter = mock(Filter::class.java)
+    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
+    verify(mockTelemetryService, times(0)).setSpanAttribute(eq("certExpiryDate"), any())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -22,10 +22,6 @@ import org.springframework.mock.web.MockHttpServletResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.LimitedAccessException
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.CERT_EXPIRY_DATE_HEADER
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.CERT_SERIAL_NUMBER_HEADER
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.OBO_HEADER
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter.Companion.SDN_HEADER
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
@@ -60,9 +56,9 @@ class AuthorisationFilterTest {
     reset(mockChain)
     reset(featureFlagConfig)
     whenever(mockRequest.requestURI).thenReturn(examplePath)
-    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(exampleSubjectDistinguishedName)
-    whenever(mockRequest.getHeader(CERT_SERIAL_NUMBER_HEADER)).thenReturn(CERT_SERIAL_RAW)
-    whenever(mockRequest.getHeader(OBO_HEADER)).thenReturn("TEST_BEHALF_OF")
+    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(exampleSubjectDistinguishedName)
+    whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(CERT_SERIAL_RAW)
+    whenever(mockRequest.getHeader("X-On-Behalf-Of")).thenReturn("TEST_BEHALF_OF")
     whenever(mockRoleService.getRoles()).thenReturn(mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)))
   }
 
@@ -73,8 +69,8 @@ class AuthorisationFilterTest {
     certificateSerialNumber: String = CERT_SERIAL_RAW,
   ): HttpServletRequest {
     val req = MockHttpServletRequest(method, path)
-    req.addHeader(SDN_HEADER, subjectDistinguishedName)
-    req.addHeader(CERT_SERIAL_NUMBER_HEADER, certificateSerialNumber)
+    req.addHeader("subject-distinguished-name", subjectDistinguishedName)
+    req.addHeader("cert-serial-number", certificateSerialNumber)
     return req
   }
 
@@ -162,7 +158,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `generates error when subject distinguished name is null in the request`() {
-    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(null)
+    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
 
@@ -323,7 +319,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles missing clientName attribute`() {
-    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(null)
+    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -340,7 +336,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a NULL certificate serial number header`() {
-    whenever(mockRequest.getHeader(CERT_SERIAL_NUMBER_HEADER)).thenReturn(null)
+    whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -357,7 +353,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a NULL on behalf of header`() {
-    whenever(mockRequest.getHeader(OBO_HEADER)).thenReturn(null)
+    whenever(mockRequest.getHeader("X-On-Behalf-Of")).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -366,7 +362,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `returns the default consumer name when there is a default consumer name and no subject distinguished name`() {
-    whenever(mockRequest.getHeader(SDN_HEADER)).thenReturn(null)
+    whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
     whenever(authorisationService.defaultConsumerName()).thenReturn("defaultConsumerName")
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
@@ -376,7 +372,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a cert-expiry-date header `() {
-    whenever(mockRequest.getHeader(CERT_EXPIRY_DATE_HEADER)).thenReturn("Aug 5 00:28:21 2026 GMT")
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Aug 5 00:28:21 2026 GMT")
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -385,7 +381,7 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a null cert-expiry-date header `() {
-    whenever(mockRequest.getHeader(CERT_EXPIRY_DATE_HEADER)).thenReturn(null)
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn(null)
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)


### PR DESCRIPTION
First PR to log the cert expiry date that is now being sent down from the API Gateway.
See [CP PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/42475)

This PR simply adds the cert expiry date (`cert-expiry-date` header) which has been created from the API Gateway header `context.identity.clientCert.validity.notAfter`.