### PR TITLE
HIA-1410: Send a message to Sentry when days to expiry is in the range 30, 21, 14, 7..0

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -15,8 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 import java.io.IOException
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 @Component
@@ -24,6 +28,7 @@ import java.util.Locale
 class AuthorisationFilter(
   private val authorisationService: AuthorisationService,
   private val telemetryService: TelemetryService,
+  private val clock: Clock,
 ) : Filter {
   @Throws(IOException::class, ServletException::class)
   override fun doFilter(
@@ -54,12 +59,11 @@ class AuthorisationFilter(
 
     // Get certificate expiry date
     val certificateExpiryDate =
-      req.getHeader("cert-expiry-date")?.let {
-        try {
-          ZonedDateTime.parse(it, DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH)).toInstant().toString()
-        } catch (ex: Exception) {
-          telemetryService.captureException(RuntimeException("Failed to parse certificate expiry date $it. ${ex.message}"))
-          null
+      req.getHeader("cert-expiry-date")?.let { headerString ->
+        val instant = parseCertExpiryDate(headerString)
+        instant?.let {
+          checkExpiry(clientName, instant, headerString)
+          instant.toString()
         }
       }
 
@@ -187,5 +191,28 @@ class AuthorisationFilter(
     certSerialNumber?.let { telemetryService.setSpanAttribute("certSerialNumber", certSerialNumber) }
     certExpiryDate?.let { telemetryService.setSpanAttribute("certExpiryDate", certExpiryDate) }
     onBehalfOf?.let { telemetryService.setSpanAttribute("onBehalfOf", onBehalfOf) }
+  }
+
+  private fun parseCertExpiryDate(certExpiryDate: String): Instant? =
+    try {
+      ZonedDateTime
+        .parse(certExpiryDate, DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH))
+        .toInstant()
+    } catch (ex: Exception) {
+      telemetryService.captureException(RuntimeException("Failed to parse certificate expiry date $certExpiryDate. ${ex.message}"))
+      null
+    }
+
+  private fun checkExpiry(
+    consumerName: String,
+    certExpiryDate: Instant,
+    certExpiryFormated: String,
+  ) {
+    val today = LocalDate.ofInstant(clock.instant(), clock.zone)
+    val expires = LocalDate.ofInstant(certExpiryDate, clock.zone)
+    val days = ChronoUnit.DAYS.between(today, expires)
+    if (days in 1..30) {
+      telemetryService.captureMessage("The certificate for $consumerName will expire on $certExpiryFormated (in $days ${if (days > 1L) "days" else "day" })")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -15,20 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 import java.io.IOException
-import java.time.Clock
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import java.util.Locale
 
 @Component
 @EnableConfigurationProperties(AuthorisationConfig::class)
 class AuthorisationFilter(
   private val authorisationService: AuthorisationService,
   private val telemetryService: TelemetryService,
-  private val clock: Clock,
 ) : Filter {
   @Throws(IOException::class, ServletException::class)
   override fun doFilter(
@@ -58,14 +50,7 @@ class AuthorisationFilter(
     }
 
     // Get certificate expiry date
-    val certificateExpiryDate =
-      req.getHeader("cert-expiry-date")?.let { headerString ->
-        val instant = parseCertExpiryDate(headerString)
-        instant?.let {
-          checkExpiry(clientName, instant, headerString)
-          instant.toString()
-        }
-      }
+    val certificateExpiryDate = req.getHeader("cert-expiry-date")?.let { authorisationService.processCertificateExpiryDate(it, clientName) }
 
     // Get the on behalf of token
     val onBehalfOf = req.getHeader("X-On-Behalf-Of")
@@ -191,28 +176,5 @@ class AuthorisationFilter(
     certSerialNumber?.let { telemetryService.setSpanAttribute("certSerialNumber", certSerialNumber) }
     certExpiryDate?.let { telemetryService.setSpanAttribute("certExpiryDate", certExpiryDate) }
     onBehalfOf?.let { telemetryService.setSpanAttribute("onBehalfOf", onBehalfOf) }
-  }
-
-  private fun parseCertExpiryDate(certExpiryDate: String): Instant? =
-    try {
-      ZonedDateTime
-        .parse(certExpiryDate, DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH))
-        .toInstant()
-    } catch (ex: Exception) {
-      telemetryService.captureException(RuntimeException("Failed to parse certificate expiry date $certExpiryDate. ${ex.message}"))
-      null
-    }
-
-  private fun checkExpiry(
-    consumerName: String,
-    certExpiryDate: Instant,
-    certExpiryFormated: String,
-  ) {
-    val today = LocalDate.ofInstant(clock.instant(), clock.zone)
-    val expires = LocalDate.ofInstant(certExpiryDate, clock.zone)
-    val days = ChronoUnit.DAYS.between(today, expires)
-    if (days in 1..30) {
-      telemetryService.captureMessage("The certificate for $consumerName will expire on $certExpiryFormated (in $days ${if (days > 1L) "days" else "day" })")
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -15,6 +15,9 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 import java.io.IOException
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Component
 @EnableConfigurationProperties(AuthorisationConfig::class)
@@ -50,7 +53,15 @@ class AuthorisationFilter(
     }
 
     // Get certificate expiry date
-    val certificateExpiryDate = req.getHeader("cert-expiry-date")
+    val certificateExpiryDate =
+      req.getHeader("cert-expiry-date")?.let {
+        try {
+          ZonedDateTime.parse(it, DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH)).toInstant().toString()
+        } catch (ex: Exception) {
+          telemetryService.captureException(RuntimeException("Failed to parse certificate expiry date $it. ${ex.message}"))
+          null
+        }
+      }
 
     // Get the on behalf of token
     val onBehalfOf = req.getHeader("X-On-Behalf-Of")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.normalisePath
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.redactionconfig.RedactionPolicy
@@ -11,11 +12,22 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.OboService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.UnsignedJwtOboService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
 import kotlin.collections.orEmpty
+import kotlin.ranges.contains
 
 @Component
 class AuthorisationService(
   private val authorisationConfig: AuthorisationConfig,
+  private val telemetryService: TelemetryService,
+  private val clock: Clock = fixedClock(),
 ) {
   /**
    * Returns true if the consumer has access to the endpoint.
@@ -176,6 +188,52 @@ class AuthorisationService(
   }
 
   fun requiresObo(consumerName: String): Boolean = authorisationConfig.consumers[consumerName]?.oboConfig != null
+
+  /**
+   * Converts a certificate expiry date in the OpenSSL format to an ISO-6801 format
+   * Creates a sentry alert if the number of days to expiry is in the range 30, 21, 14, 7..0
+   * If the date is not in the OpenSSL format, will capture exception and return null
+   * Throws a RuntimeException if the certificate has already expired
+   *
+   * @param certExpiryDate The certificate expiry date in the OpenSSL format e.g Jun 7 12:30:10 2026 GMT
+   * @param consumerName The consumer name
+   * @return The certificate expiry date in ISO-8601 format
+   */
+
+  fun processCertificateExpiryDate(
+    certExpiryDate: String,
+    consumerName: String,
+  ): String? {
+    val expiryDateTime =
+      try {
+        ZonedDateTime
+          .parse(certExpiryDate, DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH))
+          .toInstant()
+      } catch (ex: Exception) {
+        telemetryService.captureException(RuntimeException("Failed to parse certificate expiry date $certExpiryDate. ${ex.message}"))
+        null
+      }
+    return expiryDateTime?.let {
+      checkExpiryDate(expiryDateTime, certExpiryDate, consumerName)
+      expiryDateTime.toString()
+    }
+  }
+
+  fun checkExpiryDate(
+    expiryDateTime: Instant,
+    certExpiryDateString: String,
+    consumerName: String,
+  ) {
+    val today = LocalDate.ofInstant(clock.instant(), clock.zone)
+    val expires = LocalDate.ofInstant(expiryDateTime, clock.zone)
+    val days = ChronoUnit.DAYS.between(today, expires)
+    if (days < 0) {
+      throw RuntimeException("Certificate with expiry date $certExpiryDateString has expired")
+    }
+    if ((days in 0..7 || listOf<Long>(30, 21, 14).contains(days))) {
+      telemetryService.captureMessage("The certificate for $consumerName will expire on $certExpiryDateString (in $days ${if (days == 1L) "day" else "days" })")
+    }
+  }
 
   /**
    * Reduces a list of list<Any> (mixed) type to a flattened list of specified Enum type

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -22,7 +22,6 @@ import java.time.temporal.ChronoUnit
 import java.util.Locale
 import kotlin.collections.orEmpty
 import kotlin.math.ceil
-import kotlin.ranges.contains
 
 @Component
 class AuthorisationService(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -252,7 +252,7 @@ class AuthorisationService(
         else -> null
       }
     return durationMessage?.let {
-      "The certificate for $consumerName will expire on $expiryDateTime ($durationMessage)"
+      "The certificate for $consumerName will expire $durationMessage ($expiryDateTime)"
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 import kotlin.collections.orEmpty
+import kotlin.math.ceil
 import kotlin.ranges.contains
 
 @Component
@@ -227,11 +228,32 @@ class AuthorisationService(
     val today = LocalDate.ofInstant(clock.instant(), clock.zone)
     val expires = LocalDate.ofInstant(expiryDateTime, clock.zone)
     val days = ChronoUnit.DAYS.between(today, expires)
-    if (days < 0) {
-      throw RuntimeException("Certificate with expiry date $certExpiryDateString has expired")
+
+    val expiryWarningMessage = expiryWarningMessage(days, certExpiryDateString, consumerName)
+
+    if (expiryWarningMessage != null) {
+      telemetryService.captureMessage(expiryWarningMessage)
     }
-    if ((days in 0..7 || listOf<Long>(30, 21, 14).contains(days))) {
-      telemetryService.captureMessage("The certificate for $consumerName will expire on $certExpiryDateString (in $days ${if (days == 1L) "day" else "days" })")
+  }
+
+  fun expiryWarningMessage(
+    days: Long,
+    expiryDateTime: String,
+    consumerName: String,
+  ): String? {
+    val durationMessage =
+      when {
+        (days < 0) -> throw RuntimeException("The certificate for $consumerName with expiry date $expiryDateTime has expired")
+        (days <= 7) -> "in $days ${if (days == 1L) "day" else "days"}"
+        (days <= 28) -> {
+          val weeks = ceil(days / 7.0).toInt()
+          "in under $weeks ${if (weeks == 1) "week" else "weeks"}"
+        }
+        (days <= 30) -> "in under 30 days"
+        else -> null
+      }
+    return durationMessage?.let {
+      "The certificate for $consumerName will expire on $expiryDateTime ($durationMessage)"
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/ConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/ConfigTest.kt
@@ -28,7 +28,7 @@ abstract class ConfigTest {
   /**
    * Loads the configuration for a specified environment.
    */
-  fun getAuthService(environment: String): AuthorisationService = AuthorisationService(configReader.read(environment), mockTelemetryService, fixedClock())
+  fun getAuthService(environment: String): AuthorisationService = AuthorisationService(configReader.read(environment), mockTelemetryService)
 
   fun getFeatureConfig(environment: String): Map<String, Boolean> {
     val featureConfig = getConfigPath(environment, "feature-flag")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/ConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/ConfigTest.kt
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.mockito.Mockito.mock
 import org.springframework.core.io.ClassPathResource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.AuthorisationConfigReader
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.util.FileManager
 import java.io.File
@@ -16,6 +18,7 @@ import java.io.File
 abstract class ConfigTest {
   val mapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
   val configReader = AuthorisationConfigReader(FileManager())
+  val mockTelemetryService: TelemetryService = mock()
 
   fun getConfigPath(
     environment: String,
@@ -25,7 +28,7 @@ abstract class ConfigTest {
   /**
    * Loads the configuration for a specified environment.
    */
-  fun getAuthService(environment: String): AuthorisationService = AuthorisationService(configReader.read(environment))
+  fun getAuthService(environment: String): AuthorisationService = AuthorisationService(configReader.read(environment), mockTelemetryService, fixedClock())
 
   fun getFeatureConfig(environment: String): Map<String, Boolean> {
     val featureConfig = getConfigPath(environment, "feature-flag")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/WebMvcTestConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/WebMvcTestConfiguration.kt
@@ -37,5 +37,5 @@ class WebMvcTestConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  fun authorisationService(): AuthorisationService = AuthorisationService(config())
+  fun authorisationService(): AuthorisationService = AuthorisationService(config(), telemetryService(), clock())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/WebMvcTestConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/WebMvcTestConfiguration.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.limitedaccess.GetCaseAcc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.testRoleWithLaoRedactions
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
+import java.time.Clock
 
 @TestConfiguration
 class WebMvcTestConfiguration {
@@ -29,6 +30,10 @@ class WebMvcTestConfiguration {
     config.roles = roles + testRole
     return config
   }
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun clock(): Clock = Clock.systemDefaultZone()
 
   @Bean
   @ConditionalOnMissingBean

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/service/IntegrationEventSqsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/service/IntegrationEventSqsServiceTests.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.ConfigTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.entities.EventNotification
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.entities.Metadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.services.EventNotificationService
@@ -103,6 +104,8 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
                 - full-access
           """.trimIndent(),
         ),
+        telemetryService,
+        fixedClock(),
       )
 
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
@@ -122,6 +125,8 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
                 - full-access
           """.trimIndent(),
         ),
+        telemetryService,
+        fixedClock(),
       )
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
     Assertions.assertFalse(eventNotificationService.isEventApplicable("tester", testEvent))
@@ -143,6 +148,8 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
                  - MKI
           """.trimIndent(),
         ),
+        telemetryService,
+        fixedClock(),
       )
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
     Assertions.assertTrue(eventNotificationService.isEventApplicable("tester", testEvent))
@@ -164,6 +171,8 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
                   - MKI
           """.trimIndent(),
         ),
+        telemetryService,
+        fixedClock(),
       )
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
     Assertions.assertFalse(eventNotificationService.isEventApplicable("tester", testEvent))
@@ -185,7 +194,7 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
         prisonId = messagePrisonId,
         metadata = messageSupervisionStatus?.let { Metadata(it) },
       )
-    val authService = AuthorisationService(parseAuthorisationConfig(config))
+    val authService = AuthorisationService(parseAuthorisationConfig(config), telemetryService, fixedClock())
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
 
     assertThat(eventNotificationService.isEventApplicable("tester", testEvent)).isEqualTo(shouldBeSent)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/service/IntegrationEventSqsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/service/IntegrationEventSqsServiceTests.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.ConfigTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.entities.EventNotification
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.entities.Metadata
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.services.EventNotificationService
@@ -105,7 +104,6 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
           """.trimIndent(),
         ),
         telemetryService,
-        fixedClock(),
       )
 
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
@@ -126,7 +124,6 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
           """.trimIndent(),
         ),
         telemetryService,
-        fixedClock(),
       )
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
     Assertions.assertFalse(eventNotificationService.isEventApplicable("tester", testEvent))
@@ -149,7 +146,6 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
           """.trimIndent(),
         ),
         telemetryService,
-        fixedClock(),
       )
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
     Assertions.assertTrue(eventNotificationService.isEventApplicable("tester", testEvent))
@@ -172,7 +168,6 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
           """.trimIndent(),
         ),
         telemetryService,
-        fixedClock(),
       )
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
     Assertions.assertFalse(eventNotificationService.isEventApplicable("tester", testEvent))
@@ -194,7 +189,7 @@ class IntegrationEventSqsServiceTests : ConfigTest() {
         prisonId = messagePrisonId,
         metadata = messageSupervisionStatus?.let { Metadata(it) },
       )
-    val authService = AuthorisationService(parseAuthorisationConfig(config), telemetryService, fixedClock())
+    val authService = AuthorisationService(parseAuthorisationConfig(config), telemetryService)
     eventNotificationService = EventNotificationService(queueService, objectMapper, authService, telemetryService)
 
     assertThat(eventNotificationService.isEventApplicable("tester", testEvent)).isEqualTo(shouldBeSent)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -13,7 +13,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
@@ -52,7 +51,7 @@ class AuthorisationFilterTest {
   private val fixedClock: Clock = Clock.fixed(LocalDateTime.of(2026, 5, 8, 12, 30, 10).toInstant(ZoneOffset.UTC), ZoneId.systemDefault())
 
   private val roleConfig = ConsumerConfig(roles = listOf("private-prison"), filters = ConsumerFilters(prisons = listOf("MDI")))
-  private val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+  private val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
 
   @BeforeEach
   fun setup() {
@@ -88,6 +87,8 @@ class AuthorisationFilterTest {
           certificateRevocationList,
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
     return authService
   }
@@ -103,7 +104,7 @@ class AuthorisationFilterTest {
     finalFilter: Filter = mock(Filter::class.java),
   ): MockFilterChain =
     mockFilterChain(
-      AuthorisationFilter(authService, mockTelemetryService, fixedClock),
+      AuthorisationFilter(authService, mockTelemetryService),
       finalFilter,
     )
 
@@ -117,7 +118,7 @@ class AuthorisationFilterTest {
 
     val chain =
       mockFilterChain(
-        AuthorisationFilter(authService, mockTelemetryService, fixedClock),
+        AuthorisationFilter(authService, mockTelemetryService),
         finalFilter,
       )
 
@@ -134,8 +135,10 @@ class AuthorisationFilterTest {
           mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)),
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
 
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -151,9 +154,11 @@ class AuthorisationFilterTest {
           mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)),
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
     // invalid Role Config
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
 
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -169,7 +174,7 @@ class AuthorisationFilterTest {
     val req = mockRequest("GET", invalidPath)
     req.setAttribute("clientName", exampleConsumer)
 
-    val chain = mockFilterChain(AuthorisationFilter(authService, mockTelemetryService, fixedClock))
+    val chain = mockFilterChain(AuthorisationFilter(authService, mockTelemetryService))
 
     chain.doFilter(req, resp)
 
@@ -180,7 +185,7 @@ class AuthorisationFilterTest {
   @Test
   fun `generates error when subject distinguished name is null in the request`() {
     whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
 
     verify(mockResponse, times(1)).sendError(403, "No subject-distinguished-name header provided for authorisation")
@@ -194,9 +199,11 @@ class AuthorisationFilterTest {
           mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)),
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
     // invalid Role Config
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     whenever(mockChain.doFilter(mockRequest, mockResponse)).thenThrow(ServletException(LimitedAccessException()))
 
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -212,8 +219,10 @@ class AuthorisationFilterTest {
           mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)),
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     whenever(mockChain.doFilter(mockRequest, mockResponse)).thenThrow(ServletException(LimitedAccessException()))
 
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -226,7 +235,7 @@ class AuthorisationFilterTest {
     whenever(authorisationService.certificateRevocationList()).thenReturn(listOf(CERT_SERIAL_FORMATTED, "TEST_SERIAL_NUMBER_2"))
     whenever(authorisationService.consumers()).thenReturn(mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)))
     val resp = MockHttpServletResponse()
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     mockFilterChain(authorisationFilter).doFilter(mockRequest, resp)
     assertThat(resp.status).isEqualTo(403)
     assertThat(resp.errorMessage).isEqualTo("Certificate with serial number 01:AD:3E:D8:7D:D5:AA:84:F5:2D:83:E7:87:E9:90:E4:84:C5:2C:90 has been revoked")
@@ -272,7 +281,12 @@ class AuthorisationFilterTest {
     val resp = MockHttpServletResponse()
 
     val config = ConsumerConfig(include = null, filters = ConsumerFilters(prisons = listOf("A", "B")), roles = listOf())
-    val authorisationService = AuthorisationService(AuthorisationConfig(mapOf("consumer-name" to config)))
+    val authorisationService =
+      AuthorisationService(
+        AuthorisationConfig(mapOf("consumer-name" to config)),
+        mockTelemetryService,
+        fixedClock,
+      )
 
     val req = mockRequest("GET", examplePath, "O=test,CN=consumer-name")
 
@@ -297,6 +311,8 @@ class AuthorisationFilterTest {
           mapOf("consumer-name" to consumerConfig),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
 
     val req = mockRequest("GET", examplePath, "O=test,CN=consumer-name")
@@ -320,6 +336,8 @@ class AuthorisationFilterTest {
           mapOf("consumer-name" to ConsumerConfig(include = null, filters = ConsumerFilters(prisons = listOf("MDI")), roles = listOf("test-role"))),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock,
       )
 
     val req = mockRequest("GET", examplePath, "O=test,CN=consumer-name")
@@ -406,44 +424,12 @@ class AuthorisationFilterTest {
   }
 
   @Test
-  fun `handles a 1 digit day cert-expiry-date header that expires in over 30 days`() {
-    // test clock is 8th May 2026 - + 31 days
-    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Jun 8 12:30:10 2026 GMT")
-    val finalFilter = mock(Filter::class.java)
-    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-06-08T12:30:10Z")
-    verify(mockTelemetryService, times(0)).captureMessage(any())
-  }
-
-  @Test
-  fun `handles a 2 digit day cert-expiry-date header that expires in 30 days`() {
-    // test clock is 8th May 2026 + 30 days
-    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Jun 7 12:30:10 2026 GMT")
-    val finalFilter = mock(Filter::class.java)
-    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-06-07T12:30:10Z")
-    verify(mockTelemetryService, times(1)).captureMessage("The certificate for $exampleConsumer will expire on Jun 7 12:30:10 2026 GMT (in 30 days)")
-  }
-
-  @Test
-  fun `handles a cert-expiry-date header that expires in 1 day`() {
-    // test clock is 8th May 2026 + 1 day
+  fun `handles a cert-expiry-date header `() {
     whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("May 9 00:30:10 2026 GMT")
+    whenever(authorisationService.processCertificateExpiryDate(any(), any())).thenReturn("2026-05-09T00:30:10Z")
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-05-09T00:30:10Z")
-    verify(mockTelemetryService, times(1)).captureMessage("The certificate for $exampleConsumer will expire on May 9 00:30:10 2026 GMT (in 1 day)")
-  }
-
-  @Test
-  fun `handles an invalid format cert-expiry-date header and logs to sentry`() {
-    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Wrong format")
-    val finalFilter = mock(Filter::class.java)
-    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(0)).setSpanAttribute(eq("certExpiryDate"), any())
-    val exception = argumentCaptor<Throwable>()
-    verify(mockTelemetryService, times(1)).captureException(exception.capture())
-    assertThat(exception.firstValue.message).contains("Failed to parse certificate expiry date")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -385,7 +385,6 @@ class AuthorisationFilterTest {
   }
 
   @Test
-
   fun `handles a on behalf of header`() {
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
@@ -399,12 +400,33 @@ class AuthorisationFilterTest {
   }
 
   @Test
-  fun `handles a cert-expiry-date header `() {
+  fun `handles a 1 digit day cert-expiry-date header `() {
     whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Aug 5 00:28:21 2026 GMT")
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "Aug 5 00:28:21 2026 GMT")
+    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-08-05T00:28:21Z")
+  }
+
+  @Test
+  fun `handles a 2 digit day cert-expiry-date header `() {
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Jan 15 15:28:21 2026 GMT")
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
+    val finalFilter = mock(Filter::class.java)
+    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
+    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-01-15T15:28:21Z")
+  }
+
+  @Test
+  fun `handles an invalid format cert-expiry-date header and logs to sentry`() {
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Wrong format")
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
+    val finalFilter = mock(Filter::class.java)
+    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
+    verify(mockTelemetryService, times(0)).setSpanAttribute(eq("certExpiryDate"), any())
+    val exception = argumentCaptor<Throwable>()
+    verify(mockTelemetryService, times(1)).captureException(exception.capture())
+    assertThat(exception.firstValue.message).contains("Failed to parse certificate expiry date")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -27,10 +27,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
-import java.time.Clock
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
 
 private const val CERT_SERIAL_RAW = "9572494320151578633330348943480876283449388176"
 private const val CERT_SERIAL_FORMATTED = "01:AD:3E:D8:7D:D5:AA:84:F5:2D:83:E7:87:E9:90:E4:84:C5:2C:90"
@@ -48,8 +44,6 @@ class AuthorisationFilterTest {
   private val authorisationService = mock(AuthorisationService::class.java)
   private val featureFlagConfig = mock(FeatureFlagConfig::class.java)
   private val mockTelemetryService = mock(TelemetryService::class.java)
-  private val fixedClock: Clock = Clock.fixed(LocalDateTime.of(2026, 5, 8, 12, 30, 10).toInstant(ZoneOffset.UTC), ZoneId.systemDefault())
-
   private val roleConfig = ConsumerConfig(roles = listOf("private-prison"), filters = ConsumerFilters(prisons = listOf("MDI")))
   private val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
 
@@ -88,7 +82,6 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
         mockTelemetryService,
-        fixedClock,
       )
     return authService
   }
@@ -136,7 +129,6 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
         mockTelemetryService,
-        fixedClock,
       )
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
@@ -155,7 +147,6 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
         mockTelemetryService,
-        fixedClock,
       )
     // invalid Role Config
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
@@ -200,7 +191,6 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
         mockTelemetryService,
-        fixedClock,
       )
     // invalid Role Config
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
@@ -220,7 +210,6 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
         mockTelemetryService,
-        fixedClock,
       )
     val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     whenever(mockChain.doFilter(mockRequest, mockResponse)).thenThrow(ServletException(LimitedAccessException()))
@@ -285,7 +274,6 @@ class AuthorisationFilterTest {
       AuthorisationService(
         AuthorisationConfig(mapOf("consumer-name" to config)),
         mockTelemetryService,
-        fixedClock,
       )
 
     val req = mockRequest("GET", examplePath, "O=test,CN=consumer-name")
@@ -312,7 +300,6 @@ class AuthorisationFilterTest {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock,
       )
 
     val req = mockRequest("GET", examplePath, "O=test,CN=consumer-name")
@@ -337,7 +324,6 @@ class AuthorisationFilterTest {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock,
       )
 
     val req = mockRequest("GET", examplePath, "O=test,CN=consumer-name")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -28,6 +28,10 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 private const val CERT_SERIAL_RAW = "9572494320151578633330348943480876283449388176"
 private const val CERT_SERIAL_FORMATTED = "01:AD:3E:D8:7D:D5:AA:84:F5:2D:83:E7:87:E9:90:E4:84:C5:2C:90"
@@ -45,8 +49,10 @@ class AuthorisationFilterTest {
   private val authorisationService = mock(AuthorisationService::class.java)
   private val featureFlagConfig = mock(FeatureFlagConfig::class.java)
   private val mockTelemetryService = mock(TelemetryService::class.java)
+  private val fixedClock: Clock = Clock.fixed(LocalDateTime.of(2026, 5, 8, 12, 30, 10).toInstant(ZoneOffset.UTC), ZoneId.systemDefault())
 
   private val roleConfig = ConsumerConfig(roles = listOf("private-prison"), filters = ConsumerFilters(prisons = listOf("MDI")))
+  private val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
 
   @BeforeEach
   fun setup() {
@@ -97,7 +103,7 @@ class AuthorisationFilterTest {
     finalFilter: Filter = mock(Filter::class.java),
   ): MockFilterChain =
     mockFilterChain(
-      AuthorisationFilter(authService, mockTelemetryService),
+      AuthorisationFilter(authService, mockTelemetryService, fixedClock),
       finalFilter,
     )
 
@@ -111,7 +117,7 @@ class AuthorisationFilterTest {
 
     val chain =
       mockFilterChain(
-        AuthorisationFilter(authService, mockTelemetryService),
+        AuthorisationFilter(authService, mockTelemetryService, fixedClock),
         finalFilter,
       )
 
@@ -129,7 +135,7 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
       )
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
     val finalFilter = mock(Filter::class.java)
 
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -147,7 +153,7 @@ class AuthorisationFilterTest {
         ),
       )
     // invalid Role Config
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
     val finalFilter = mock(Filter::class.java)
 
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
@@ -163,7 +169,7 @@ class AuthorisationFilterTest {
     val req = mockRequest("GET", invalidPath)
     req.setAttribute("clientName", exampleConsumer)
 
-    val chain = mockFilterChain(AuthorisationFilter(authService, mockTelemetryService))
+    val chain = mockFilterChain(AuthorisationFilter(authService, mockTelemetryService, fixedClock))
 
     chain.doFilter(req, resp)
 
@@ -174,7 +180,7 @@ class AuthorisationFilterTest {
   @Test
   fun `generates error when subject distinguished name is null in the request`() {
     whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
 
     verify(mockResponse, times(1)).sendError(403, "No subject-distinguished-name header provided for authorisation")
@@ -190,7 +196,7 @@ class AuthorisationFilterTest {
         ),
       )
     // invalid Role Config
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
     whenever(mockChain.doFilter(mockRequest, mockResponse)).thenThrow(ServletException(LimitedAccessException()))
 
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -207,8 +213,7 @@ class AuthorisationFilterTest {
           roles = mapOf(roleName to Role(name = "test", permissions = mutableListOf(examplePath), filters = null)),
         ),
       )
-    // whenever(authorisationService.consumers()).thenReturn(mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)))
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
     whenever(mockChain.doFilter(mockRequest, mockResponse)).thenThrow(ServletException(LimitedAccessException()))
 
     authorisationFilter.doFilter(mockRequest, mockResponse, mockChain)
@@ -221,7 +226,7 @@ class AuthorisationFilterTest {
     whenever(authorisationService.certificateRevocationList()).thenReturn(listOf(CERT_SERIAL_FORMATTED, "TEST_SERIAL_NUMBER_2"))
     whenever(authorisationService.consumers()).thenReturn(mapOf(exampleConsumer to ConsumerConfig(include = emptyList(), filters = ConsumerFilters(prisons = null), roles = exampleRoles)))
     val resp = MockHttpServletResponse()
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, fixedClock)
     mockFilterChain(authorisationFilter).doFilter(mockRequest, resp)
     assertThat(resp.status).isEqualTo(403)
     assertThat(resp.errorMessage).isEqualTo("Certificate with serial number 01:AD:3E:D8:7D:D5:AA:84:F5:2D:83:E7:87:E9:90:E4:84:C5:2C:90 has been revoked")
@@ -231,7 +236,6 @@ class AuthorisationFilterTest {
   fun `NOT Forbidden if certificate serial number is in the certificate revocation list and feature flag is enabled`() {
     whenever(authorisationService.certificateRevocationList()).thenReturn(listOf("TEST_SERIAL_NUMBER_3", "TEST_SERIAL_NUMBER_4"))
     val resp = MockHttpServletResponse()
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     mockFilterChain(authorisationFilter).doFilter(mockRequest, resp)
     assertThat(resp.errorMessage).isNotEqualTo("Certificate with serial number 01:AD:3E:D8:7D:D5:AA:84:F5:2D:83:E7:87:E9:90:E4:84:C5:2C:90 has been revoked")
   }
@@ -348,7 +352,6 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles clientName attribute`() {
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(1)).setSpanAttribute("clientId", exampleConsumer)
@@ -357,7 +360,6 @@ class AuthorisationFilterTest {
   @Test
   fun `handles missing clientName attribute`() {
     whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(0)).setSpanAttribute("clientId", exampleConsumer)
@@ -365,7 +367,6 @@ class AuthorisationFilterTest {
 
   @Test
   fun `handles a certificate serial number header`() {
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(1)).setSpanAttribute("certSerialNumber", CERT_SERIAL_FORMATTED)
@@ -374,16 +375,22 @@ class AuthorisationFilterTest {
   @Test
   fun `handles a NULL certificate serial number header`() {
     whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(null)
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(0)).setSpanAttribute("certSerialNumber", CERT_SERIAL_FORMATTED)
   }
 
   @Test
+
+  fun `handles a on behalf of header`() {
+    val finalFilter = mock(Filter::class.java)
+    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
+    verify(mockTelemetryService, times(1)).setSpanAttribute("onBehalfOf", "testName")
+  }
+
+  @Test
   fun `handles a NULL on behalf of header`() {
     whenever(mockRequest.getHeader("X-On-Behalf-Of")).thenReturn(null)
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(0)).setSpanAttribute("onBehalfOf", "testName")
@@ -393,34 +400,44 @@ class AuthorisationFilterTest {
   fun `returns the default consumer name when there is a default consumer name and no subject distinguished name`() {
     whenever(mockRequest.getHeader("subject-distinguished-name")).thenReturn(null)
     whenever(authorisationService.defaultConsumerName()).thenReturn("defaultConsumerName")
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(1)).setSpanAttribute("clientId", "defaultConsumerName")
   }
 
   @Test
-  fun `handles a 1 digit day cert-expiry-date header `() {
-    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Aug 5 00:28:21 2026 GMT")
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
+  fun `handles a 1 digit day cert-expiry-date header that expires in over 30 days`() {
+    // test clock is 8th May 2026 - + 31 days
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Jun 8 12:30:10 2026 GMT")
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-08-05T00:28:21Z")
+    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-06-08T12:30:10Z")
+    verify(mockTelemetryService, times(0)).captureMessage(any())
   }
 
   @Test
-  fun `handles a 2 digit day cert-expiry-date header `() {
-    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Jan 15 15:28:21 2026 GMT")
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
+  fun `handles a 2 digit day cert-expiry-date header that expires in 30 days`() {
+    // test clock is 8th May 2026 + 30 days
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Jun 7 12:30:10 2026 GMT")
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-01-15T15:28:21Z")
+    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-06-07T12:30:10Z")
+    verify(mockTelemetryService, times(1)).captureMessage("The certificate for $exampleConsumer will expire on Jun 7 12:30:10 2026 GMT (in 30 days)")
+  }
+
+  @Test
+  fun `handles a cert-expiry-date header that expires in 1 day`() {
+    // test clock is 8th May 2026 + 1 day
+    whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("May 9 00:30:10 2026 GMT")
+    val finalFilter = mock(Filter::class.java)
+    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
+    verify(mockTelemetryService, times(1)).setSpanAttribute("certExpiryDate", "2026-05-09T00:30:10Z")
+    verify(mockTelemetryService, times(1)).captureMessage("The certificate for $exampleConsumer will expire on May 9 00:30:10 2026 GMT (in 1 day)")
   }
 
   @Test
   fun `handles an invalid format cert-expiry-date header and logs to sentry`() {
     whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn("Wrong format")
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService, mockRoleService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(0)).setSpanAttribute(eq("certExpiryDate"), any())
@@ -432,7 +449,6 @@ class AuthorisationFilterTest {
   @Test
   fun `handles a null cert-expiry-date header `() {
     whenever(mockRequest.getHeader("cert-expiry-date")).thenReturn(null)
-    val authorisationFilter = AuthorisationFilter(authorisationService, mockTelemetryService)
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(0)).setSpanAttribute(eq("certExpiryDate"), any())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -385,13 +385,6 @@ class AuthorisationFilterTest {
   }
 
   @Test
-  fun `handles a on behalf of header`() {
-    val finalFilter = mock(Filter::class.java)
-    mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
-    verify(mockTelemetryService, times(1)).setSpanAttribute("onBehalfOf", "testName")
-  }
-
-  @Test
   fun `handles a NULL on behalf of header`() {
     whenever(mockRequest.getHeader("X-On-Behalf-Of")).thenReturn(null)
     val finalFilter = mock(Filter::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FiltersIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FiltersIntegrationTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory
@@ -35,6 +36,7 @@ class FiltersIntegrationTest : IntegrationTestBase() {
       AuthorisationFilter(
         authorisationService,
         mockTelemetryService,
+        fixedClock(),
       )
     whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(certSerialNumber)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FiltersIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FiltersIntegrationTest.kt
@@ -12,7 +12,6 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.AuthorisationFilter
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory
@@ -36,7 +35,6 @@ class FiltersIntegrationTest : IntegrationTestBase() {
       AuthorisationFilter(
         authorisationService,
         mockTelemetryService,
-        fixedClock(),
       )
     whenever(mockRequest.getHeader("cert-serial-number")).thenReturn(certSerialNumber)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -322,7 +322,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ConsumerConfig(),
           ),
         ),
-        mockTelemetryService
+        mockTelemetryService,
       )
     assertEquals(null, service.oboService("consumer-name"))
   }
@@ -339,7 +339,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ),
           ),
         ),
-        mockTelemetryService
+        mockTelemetryService,
       )
     assertEquals(UnsignedJwtOboService()::class::java, service.oboService("consumer-name")!!::class::java)
   }
@@ -356,7 +356,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ),
           ),
         ),
-        mockTelemetryService
+        mockTelemetryService,
       )
     assertEquals(null, service.oboService("consumer-name"))
   }
@@ -373,7 +373,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ),
           ),
         ),
-        mockTelemetryService
+        mockTelemetryService,
       )
     assertEquals(true, service.requiresObo("consumer-name"))
   }
@@ -388,7 +388,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ConsumerConfig(),
           ),
         ),
-        mockTelemetryService
+        mockTelemetryService,
       )
     assertEquals(false, service.requiresObo("consumer-name"))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
@@ -408,35 +410,35 @@ class AuthorisationServiceTest : ConfigTest() {
     fun `alerts a 2 digit day cert-expiry-date that expires in 30 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("Jun 7 12:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-06-07T12:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on Jun 7 12:30:10 2026 GMT (in 30 days)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on Jun 7 12:30:10 2026 GMT (in under 30 days)")
     }
 
     @Test
     fun `alerts a cert-expiry-date that expires in 21 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 29 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-29T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 29 00:30:10 2026 GMT (in 21 days)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 29 00:30:10 2026 GMT (in under 3 weeks)")
     }
 
     @Test
-    fun `does not alert for a cert-expiry-date that expires in 20 days`() {
+    fun `alerts for a cert-expiry-date that expires in 20 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 28 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-28T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(0)).captureMessage(any())
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 28 00:30:10 2026 GMT (in under 3 weeks)")
     }
 
     @Test
     fun `alerts for a cert-expiry-date that expires in 14 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 22 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-22T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 22 00:30:10 2026 GMT (in 14 days)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 22 00:30:10 2026 GMT (in under 2 weeks)")
     }
 
     @Test
     fun `does not alert for a cert-expiry-date that expires in 12 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 20 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-20T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(0)).captureMessage(any())
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 20 00:30:10 2026 GMT (in under 2 weeks)")
     }
 
     @Test
@@ -466,7 +468,7 @@ class AuthorisationServiceTest : ConfigTest() {
         assertThrows<RuntimeException> {
           authorisationService.processCertificateExpiryDate("May 7 00:30:10 2026 GMT", "consumer-name")
         }
-      assertEquals(exception.message, "Certificate with expiry date May 7 00:30:10 2026 GMT has expired")
+      assertThat(exception.message).isEqualTo("The certificate for consumer-name with expiry date May 7 00:30:10 2026 GMT has expired")
     }
 
     @Test
@@ -476,6 +478,85 @@ class AuthorisationServiceTest : ConfigTest() {
       val exception = argumentCaptor<Throwable>()
       verify(mockTelemetryService, times(1)).captureException(exception.capture())
       assertThat(exception.firstValue.message).contains("Failed to parse certificate expiry date")
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+      longs = [
+        29, 30,
+      ],
+    )
+    fun `creates the same messages for days in the under 30 days category`(days: Long) {
+      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
+      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 30 days)")
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+      longs = [
+        22, 23, 24, 25, 26, 27, 28,
+      ],
+    )
+    fun `creates the same messages for days in the under 4 weeks category`(days: Long) {
+      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
+      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 4 weeks)")
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+      longs = [
+        15, 16, 17, 18, 19, 20, 21,
+      ],
+    )
+    fun `creates the same messages for days in the under 3 weeks category`(days: Long) {
+      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
+      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 3 weeks)")
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+      longs = [
+        8, 9, 10, 11, 12, 13, 14,
+      ],
+    )
+    fun `creates the same messages for days in the under 2 weeks category`(days: Long) {
+      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
+      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 2 weeks)")
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+      longs = [
+        0, 1, 2, 3, 4, 5, 6, 7,
+      ],
+    )
+    fun `creates different messages for days in the under 1 week category`(days: Long) {
+      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
+      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in $days ${if (days == 1L) "day" else "days"})")
+    }
+
+    @Test
+    fun `does not create a message for days over 30`() {
+      val warningMessage = authorisationService.expiryWarningMessage(31, "May 7 00:30:10 2026 GMT", "consumer-name")
+      assertThat(warningMessage).isEqualTo(null)
+    }
+
+    @Test
+    fun `throws an exception when days are negative`() {
+      val exception =
+        assertThrows<RuntimeException> {
+          authorisationService.expiryWarningMessage(-1, "May 7 00:30:10 2026 GMT", "consumer-name")
+        }
+      assertThat(exception.message).isEqualTo("The certificate for consumer-name with expiry date May 7 00:30:10 2026 GMT has expired")
+    }
+
+    @Test
+    fun `creates the correct message`() {
+      val exception =
+        assertThrows<RuntimeException> {
+          authorisationService.expiryWarningMessage(-1, "May 7 00:30:10 2026 GMT", "consumer-name")
+        }
+      assertThat(exception.message).isEqualTo("The certificate for consumer-name with expiry date May 7 00:30:10 2026 GMT has expired")
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -1,16 +1,29 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.ConfigTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.oboconfig.OboConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.laoRedactionPolicy
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.role
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.UnsignedJwtOboService
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -89,6 +102,8 @@ class AuthorisationServiceTest : ConfigTest() {
             "c3" to ConsumerConfig(include = listOf("/other"), filters = null, roles = listOf()),
           ),
         ),
+        mockTelemetryService,
+        fixedClock(),
       )
 
     val matches = authorisationService.consumersWithAccess("/tester")
@@ -110,6 +125,8 @@ class AuthorisationServiceTest : ConfigTest() {
                 - full-access
           """.trimIndent(),
         ),
+        mockTelemetryService,
+        fixedClock(),
       )
 
     val emptyConfig =
@@ -124,6 +141,8 @@ class AuthorisationServiceTest : ConfigTest() {
                 - full-access
           """.trimIndent(),
         ),
+        mockTelemetryService,
+        fixedClock(),
       )
 
     assertEquals(missingConfig.consumers()["tester"]?.permissions(), emptyConfig.consumers()["tester"]?.permissions())
@@ -148,6 +167,8 @@ class AuthorisationServiceTest : ConfigTest() {
           ),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertEquals(filters, ConsumerFilters.Companion.NO_FILTERS)
@@ -179,6 +200,8 @@ class AuthorisationServiceTest : ConfigTest() {
           ),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertFalse(filters == ConsumerFilters.Companion.NO_FILTERS)
@@ -213,6 +236,8 @@ class AuthorisationServiceTest : ConfigTest() {
           ),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertFalse(filters == ConsumerFilters.Companion.NO_FILTERS)
@@ -248,6 +273,8 @@ class AuthorisationServiceTest : ConfigTest() {
           ),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertFalse(filters == ConsumerFilters.Companion.NO_FILTERS)
@@ -271,6 +298,8 @@ class AuthorisationServiceTest : ConfigTest() {
           ),
           roles = mapOf("test-role" to testRole),
         ),
+        mockTelemetryService,
+        fixedClock(),
       )
     assertEquals(listOf(laoRedactionPolicy), service.redactionPolicies("consumer-name"))
   }
@@ -285,6 +314,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ConsumerConfig(),
           ),
         ),
+        mockTelemetryService
       )
     assertEquals(null, service.oboService("consumer-name"))
   }
@@ -301,6 +331,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ),
           ),
         ),
+        mockTelemetryService
       )
     assertEquals(UnsignedJwtOboService()::class::java, service.oboService("consumer-name")!!::class::java)
   }
@@ -317,6 +348,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ),
           ),
         ),
+        mockTelemetryService
       )
     assertEquals(null, service.oboService("consumer-name"))
   }
@@ -333,6 +365,7 @@ class AuthorisationServiceTest : ConfigTest() {
               ),
           ),
         ),
+        mockTelemetryService
       )
     assertEquals(true, service.requiresObo("consumer-name"))
   }
@@ -347,7 +380,102 @@ class AuthorisationServiceTest : ConfigTest() {
               ConsumerConfig(),
           ),
         ),
+        mockTelemetryService
       )
     assertEquals(false, service.requiresObo("consumer-name"))
+  }
+
+  @DisplayName("Handle certificate expiry date")
+  @Nested
+  inner class TestCertificateExpiry {
+    private val fixedClock: Clock = Clock.fixed(LocalDateTime.of(2026, 5, 8, 12, 30, 10).toInstant(ZoneOffset.UTC), ZoneId.systemDefault())
+
+    val authorisationService =
+      AuthorisationService(
+        AuthorisationConfig(),
+        mockTelemetryService,
+        fixedClock,
+      )
+
+    @Test
+    fun `does not alert for a 1 digit day cert-expiry-date that expires in over 30 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("Jun 8 12:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-06-08T12:30:10Z", dateString)
+      verify(mockTelemetryService, times(0)).captureMessage(any())
+    }
+
+    @Test
+    fun `alerts a 2 digit day cert-expiry-date that expires in 30 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("Jun 7 12:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-06-07T12:30:10Z", dateString)
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on Jun 7 12:30:10 2026 GMT (in 30 days)")
+    }
+
+    @Test
+    fun `alerts a cert-expiry-date that expires in 21 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 29 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-29T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 29 00:30:10 2026 GMT (in 21 days)")
+    }
+
+    @Test
+    fun `does not alert for a cert-expiry-date that expires in 20 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 28 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-28T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(0)).captureMessage(any())
+    }
+
+    @Test
+    fun `alerts for a cert-expiry-date that expires in 14 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 22 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-22T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 22 00:30:10 2026 GMT (in 14 days)")
+    }
+
+    @Test
+    fun `does not alert for a cert-expiry-date that expires in 12 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 20 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-20T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(0)).captureMessage(any())
+    }
+
+    @Test
+    fun `alerts for a cert-expiry-date that expires in 7 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 15 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-15T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 15 00:30:10 2026 GMT (in 7 days)")
+    }
+
+    @Test
+    fun `alerts for a cert-expiry-date header that expires in 1 day`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 9 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-09T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 9 00:30:10 2026 GMT (in 1 day)")
+    }
+
+    @Test
+    fun `alerts for a cert-expiry-date header that expires in 0 days`() {
+      val dateString = authorisationService.processCertificateExpiryDate("May 8 00:30:10 2026 GMT", "consumer-name")
+      assertEquals("2026-05-08T00:30:10Z", dateString)
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 8 00:30:10 2026 GMT (in 0 days)")
+    }
+
+    @Test
+    fun `throws an exception if already expired`() {
+      val exception =
+        assertThrows<RuntimeException> {
+          authorisationService.processCertificateExpiryDate("May 7 00:30:10 2026 GMT", "consumer-name")
+        }
+      assertEquals(exception.message, "Certificate with expiry date May 7 00:30:10 2026 GMT has expired")
+    }
+
+    @Test
+    fun `handles an invalid format cert-expiry-date header and logs to sentry`() {
+      val dateString = authorisationService.processCertificateExpiryDate("Wrong format", "consumer-name")
+      assertEquals(null, dateString)
+      val exception = argumentCaptor<Throwable>()
+      verify(mockTelemetryService, times(1)).captureException(exception.capture())
+      assertThat(exception.firstValue.message).contains("Failed to parse certificate expiry date")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -422,56 +422,56 @@ class AuthorisationServiceTest : ConfigTest() {
     fun `alerts a 2 digit day cert-expiry-date that expires in 30 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("Jun 7 12:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-06-07T12:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on Jun 7 12:30:10 2026 GMT (in under 30 days)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in under 30 days (Jun 7 12:30:10 2026 GMT)")
     }
 
     @Test
     fun `alerts a cert-expiry-date that expires in 21 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 29 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-29T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 29 00:30:10 2026 GMT (in under 3 weeks)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in under 3 weeks (May 29 00:30:10 2026 GMT)")
     }
 
     @Test
     fun `alerts for a cert-expiry-date that expires in 20 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 28 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-28T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 28 00:30:10 2026 GMT (in under 3 weeks)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in under 3 weeks (May 28 00:30:10 2026 GMT)")
     }
 
     @Test
     fun `alerts for a cert-expiry-date that expires in 14 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 22 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-22T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 22 00:30:10 2026 GMT (in under 2 weeks)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in under 2 weeks (May 22 00:30:10 2026 GMT)")
     }
 
     @Test
     fun `does not alert for a cert-expiry-date that expires in 12 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 20 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-20T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 20 00:30:10 2026 GMT (in under 2 weeks)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in under 2 weeks (May 20 00:30:10 2026 GMT)")
     }
 
     @Test
     fun `alerts for a cert-expiry-date that expires in 7 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 15 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-15T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 15 00:30:10 2026 GMT (in 7 days)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in 7 days (May 15 00:30:10 2026 GMT)")
     }
 
     @Test
     fun `alerts for a cert-expiry-date header that expires in 1 day`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 9 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-09T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 9 00:30:10 2026 GMT (in 1 day)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in 1 day (May 9 00:30:10 2026 GMT)")
     }
 
     @Test
     fun `alerts for a cert-expiry-date header that expires in 0 days`() {
       val dateString = authorisationService.processCertificateExpiryDate("May 8 00:30:10 2026 GMT", "consumer-name")
       assertEquals("2026-05-08T00:30:10Z", dateString)
-      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire on May 8 00:30:10 2026 GMT (in 0 days)")
+      verify(mockTelemetryService, times(1)).captureMessage("The certificate for consumer-name will expire in 0 days (May 8 00:30:10 2026 GMT)")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -1,14 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
+import io.kotest.matchers.collections.shouldHaveSize
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.slf4j.Logger
@@ -16,7 +21,6 @@ import org.slf4j.LoggerFactory
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.ConfigTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.oboconfig.OboConfig
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.fixedClock
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.laoRedactionPolicy
@@ -35,6 +39,16 @@ import kotlin.test.assertTrue
 class AuthorisationServiceTest : ConfigTest() {
   companion object {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @JvmStatic
+    fun expiryBandTestArgs() =
+      listOf(
+        Arguments.of(listOf<Long>(0, 1, 2, 3, 4, 5, 6, 7), 8),
+        Arguments.of(listOf<Long>(8, 9, 10, 11, 12, 13, 14), 1),
+        Arguments.of(listOf<Long>(15, 16, 17, 18, 19, 20, 21), 1),
+        Arguments.of(listOf<Long>(22, 23, 24, 25, 26, 27, 28), 1),
+        Arguments.of(listOf<Long>(29, 30), 1),
+      )
   }
 
   val testRole =
@@ -105,7 +119,6 @@ class AuthorisationServiceTest : ConfigTest() {
           ),
         ),
         mockTelemetryService,
-        fixedClock(),
       )
 
     val matches = authorisationService.consumersWithAccess("/tester")
@@ -128,7 +141,6 @@ class AuthorisationServiceTest : ConfigTest() {
           """.trimIndent(),
         ),
         mockTelemetryService,
-        fixedClock(),
       )
 
     val emptyConfig =
@@ -144,7 +156,6 @@ class AuthorisationServiceTest : ConfigTest() {
           """.trimIndent(),
         ),
         mockTelemetryService,
-        fixedClock(),
       )
 
     assertEquals(missingConfig.consumers()["tester"]?.permissions(), emptyConfig.consumers()["tester"]?.permissions())
@@ -170,7 +181,6 @@ class AuthorisationServiceTest : ConfigTest() {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertEquals(filters, ConsumerFilters.Companion.NO_FILTERS)
@@ -203,7 +213,6 @@ class AuthorisationServiceTest : ConfigTest() {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertFalse(filters == ConsumerFilters.Companion.NO_FILTERS)
@@ -239,7 +248,6 @@ class AuthorisationServiceTest : ConfigTest() {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertFalse(filters == ConsumerFilters.Companion.NO_FILTERS)
@@ -276,7 +284,6 @@ class AuthorisationServiceTest : ConfigTest() {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock(),
       ).allFilters(consumer, listOf(role))
 
     assertFalse(filters == ConsumerFilters.Companion.NO_FILTERS)
@@ -301,7 +308,6 @@ class AuthorisationServiceTest : ConfigTest() {
           roles = mapOf("test-role" to testRole),
         ),
         mockTelemetryService,
-        fixedClock(),
       )
     assertEquals(listOf(laoRedactionPolicy), service.redactionPolicies("consumer-name"))
   }
@@ -388,6 +394,7 @@ class AuthorisationServiceTest : ConfigTest() {
   }
 
   @DisplayName("Handle certificate expiry date")
+  @TestInstance(TestInstance.Lifecycle.PER_CLASS)
   @Nested
   inner class TestCertificateExpiry {
     private val fixedClock: Clock = Clock.fixed(LocalDateTime.of(2026, 5, 8, 12, 30, 10).toInstant(ZoneOffset.UTC), ZoneId.systemDefault())
@@ -398,6 +405,11 @@ class AuthorisationServiceTest : ConfigTest() {
         mockTelemetryService,
         fixedClock,
       )
+
+    @BeforeEach
+    fun setUp() {
+      reset(mockTelemetryService)
+    }
 
     @Test
     fun `does not alert for a 1 digit day cert-expiry-date that expires in over 30 days`() {
@@ -480,78 +492,25 @@ class AuthorisationServiceTest : ConfigTest() {
       assertThat(exception.firstValue.message).contains("Failed to parse certificate expiry date")
     }
 
-    @ParameterizedTest
-    @ValueSource(
-      longs = [
-        29, 30,
-      ],
-    )
-    fun `creates the same messages for days in the under 30 days category`(days: Long) {
-      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
-      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 30 days)")
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-      longs = [
-        22, 23, 24, 25, 26, 27, 28,
-      ],
-    )
-    fun `creates the same messages for days in the under 4 weeks category`(days: Long) {
-      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
-      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 4 weeks)")
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-      longs = [
-        15, 16, 17, 18, 19, 20, 21,
-      ],
-    )
-    fun `creates the same messages for days in the under 3 weeks category`(days: Long) {
-      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
-      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 3 weeks)")
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-      longs = [
-        8, 9, 10, 11, 12, 13, 14,
-      ],
-    )
-    fun `creates the same messages for days in the under 2 weeks category`(days: Long) {
-      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
-      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in under 2 weeks)")
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-      longs = [
-        0, 1, 2, 3, 4, 5, 6, 7,
-      ],
-    )
-    fun `creates different messages for days in the under 1 week category`(days: Long) {
-      val warningMessage = authorisationService.expiryWarningMessage(days, "May 7 00:30:10 2026 GMT", "consumer-name")
-      assertThat(warningMessage).isEqualTo("The certificate for consumer-name will expire on May 7 00:30:10 2026 GMT (in $days ${if (days == 1L) "day" else "days"})")
-    }
-
     @Test
     fun `does not create a message for days over 30`() {
       val warningMessage = authorisationService.expiryWarningMessage(31, "May 7 00:30:10 2026 GMT", "consumer-name")
       assertThat(warningMessage).isEqualTo(null)
     }
 
-    @Test
-    fun `throws an exception when days are negative`() {
-      val exception =
-        assertThrows<RuntimeException> {
-          authorisationService.expiryWarningMessage(-1, "May 7 00:30:10 2026 GMT", "consumer-name")
-        }
-      assertThat(exception.message).isEqualTo("The certificate for consumer-name with expiry date May 7 00:30:10 2026 GMT has expired")
+    @ParameterizedTest
+    @MethodSource("uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationServiceTest#expiryBandTestArgs")
+    fun `creates the same message for each band`(
+      days: List<Long>,
+      expectedNumberOfDistinctMessages: Int,
+    ) {
+      val certificateExpiry = "May 7 00:30:10 2026 GMT"
+      val messages = days.map { days -> authorisationService.expiryWarningMessage(days, certificateExpiry, "consumer-name") }
+      messages.toSet().shouldHaveSize(expectedNumberOfDistinctMessages)
     }
 
     @Test
-    fun `creates the correct message`() {
+    fun `throws an exception when days are negative`() {
       val exception =
         assertThrows<RuntimeException> {
           authorisationService.expiryWarningMessage(-1, "May 7 00:30:10 2026 GMT", "consumer-name")


### PR DESCRIPTION
For the cert expiry date, API gateway send us the notAfter date in the format

e.g `Aug 5 00:28:21 2026 GMT`

This PR converts this to the ISO-6801 format so it is easier to work with
e.g `2026-08-05T00:28:21Z`

This then captures the expiry date in the ISO-6801 format in an app insights Span attribute.

If the number of days to expiry is within the range 1-30, then a message will be logged to sentry
e.g
`The certificate for [consumer-name] will expire on Aug 5 00:28:21 2026 GMT (in 30 days)`
