### PR TITLE
HIA-1464: Turn on modsec in detection only mode in preprod and prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,6 +8,14 @@ generic-service:
     host: hmpps-integration-api-preprod.apps.live.cloud-platform.service.justice.gov.uk
     annotations:
       nginx.ingress.kubernetes.io/auth-tls-secret: "hmpps-integration-api-preprod/client-certificate-auth"
+    modsecurity_enabled: true
+    modsecurity_github_team: "hmpps-integration-api"
+    modsecurity_snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-integration-api,tag:namespace={{ .Release.Namespace }}"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT.
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT"
 
   poddisruptionbudget:
     enabled: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,6 +6,14 @@ generic-service:
     host: hmpps-integration-api-prod.apps.live.cloud-platform.service.justice.gov.uk
     annotations:
       nginx.ingress.kubernetes.io/auth-tls-secret: "hmpps-integration-api-prod/client-certificate-auth"
+    modsecurity_enabled: true
+    modsecurity_github_team: "hmpps-integration-api"
+    modsecurity_snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-integration-api,tag:namespace={{ .Release.Namespace }}"
+      # Default is only GET HEAD POST OPTIONS so need to include PUT.
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT"
 
   poddisruptionbudget:
     enabled: false


### PR DESCRIPTION
Turning on modsec in Detection Only mode in preprod and prod

Keeping the enviroment configs separate at the moment so that we can configure each environment independently whilst in detection mode