### PR TITLE
HIA-1458: Include PUT in modsecs allowed http methods

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,8 @@ generic-service:
       SecAuditEngine On
       SecRuleEngine DetectionOnly
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-integration-api,tag:namespace={{ .Release.Namespace }}"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT.
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT"
 
   poddisruptionbudget:
     enabled: false


### PR DESCRIPTION
The default modsec CRS rule for the http methods a client is allowed to use is
`GET HEAD POST OPTIONS`

See https://github.com/coreruleset/coreruleset/blob/c35d6d4a8793addf54fffb8b65c09cfa08eea7c2/crs-setup.conf.example#L456-L480

This PR includes PUT requests in this rule for integration api