### PR TITLE
Added cp-course-completion-events-secret to values.yaml so its available for both dev and prod.

### DIFF
--- a/helm_deploy/hmpps-integration-api/values.yaml
+++ b/helm_deploy/hmpps-integration-api/values.yaml
@@ -65,6 +65,8 @@ generic-service:
       HMPPS_SQS_QUEUES_LOCATIONS_QUEUE_NAME: "sqs_queue_name"
     sqs-update-from-external-system-events-activities-queue-secret:
       HMPPS_SQS_QUEUES_ACTIVITIES_QUEUE_NAME: "sqs_queue_name"
+    cp-course-completion-events-secret:
+      HMPPS_SQS_QUEUES_EDUCATIONCOURSECOMPLETIONEVENTS_QUEUE_NAME: "sqs_queue_name"
     rds-postgresql-instance-output:
       DB_SERVER: "rds_instance_endpoint"
       DB_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,8 +23,6 @@ generic-service:
     other-services:
       APPINSIGHTS_INSTRUMENTATIONKEY: "azure-app-insights"
       SENTRY_DSN: "sentry"
-    cp-course-completion-events-secret:
-      HMPPS_SQS_QUEUES_EDUCATIONCOURSECOMPLETIONEVENTS_QUEUE_NAME: "sqs_queue_name"
     event-test-client-queue:
       TEST_CLIENT_QUEUE_NAME: "sqs_name"
       TEST_CLIENT_QUEUE_ARN: "sqs_arn"


### PR DESCRIPTION
Added cp-course-completion-events-secret to values.yaml so its available for both dev and prod.

We sent a "smoke test" course completion message from meganexus and it failed due to missing config on prod.