### PR TITLE
HIA-1458: Enable modsec in detection only mode in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,6 +8,11 @@ generic-service:
     host: hmpps-integration-api-dev.apps.live.cloud-platform.service.justice.gov.uk
     annotations:
       nginx.ingress.kubernetes.io/auth-tls-secret: "hmpps-integration-api-dev/client-certificate-auth"
+    modsecurity_enabled: true
+    modsecurity_github_team: "hmpps-integration-api"
+    modsecurity_snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
 
   poddisruptionbudget:
     enabled: false


### PR DESCRIPTION
Added the following config to the dev ingress

```
    modsecurity_enabled: true
    modsecurity_github_team: "hmpps-integration-api"
    modsecurity_snippet: |
      SecAuditEngine On
      SecRuleEngine DetectionOnly
```

Looking at the modsec documentation here: https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html#ingress-annotations

The above annotation enables ModSecurity for the ingress on the nginx ingress-controller in detection only mode. There is no disruptive action if a critical rule triggers, but it is logged in [opensearch](https://logs.cloud-platform.service.justice.gov.uk/_dashboards). The SecRuleEngine defaults to DetectionOnly Mode and the tags help you to find the logs in opensearch.

Setting the `modsecurity_github_team ` in the chart adds the following line to the `modsecurity_snippet`.

`SecDefaultAction "phase:2,pass,log,tag:github_team={{ .Values.ingress.modsecurity_github_team }}"`

This is to identify the logs in opensearch
