### PR TITLE
HIA-1372 Validate JWT using JWKS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -181,12 +181,13 @@ class AuthorisationService(
   fun allNull(vararg values: List<Any>?) = values.all { it == null }
 
   private val entraJwksUrl = URI.create("https://login.microsoftonline.com/common/discovery/v2.0/keys").toURL()
+  private val entraOboService = JwksOboService(entraJwksUrl, "unique_name")
 
   fun oboService(consumerName: String): OboService? {
     val oboServiceName = authorisationConfig.consumers[consumerName]?.oboConfig?.strategy
     return when (oboServiceName) {
       "unsigned" -> UnsignedJwtOboService()
-      "entra" -> JwksOboService(entraJwksUrl, "unique_name")
+      "entra" -> entraOboService // reuse the same instance to benefit from JWKS caching
       else -> null
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Role
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.JwksOboService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.OboService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.UnsignedJwtOboService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
@@ -182,7 +183,7 @@ class AuthorisationService(
     val oboServiceName = authorisationConfig.consumers[consumerName]?.oboConfig?.strategy
     return when (oboServiceName) {
       "unsigned" -> UnsignedJwtOboService()
-      "entra" -> null // EntraJwtOboService()
+      "entra" -> JwksOboService()
       else -> null
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.Jwks
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.OboService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.UnsignedJwtOboService
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
+import java.net.URI
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
@@ -179,11 +180,13 @@ class AuthorisationService(
 
   fun allNull(vararg values: List<Any>?) = values.all { it == null }
 
+  private val entraJwksUrl = URI.create("https://login.microsoftonline.com/common/discovery/v2.0/keys").toURL()
+
   fun oboService(consumerName: String): OboService? {
     val oboServiceName = authorisationConfig.consumers[consumerName]?.oboConfig?.strategy
     return when (oboServiceName) {
       "unsigned" -> UnsignedJwtOboService()
-      "entra" -> JwksOboService()
+      "entra" -> JwksOboService(entraJwksUrl, "unique_name")
       else -> null
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.Jwks
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -22,14 +23,19 @@ class JwksOboService(
   override fun extractUsername(token: String): String? {
     loadJwks()
 
-    val jwt =
-      Jwts
-        .parser()
-        .keyLocator { header -> keyCache[header["kid"]] }
-        .build()
-        .parseSignedClaims(token)
+    try {
+      val jwt =
+        Jwts
+          .parser()
+          .keyLocator { header -> keyCache[header["kid"]] }
+          .build()
+          .parseSignedClaims(token)
 
-    return jwt?.payload[usernameClaim]?.toString()
+      return jwt?.payload[usernameClaim]?.toString()
+    } catch (e: UnsupportedJwtException) {
+      log.error("Unable to parse JWT", e)
+      return null
+    }
   }
 
   fun loadJwks() {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -21,7 +21,9 @@ class JwksOboService(
   }
 
   enum class KeyStatus {
-    NEW, LOADED, FAILED,
+    NEW,
+    LOADED,
+    FAILED,
   }
 
   private var keyStatus: KeyStatus = KeyStatus.NEW
@@ -54,18 +56,19 @@ class JwksOboService(
 
     val jwkParser = Jwks.parser().build()
 
-    val jsonContent = try {
-      jwks
-        .openStream()
-        .bufferedReader()
-        .use { reader ->
-          jacksonObjectMapper().readTree(reader)
-        }
-    } catch (e: Exception) {
-      keyStatus = KeyStatus.FAILED
-      log.error("Unable to load and parse JWKs from ${jwks}", e)
-      return
-    }
+    val jsonContent =
+      try {
+        jwks
+          .openStream()
+          .bufferedReader()
+          .use { reader ->
+            jacksonObjectMapper().readTree(reader)
+          }
+      } catch (e: Exception) {
+        keyStatus = KeyStatus.FAILED
+        log.error("Unable to load and parse JWKs from $jwks", e)
+        return
+      }
 
     log.debug(jsonContent.toString())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -20,6 +20,12 @@ class JwksOboService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  enum class KeyStatus {
+    NEW, LOADED, FAILED,
+  }
+
+  private var keyStatus: KeyStatus = KeyStatus.NEW
+
   private val keyCache: MutableMap<String, Key> = mutableMapOf()
 
   override fun extractUsername(token: String): String? {
@@ -41,7 +47,7 @@ class JwksOboService(
   }
 
   fun loadJwks() {
-    if (!keyCache.isEmpty()) {
+    if (keyStatus() == KeyStatus.LOADED) {
       log.debug("Using cached JWKS")
       return
     }
@@ -56,6 +62,7 @@ class JwksOboService(
           jacksonObjectMapper().readTree(reader)
         }
     } catch (e: Exception) {
+      keyStatus = KeyStatus.FAILED
       log.error("Unable to load and parse JWKs from ${jwks}", e)
       return
     }
@@ -68,8 +75,11 @@ class JwksOboService(
       },
     )
 
+    keyStatus = KeyStatus.LOADED
     log.info("Loaded {} public keys from {}}", keyCache.size, jwks.toString())
   }
 
   fun keyCount() = keyCache.size
+
+  fun keyStatus() = keyStatus
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -20,7 +20,7 @@ class JwksOboService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  val keyCache: MutableMap<String?, Key?> = mutableMapOf()
+  private val keyCache: MutableMap<String, Key> = mutableMapOf()
 
   override fun extractUsername(token: String): String? {
     loadJwks()
@@ -48,13 +48,17 @@ class JwksOboService(
 
     val jwkParser = Jwks.parser().build()
 
-    val jsonContent =
+    val jsonContent = try {
       jwks
         .openStream()
         .bufferedReader()
         .use { reader ->
           jacksonObjectMapper().readTree(reader)
         }
+    } catch (e: Exception) {
+      log.error("Unable to load and parse JWKs from ${jwks}", e)
+      return
+    }
 
     log.debug(jsonContent.toString())
 
@@ -66,4 +70,6 @@ class JwksOboService(
 
     log.info("Loaded {} public keys from {}}", keyCache.size, jwks.toString())
   }
+
+  fun keyCount() = keyCache.size
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.Jwks
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -32,7 +32,7 @@ class JwksOboService(
           .parseSignedClaims(token)
 
       return jwt?.payload[usernameClaim]?.toString()
-    } catch (e: UnsupportedJwtException) {
+    } catch (e: JwtException) {
       log.error("Unable to parse JWT", e)
       return null
     }
@@ -54,7 +54,7 @@ class JwksOboService(
           jacksonObjectMapper().readTree(reader)
         }
 
-    log.info(jsonContent.toString())
+    log.debug(jsonContent.toString())
 
     keyCache.putAll(
       jsonContent["keys"].associate {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -40,9 +40,13 @@ class JwksOboService(
 
     val jwkParser = Jwks.parser().build()
 
-    val jsonContent = jwks.openStream().bufferedReader().use { reader ->
-      jacksonObjectMapper().readTree(reader)
-    }
+    val jsonContent =
+      jwks
+        .openStream()
+        .bufferedReader()
+        .use { reader ->
+          jacksonObjectMapper().readTree(reader)
+        }
 
     log.info(jsonContent.toString())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -6,13 +6,15 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Jwks
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.net.URI
 import java.net.URL
 import java.security.Key
 
+/**
+ * An on-behalf-of service implementation that validates JWTs using JWKS.
+ */
 class JwksOboService(
-  val jwks: URL = URI.create("https://login.microsoftonline.com/common/discovery/v2.0/keys").toURL(),
-  val usernameClaim: String = "unique_name",
+  val jwks: URL,
+  val usernameClaim: String,
 ) : OboService {
   private companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboService.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Jwks
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.URL
+import java.security.Key
+
+class JwksOboService(
+  val jwks: URL = URI.create("https://login.microsoftonline.com/common/discovery/v2.0/keys").toURL(),
+  val usernameClaim: String = "unique_name",
+) : OboService {
+  private companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  val keyCache: MutableMap<String?, Key?> = mutableMapOf()
+
+  override fun extractUsername(token: String): String? {
+    loadJwks()
+
+    val jwt =
+      Jwts
+        .parser()
+        .keyLocator { header -> keyCache[header["kid"]] }
+        .build()
+        .parseSignedClaims(token)
+
+    return jwt?.payload[usernameClaim]?.toString()
+  }
+
+  fun loadJwks() {
+    if (!keyCache.isEmpty()) {
+      log.debug("Using cached JWKS")
+      return
+    }
+
+    val jwkParser = Jwks.parser().build()
+
+    val jsonContent = jwks.openStream().bufferedReader().use { reader ->
+      jacksonObjectMapper().readTree(reader)
+    }
+
+    log.info(jsonContent.toString())
+
+    keyCache.putAll(
+      jsonContent["keys"].associate {
+        it["kid"].asText() to jwkParser.parse(it.toString()).toKey()
+      },
+    )
+
+    log.info("Loaded {} public keys from {}}", keyCache.size, jwks.toString())
+  }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -232,6 +232,8 @@ authorisation:
       notes: "See client list in Confluence"
       roles:
         - "status-only"
+      oboConfig:
+        strategy: "entra"
 
 hmpps.sqs:
   queues:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/OnBehalfOfIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/OnBehalfOfIntegrationTest.kt
@@ -36,7 +36,7 @@ class OnBehalfOfIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `if oboConfig is entra, and a Jwt is provided, return unauthorized`() {
+  fun `if oboConfig is entra, and an unsigned Jwt is provided, return unauthorized`() {
     callApiWithCN("/v1/status", "obo-entra", oboValue = createUnsignedJwt())
       .andExpect(MockMvcResultMatchers.status().isUnauthorized)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -26,6 +27,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.laoRedactionPolicy
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.role
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.JwksOboService
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.JwksOboServiceTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.UnsignedJwtOboService
 import java.time.Clock
 import java.time.LocalDateTime
@@ -346,7 +349,7 @@ class AuthorisationServiceTest : ConfigTest() {
   }
 
   @Test
-  fun `returns null for entra oboConfig`() {
+  fun `returns valid entra oboConfig`() {
     val service =
       AuthorisationService(
         AuthorisationConfig(
@@ -359,7 +362,7 @@ class AuthorisationServiceTest : ConfigTest() {
         ),
         mockTelemetryService,
       )
-    assertNotNull(service.oboService("consumer-name"))
+    assertEquals(JwksOboService::class, service.oboService("consumer-name")!!::class)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -358,7 +359,7 @@ class AuthorisationServiceTest : ConfigTest() {
         ),
         mockTelemetryService,
       )
-    assertEquals(null, service.oboService("consumer-name"))
+    assertNotNull(service.oboService("consumer-name"))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.assertInstanceOf
-import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -28,7 +26,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.Consum
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.laoRedactionPolicy
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.role
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.JwksOboService
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.JwksOboServiceTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.UnsignedJwtOboService
 import java.time.Clock
 import java.time.LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -26,10 +26,12 @@ class JwksOboServiceTest :
 
       it("loads the JWKS") {
         service.keyCount() shouldBe 0
+        service.keyStatus() shouldBe JwksOboService.KeyStatus.NEW
 
         service.loadJwks()
 
         service.keyCount() shouldBe 1
+        service.keyStatus() shouldBe JwksOboService.KeyStatus.LOADED
       }
 
       it("parses a JWT using JWKS") {
@@ -53,8 +55,11 @@ class JwksOboServiceTest :
       it("doesn't crash on JWKS loading error") {
         val badUri = URI.create("http://localhost:98765/").toURL()
         val badService = JwksOboService(badUri, "subject")
+
         badService.loadJwks()
+
         badService.keyCount() shouldBe 0
+        badService.keyStatus() shouldBe JwksOboService.KeyStatus.FAILED
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -21,7 +21,7 @@ class JwksOboServiceTest :
 
       val keyPair = generateKeyPair()
       val jwksUri = buildJwks(keyPair, kid)
-      val service = JwksOboService(jwksUri)
+      val service = JwksOboService(jwksUri, "subject")
 
       it("loads the JWKS") {
         service.loadJwks()
@@ -60,7 +60,7 @@ private fun makeJwt(
     .subject(username)
     .issuedAt(Date.from(Instant.now()))
     .expiration(Date.from(Instant.now().plusSeconds(3600)))
-    .claim("unique_name", username)
+    .claim("subject", username)
     .signWith(signingKey)
     .compact()!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -2,9 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.jsonwebtoken.Jwts
-import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.Jwks
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.shouldBe
@@ -37,9 +35,8 @@ class JwksOboServiceTest :
 
       it("fails if KID not found") {
         val jwt = makeJwt("XYZ-987", "tester2", keyPair.private)
-        shouldThrow<UnsupportedJwtException> {
-          service.extractUsername(jwt)
-        }
+        val jwtUser = service.extractUsername(jwt)
+        jwtUser shouldBe null
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -6,6 +6,7 @@ import io.jsonwebtoken.security.Jwks
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.engine.spec.tempfile
 import io.kotest.matchers.shouldBe
+import java.net.URI
 import java.net.URL
 import java.security.KeyPair
 import java.security.KeyPairGenerator
@@ -24,7 +25,11 @@ class JwksOboServiceTest :
       val service = JwksOboService(jwksUri, "subject")
 
       it("loads the JWKS") {
+        service.keyCount() shouldBe 0
+
         service.loadJwks()
+
+        service.keyCount() shouldBe 1
       }
 
       it("parses a JWT using JWKS") {
@@ -34,7 +39,7 @@ class JwksOboServiceTest :
       }
 
       it("fails if KID not found") {
-        val jwt = makeJwt("XYZ-987", "tester2", keyPair.private)
+        val jwt = makeJwt("BAD-KID", "tester2", keyPair.private)
         val jwtUser = service.extractUsername(jwt)
         jwtUser shouldBe null
       }
@@ -43,6 +48,13 @@ class JwksOboServiceTest :
         val jwt = makeJwt(kid, "tester3", generateKeyPair().private)
         val jwtUser = service.extractUsername(jwt)
         jwtUser shouldBe null
+      }
+
+      it("doesn't crash on JWKS loading error") {
+        val badUri = URI.create("http://localhost:98765/").toURL()
+        val badService = JwksOboService(badUri, "subject")
+        badService.loadJwks()
+        badService.keyCount() shouldBe 0
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.UnsupportedJwtException
+import io.jsonwebtoken.security.Jwks
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.shouldBe
+import java.net.URL
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.time.Instant
+import java.util.Date
+
+class JwksOboServiceTest :
+  DescribeSpec(
+    {
+      val kid = "ABC-123"
+      val username = "tester1"
+
+      val keyPair = generateKeyPair()
+      val jwksUri = buildJwks(keyPair, kid)
+      val service = JwksOboService(jwksUri)
+
+      it("loads the JWKS") {
+        service.loadJwks()
+      }
+
+      it("parses a JWT using JWKS") {
+        val jwt = makeJwt(kid, username, keyPair.private)!!
+        val jwtUser = service.extractUsername(jwt)
+        jwtUser shouldBe username
+      }
+
+      it("fails if KID not found") {
+        val jwt = makeJwt("XYZ-987", username, keyPair.private)!!
+        shouldThrow<UnsupportedJwtException> {
+          service.extractUsername(jwt)
+        }
+      }
+    },
+  )
+
+private fun makeJwt(
+  kid: String,
+  username: String,
+  signingKey: PrivateKey,
+): String = Jwts
+  .builder()
+  .header()
+  .keyId(kid)
+  .and()
+  .subject(username)
+  .issuedAt(Date.from(Instant.now()))
+  .expiration(Date.from(Instant.now().plusSeconds(3600)))
+  .claim("unique_name", username)
+  .signWith(signingKey)
+  .compact()!!
+
+private fun generateKeyPair(): KeyPair {
+  val keyGenerator = KeyPairGenerator.getInstance("RSA")
+  keyGenerator.initialize(2048)
+  val keyPair = keyGenerator.generateKeyPair()
+  return keyPair!!
+}
+
+private fun DescribeSpec.buildJwks(keyPair: KeyPair, kid: String): URL {
+  val jwk = Jwks.builder().key(keyPair.public as RSAPublicKey).id(kid).algorithm("RS256").build()
+
+  val wrapper = mapOf("keys" to listOf(jwk))
+  val jwksText = ObjectMapper().writeValueAsString(wrapper)
+  println(jwksText)
+  val jwksFile = tempfile("testing", "jwks")
+  jwksFile.deleteOnExit()
+  jwksFile.writeText(jwksText)
+  val uri = jwksFile.toURI().toURL()
+
+  return uri
+}
+
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -38,6 +38,12 @@ class JwksOboServiceTest :
         val jwtUser = service.extractUsername(jwt)
         jwtUser shouldBe null
       }
+
+      it("fails if incorrect key used") {
+        val jwt = makeJwt(kid, "tester3", generateKeyPair().private)
+        val jwtUser = service.extractUsername(jwt)
+        jwtUser shouldBe null
+      }
     },
   )
 
@@ -82,7 +88,6 @@ private fun DescribeSpec.buildJwks(
   val jwksFile = tempfile("testing", "jwks")
   jwksFile.deleteOnExit()
   jwksFile.writeText(jwksText)
-  val uri = jwksFile.toURI().toURL()
 
-  return uri
+  return jwksFile.toURI().toURL()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -49,17 +49,18 @@ private fun makeJwt(
   kid: String,
   username: String,
   signingKey: PrivateKey,
-): String = Jwts
-  .builder()
-  .header()
-  .keyId(kid)
-  .and()
-  .subject(username)
-  .issuedAt(Date.from(Instant.now()))
-  .expiration(Date.from(Instant.now().plusSeconds(3600)))
-  .claim("unique_name", username)
-  .signWith(signingKey)
-  .compact()!!
+): String =
+  Jwts
+    .builder()
+    .header()
+    .keyId(kid)
+    .and()
+    .subject(username)
+    .issuedAt(Date.from(Instant.now()))
+    .expiration(Date.from(Instant.now().plusSeconds(3600)))
+    .claim("unique_name", username)
+    .signWith(signingKey)
+    .compact()!!
 
 private fun generateKeyPair(): KeyPair {
   val keyGenerator = KeyPairGenerator.getInstance("RSA")
@@ -68,8 +69,17 @@ private fun generateKeyPair(): KeyPair {
   return keyPair!!
 }
 
-private fun DescribeSpec.buildJwks(keyPair: KeyPair, kid: String): URL {
-  val jwk = Jwks.builder().key(keyPair.public as RSAPublicKey).id(kid).algorithm("RS256").build()
+private fun DescribeSpec.buildJwks(
+  keyPair: KeyPair,
+  kid: String,
+): URL {
+  val jwk =
+    Jwks
+      .builder()
+      .key(keyPair.public as RSAPublicKey)
+      .id(kid)
+      .algorithm("RS256")
+      .build()
 
   val wrapper = mapOf("keys" to listOf(jwk))
   val jwksText = ObjectMapper().writeValueAsString(wrapper)
@@ -81,5 +91,3 @@ private fun DescribeSpec.buildJwks(keyPair: KeyPair, kid: String): URL {
 
   return uri
 }
-
-

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/onbehalfof/JwksOboServiceTest.kt
@@ -20,7 +20,6 @@ class JwksOboServiceTest :
   DescribeSpec(
     {
       val kid = "ABC-123"
-      val username = "tester1"
 
       val keyPair = generateKeyPair()
       val jwksUri = buildJwks(keyPair, kid)
@@ -31,13 +30,13 @@ class JwksOboServiceTest :
       }
 
       it("parses a JWT using JWKS") {
-        val jwt = makeJwt(kid, username, keyPair.private)!!
+        val jwt = makeJwt(kid, "tester1", keyPair.private)
         val jwtUser = service.extractUsername(jwt)
-        jwtUser shouldBe username
+        jwtUser shouldBe "tester1"
       }
 
       it("fails if KID not found") {
-        val jwt = makeJwt("XYZ-987", username, keyPair.private)!!
+        val jwt = makeJwt("XYZ-987", "tester2", keyPair.private)
         shouldThrow<UnsupportedJwtException> {
           service.extractUsername(jwt)
         }
@@ -83,7 +82,6 @@ private fun DescribeSpec.buildJwks(
 
   val wrapper = mapOf("keys" to listOf(jwk))
   val jwksText = ObjectMapper().writeValueAsString(wrapper)
-  println(jwksText)
   val jwksFile = tempfile("testing", "jwks")
   jwksFile.deleteOnExit()
   jwksFile.writeText(jwksText)


### PR DESCRIPTION
Introduce a `JwksOboService` implementation that loads the public keys for signature validation from a JWKS file, and use it for JWTs signed by the MoJ Entra. The Entra-specific configuration is currently hard-coded in the `AuthorisationService` but could be derived dynamically if needed in future.

The unit tests for `JwksOboService` use a local JWKS and so are entirely self-contained.

https://dsdmoj.atlassian.net/browse/HIA-1406