### PR TITLE
HIA-1458: Add github team to modsec

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,6 +13,7 @@ generic-service:
     modsecurity_snippet: |
       SecAuditEngine On
       SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-integration-api,tag:namespace={{ .Release.Namespace }}"
 
   poddisruptionbudget:
     enabled: false


### PR DESCRIPTION
Looks like just adding the `modsecurity_github_team` doesnt actually set the `SecDefaultAction` if we have set the `SecRuleEngine` in the `modsecurity_snippet`