### PR TITLE
HIA-1410: Remove double whitespace from open ssl not after date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -206,8 +206,10 @@ class AuthorisationService(
   ): String? {
     val expiryDateTime =
       try {
+        // OpenSSL notAfter date still uses 2 characters for a single digit day (with the first blank). eg Jan  8 12:30:10 2026 GMT
+        // Therefore we strip any double whitespaces
         ZonedDateTime
-          .parse(certExpiryDate, DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH))
+          .parse(certExpiryDate.replace("\\s{2,}".toRegex(), " "), DateTimeFormatter.ofPattern("MMM d HH:mm:ss yyyy zzz", Locale.ENGLISH))
           .toInstant()
       } catch (ex: Exception) {
         telemetryService.captureException(RuntimeException("Failed to parse certificate expiry date $certExpiryDate. ${ex.message}"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -484,6 +484,12 @@ class AuthorisationServiceTest : ConfigTest() {
     }
 
     @Test
+    fun `handles an SSL single digit day date with multiple spaces`() {
+      val dateString = authorisationService.processCertificateExpiryDate("Jan  8 11:23:46 2027 GMT", "consumer-name")
+      assertEquals("2027-01-08T11:23:46Z", dateString)
+    }
+
+    @Test
     fun `handles an invalid format cert-expiry-date header and logs to sentry`() {
       val dateString = authorisationService.processCertificateExpiryDate("Wrong format", "consumer-name")
       assertEquals(null, dateString)


### PR DESCRIPTION
OpenSSL notAfter date still uses 2 characters for a single digit day (with the first blank). 
e.g `Jan  8 12:30:10 2026 GMT`
Therefore we strip any double whitespaces