### PR TITLE
HIA-1448: Remove gateway cache feature flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/CacheConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/CacheConfig.kt
@@ -5,19 +5,16 @@ import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
 import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.caffeine.CaffeineCache
 import org.springframework.cache.interceptor.KeyGenerator
-import org.springframework.cache.support.NoOpCacheManager
 import org.springframework.cache.support.SimpleCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.GATEWAY_CACHE_ENABLED
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.telemetry.TelemetryService
 import java.lang.reflect.Method
 import java.time.Duration
@@ -42,13 +39,7 @@ class CacheConfig {
     )
 
   @Bean
-  fun gatewayCacheEnabled(featureFlagConfig: FeatureFlagConfig): Boolean = featureFlagConfig.isEnabled(GATEWAY_CACHE_ENABLED)
-
-  @Bean
-  fun caffeineCacheManager(gatewayCacheEnabled: Boolean): CacheManager {
-    if (!gatewayCacheEnabled) {
-      return NoOpCacheManager()
-    }
+  fun caffeineCacheManager(): CacheManager {
     val cacheManager = SimpleCacheManager()
     val caches = listOf(gatewayCache())
     cacheManager.setCaches(caches)
@@ -85,7 +76,6 @@ class CacheLogFilter : Filter<ILoggingEvent>() {
 const val GATEWAY_CACHE_METRICS = "GatewayCacheMetrics"
 
 @Component
-@ConditionalOnProperty("feature-flag.gateway-cache-enabled", havingValue = "true")
 @ConditionalOnBean(CaffeineCache::class)
 class CacheMetricsListener(
   private val gatewayCache: CaffeineCache,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CorePersonRecordGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/CorePersonRecordGateway.kt
@@ -46,7 +46,7 @@ class CorePersonRecordGateway(
    * Any exceptions should be thrown at this point and caught at the HmppsIntegrationApiExceptionHandler
    * There is no point passing these exceptions all the way up to a controller just to be thrown and caught by the HmppsIntegrationApiExceptionHandler
    */
-  @Cacheable(GATEWAY_CACHE, keyGenerator = "gatewayKeyGenerator", condition = "@gatewayCacheEnabled")
+  @Cacheable(GATEWAY_CACHE, keyGenerator = "gatewayKeyGenerator")
   fun corePersonRecordFor(
     cprType: IdentifierType, // prison or probation
     hmppsId: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -267,7 +267,7 @@ class NDeliusGateway(
     )
   }
 
-  @Cacheable(GATEWAY_CACHE, keyGenerator = "gatewayKeyGenerator", condition = "@gatewayCacheEnabled")
+  @Cacheable(GATEWAY_CACHE, keyGenerator = "gatewayKeyGenerator")
   fun getOffender(id: String? = null): Response<Offender?> {
     val queryField =
       if (isNomsNumber(id)) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -113,7 +113,7 @@ class PrisonerOffenderSearchGateway(
     }
   }
 
-  @Cacheable(GATEWAY_CACHE, keyGenerator = "gatewayKeyGenerator", condition = "@gatewayCacheEnabled")
+  @Cacheable(GATEWAY_CACHE, keyGenerator = "gatewayKeyGenerator")
   fun getPrisonOffender(nomsNumber: String): Response<POSPrisoner?> {
     val result =
       webClient.request<POSPrisoner>(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -58,7 +58,6 @@ feature-flag:
   epf-endpoint-includes-lao: true
   epf-gateway-disabled: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: true

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -114,7 +114,6 @@ feature-flag:
   csra-endpoint: true
   epf-endpoint-includes-lao: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: true

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -96,7 +96,6 @@ feature-flag:
   use-emergency-contacts-endpoint: true
   epf-endpoint-includes-lao: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -74,7 +74,6 @@ feature-flag:
   csra-endpoint: true
   epf-endpoint-includes-lao: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: false

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -56,7 +56,6 @@ feature-flag:
   epf-endpoint-includes-lao: true
   epf-gateway-disabled: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -56,7 +56,6 @@ feature-flag:
   epf-endpoint-includes-lao: true
   epf-gateway-disabled: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -99,7 +99,6 @@ feature-flag:
   use-emergency-contacts-endpoint: false
   epf-endpoint-includes-lao: true
   cpr-enabled: true
-  gateway-cache-enabled: true
   use-webclient-wrapper-for-hmpps-auth: true
   # Events Config
   enable-delete-processed-events: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/CacheDisabledTestConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/CacheDisabledTestConfiguration.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.cache.CacheManager
+import org.springframework.cache.support.NoOpCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+@TestConfiguration
+class CacheDisabledTestConfiguration {
+  @ConditionalOnProperty("cache-enabled", havingValue = "false")
+  @Primary
+  @Bean("noOpCacheManager")
+  fun caffeineCacheManager(): CacheManager = NoOpCacheManager()
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/CacheIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/CacheIntegrationTest.kt
@@ -5,19 +5,14 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.cache.caffeine.CaffeineCache
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-@TestPropertySource(properties = ["feature-flag.gateway-cache-enabled=true"])
+@TestPropertySource(properties = ["cache-enabled=true"])
 class CacheIntegrationTest : IntegrationTestBase() {
   private final val nomsPath = "/v1/persons/$nomsId"
   private final val crnPath = "/v1/persons/$crn"
   private final val addressPath = "$nomsPath/addresses"
-
-  @Autowired
-  lateinit var cache: CaffeineCache
 
   @Test
   fun `caches prisoner and cpr data when addresses endpoint called twice and feature enabled`() {
@@ -48,42 +43,5 @@ class CacheIntegrationTest : IntegrationTestBase() {
 
     // Calls the cacheable method only once (caches first request)
     verify(nDeliusGateway, times(1)).getOffender(crn)
-  }
-}
-
-class CacheDisabledIntegrationTest : IntegrationTestBase() {
-  private final val nomsPath = "/v1/persons/$nomsId"
-  private final val crnPath = "/v1/persons/$crn"
-  private final val addressPath = "$nomsPath/addresses"
-
-  @Test
-  fun `does not cache prisoner data when addresses endpoint called twice and feature disabled`() {
-    // Request 1
-    callApiWithCN(addressPath, specificPrisonCn)
-      .andExpect(status().isOk)
-
-    // Request 2
-    callApiWithCN(addressPath, specificPrisonCn)
-      .andExpect(status().isOk)
-
-    // Calls the cacheable method twice (does not cache)
-    verify(prisonerOffenderSearchGateway, times(2)).getPrisonOffender(nomsId)
-
-    // Address endpoint calls CPR twice per request. One for nomis and one for crn
-    // Calls the cached CPR method 4 times in total across 2 requests
-    verify(corePersonRecordGateway, times(4)).corePersonRecordFor(any(), eq(nomsId))
-  }
-
-  @Test
-  fun `does not cache offender data when crn endpoint called twice and feature disabled`() {
-    // Request 1
-    callApiWithCN(crnPath, specificPrisonCn)
-      .andExpect(status().isOk)
-
-    // Request 2
-    callApiWithCN(crnPath, specificPrisonCn)
-      .andExpect(status().isOk)
-    // Calls the cacheable method twice (does not cache)
-    verify(nDeliusGateway, times(2)).getOffender(crn)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/CacheIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/CacheIntegrationTest.kt
@@ -45,3 +45,40 @@ class CacheIntegrationTest : IntegrationTestBase() {
     verify(nDeliusGateway, times(1)).getOffender(crn)
   }
 }
+
+class CacheDisabledIntegrationTest : IntegrationTestBase() {
+  private final val nomsPath = "/v1/persons/$nomsId"
+  private final val crnPath = "/v1/persons/$crn"
+  private final val addressPath = "$nomsPath/addresses"
+
+  @Test
+  fun `does not cache prisoner data when addresses endpoint called twice and feature disabled`() {
+    // Request 1
+    callApiWithCN(addressPath, specificPrisonCn)
+      .andExpect(status().isOk)
+
+    // Request 2
+    callApiWithCN(addressPath, specificPrisonCn)
+      .andExpect(status().isOk)
+
+    // Calls the cacheable method twice (does not cache)
+    verify(prisonerOffenderSearchGateway, times(2)).getPrisonOffender(nomsId)
+
+    // Address endpoint calls CPR twice per request. One for nomis and one for crn
+    // Calls the cached CPR method 4 times in total across 2 requests
+    verify(corePersonRecordGateway, times(4)).corePersonRecordFor(any(), eq(nomsId))
+  }
+
+  @Test
+  fun `does not cache offender data when crn endpoint called twice and feature disabled`() {
+    // Request 1
+    callApiWithCN(crnPath, specificPrisonCn)
+      .andExpect(status().isOk)
+
+    // Request 2
+    callApiWithCN(crnPath, specificPrisonCn)
+      .andExpect(status().isOk)
+    // Calls the cacheable method twice (does not cache)
+    verify(nDeliusGateway, times(2)).getOffender(crn)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FilterViolationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/FilterViolationIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration
 
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -11,7 +10,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.prisoneroffenders
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.dsl.objectMapper
 import java.io.File
 
-@TestPropertySource(properties = ["feature-flag.gateway-cache-enabled=false"])
 class FilterViolationIntegrationTest : IntegrationTestBase() {
   private final val nomsPath = "/v1/persons/$nomsId"
   private final val addressPath = "$nomsPath/addresses"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
-import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
@@ -85,9 +84,6 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var mockMvc: MockMvc
-
-  @Autowired
-  lateinit var cacheManager: CacheManager
 
   @BeforeEach
   fun evictAllCaches() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
@@ -11,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.cache.CacheManager
+import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.CacheDisabledTestConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.repository.JdbcTemplateEventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.MockMvcExtensions.writeAsJson
@@ -42,9 +45,10 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 @ActiveProfiles("integration-test")
-@TestPropertySource(properties = ["feature-flag.gateway-cache-enabled=false"])
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = RANDOM_PORT)
+@TestPropertySource(properties = ["cache-enabled=false"])
+@Import(CacheDisabledTestConfiguration::class)
 abstract class IntegrationTestBase {
   @MockitoSpyBean
   lateinit var featureFlagConfig: FeatureFlagConfig
@@ -81,6 +85,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   lateinit var mockMvc: MockMvc
+
+  @Autowired
+  lateinit var cacheManager: CacheManager
 
   @BeforeEach
   fun evictAllCaches() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RolesAuthenticationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RolesAuthenticationIntegrationTest.kt
@@ -2,11 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration
 
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.test.context.TestPropertySource
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.roles
 import kotlin.test.assertTrue
 
-@TestPropertySource(properties = ["feature-flag.gateway-cache-enabled=false"])
 class RolesAuthenticationIntegrationTest : IntegrationTestBase() {
 //  @Test
 //  fun `all endpoints in all roles are authenticated and exist`() {


### PR DESCRIPTION
PR to remove the gateway cache feature flag.
The original integration tests relied on this feature flag to disable caching (Disabled on all tests apart from the cache test).
Therefore i have introduced a new test configuration to handle this.
