### PR TITLE
HIA-1428: Upgrade hmpps.gradle-spring-boot to 10.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.2.5"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "10.3.1"
   kotlin("plugin.spring") version "2.3.21"
   id("dev.detekt") version "2.0.0-alpha.3"
   id("org.jetbrains.kotlinx.kover") version "0.9.8"


### PR DESCRIPTION
Fixes
CVE-2026-43515
CVE-2026-43514
CVE-2026-41293
CVE-2026-41284 
CVE-2026-43512
CVE-2026-42498

Passing OWASP
https://github.com/ministryofjustice/hmpps-integration-api/pull/1760