### PR TITLE
HIA-1484: Pass obo header to auth for v1/persons (person search)

### DIFF
--- a/scripts/K6/smoke-tests.js
+++ b/scripts/K6/smoke-tests.js
@@ -399,9 +399,6 @@ function validate_person_search(lastName, dob) {
   })
 }
 
-
-
-
 function verify_get_person(hmppsId) {
   let res = validate_get_request(`/v1/persons/${hmppsId}`);
   if (res.status >= 400) {

--- a/scripts/K6/smoke-tests.js
+++ b/scripts/K6/smoke-tests.js
@@ -386,7 +386,7 @@ function verify_contact_events(hmppsId){
 }
 
 function validate_person_search(lastName, dob) {
-  let res = validate_get_request(`/v1/persons?last_name=${lastName}&date_of_birth=${dob}`);
+  let res = validate_get_request_with_obo(`/v1/persons?last_name=${lastName}&date_of_birth=${dob}`);
   if (res.status !== 200) {
     return
   }

--- a/scripts/K6/smoke-tests.js
+++ b/scripts/K6/smoke-tests.js
@@ -386,7 +386,7 @@ function verify_contact_events(hmppsId){
 }
 
 function validate_person_search(lastName, dob) {
-  let res = validate_get_request_with_obo(`/v1/persons?last_name=${lastName}&date_of_birth=${dob}`);
+  let res = validate_get_request(`/v1/persons?last_name=${lastName}&date_of_birth=${dob}`);
   if (res.status !== 200) {
     return
   }
@@ -398,6 +398,9 @@ function validate_person_search(lastName, dob) {
     [`Search result last name matches`]: (data) => data[0]["lastName"].toLowerCase() === lastName.toLowerCase(),
   })
 }
+
+
+
 
 function verify_get_person(hmppsId) {
   let res = validate_get_request(`/v1/persons/${hmppsId}`);
@@ -647,7 +650,7 @@ function verify_get_basic_details(hmppsId) {
     validate_get_request(`/v1/persons/${hmppsId}/addresses`);
     validate_get_request(`/v1/persons/${hmppsId}/alerts`);
     validate_get_request(`/v1/persons/${hmppsId}/offences`);
-    validate_get_request_with_obo(`/v1/persons/${hmppsId}/sentences`);
+    validate_get_request(`/v1/persons/${hmppsId}/sentences`);
     validate_get_request(`/v1/persons/${hmppsId}/reported-adjudications`);
     validate_get_request(`/v1/persons/${hmppsId}/number-of-children`);
     validate_get_request(`/v1/persons/${hmppsId}/physical-characteristics`);
@@ -707,14 +710,19 @@ function verify_prisoner_contacts(hmppsId) {
   validate_get_request(`/v1/contacts/${contactId}`);
 }
 
-function verify_headers() {
-  //Tests to add headers too for app insights
-  const res = http.get(`${baseUrl}/v1/status`, httpOboHeaderParams);
-    if (!check(res, {
-      [`Successful sent api call with extended headers.`]: (r) => r.status < 400,
-    })) {
-      exec.test.fail(`Failed to use headers in api call.`);
-    }
+function verify_obo_access() {
+  let res = validate_get_request_with_obo(`/v1/persons/${hmppsId}`);
+  if (res.status >= 400) {
+    return null
+  }
+
+  let probationData = res.json()["data"]["probationOffenderSearch"];
+  let lastName = probationData["lastName"];
+  let dob = probationData["dateOfBirth"];
+
+  validate_get_request_with_obo(`/v1/status`);
+  validate_get_request_with_obo(`/v1/persons/${hmppsId}/sentences`);
+  validate_get_request_with_obo(`/v1/persons?last_name=${lastName}&date_of_birth=${dob}`);
 }
 
 /**
@@ -756,7 +764,7 @@ function structured_verification_test(hmppsId) {
 
   verify_education_san(hmppsId);
 
-  verify_headers()
+  verify_obo_access()
 }
 /************************************************************************/
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonController.kt
@@ -134,7 +134,7 @@ class PersonController(
       throw ValidationException("Invalid date format. Please use yyyy-MM-dd.")
     }
 
-    val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, searchWithinAliases, requestContext?.filters)
+    val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, searchWithinAliases, requestContext)
 
     auditService.createEvent(
       "SEARCH_PERSON",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/NDeliusGateway.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.CacheConfig.Companion.GATEWAY_CACHE
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.EPF_ENDPOINT_INCLUDES_LAO
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Address
@@ -259,8 +260,8 @@ class NDeliusGateway(
     }
   }
 
-  private fun authenticationHeader(): Map<String, String> {
-    val token = hmppsAuthGateway.getClientToken("nDelius")
+  private fun authenticationHeader(requestContext: RequestContext? = null): Map<String, String> {
+    val token = hmppsAuthGateway.getClientToken("nDelius", requestContext)
 
     return mapOf(
       "Authorization" to "Bearer $token",
@@ -321,6 +322,7 @@ class NDeliusGateway(
     pncNumber: String?,
     dateOfBirth: String?,
     searchWithinAliases: Boolean = false,
+    requestContext: RequestContext? = null,
   ): Response<List<Person>> {
     val requestBody =
       mapOf(
@@ -335,7 +337,7 @@ class NDeliusGateway(
       webClient.requestListWithRetry<Offender>(
         HttpMethod.POST,
         "/search/probation-cases",
-        authenticationHeader(),
+        authenticationHeader(requestContext),
         UpstreamApi.NDELIUS,
         requestBody,
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PrisonerOffenderSearchGateway.kt
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.CacheConfig.Companion.GATEWAY_CACHE
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
@@ -137,12 +138,15 @@ class PrisonerOffenderSearchGateway(
     }
   }
 
-  fun attributeSearch(request: POSAttributeSearchRequest): Response<POSPaginatedPrisoners?> {
+  fun attributeSearch(
+    request: POSAttributeSearchRequest,
+    requestContext: RequestContext? = null,
+  ): Response<POSPaginatedPrisoners?> {
     val result =
       webClient.request<POSPaginatedPrisoners>(
         HttpMethod.POST,
         "/attribute-search",
-        authenticationHeader(),
+        authenticationHeader(requestContext),
         UpstreamApi.PRISONER_OFFENDER_SEARCH,
         request.toMap(),
       )
@@ -163,8 +167,8 @@ class PrisonerOffenderSearchGateway(
     }
   }
 
-  private fun authenticationHeader(): Map<String, String> {
-    val token = hmppsAuthGateway.getClientToken("Prisoner Offender Search")
+  private fun authenticationHeader(requestContext: RequestContext? = null): Map<String, String> {
+    val token = hmppsAuthGateway.getClientToken("Prisoner Offender Search", requestContext)
 
     return mapOf(
       "Authorization" to "Bearer $token",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Person
@@ -27,19 +28,20 @@ class GetPersonsService(
     pncNumber: String?,
     dateOfBirth: String?,
     searchWithinAliases: Boolean = false,
-    consumerFilters: ConsumerFilters? = null,
+    requestContext: RequestContext? = null,
   ): Response<List<Person>> {
     // Perform probation search
+    val consumerFilters = requestContext?.filters
     val probationSearchResponse =
       if (consumerFilters?.isPrisonsOnly() != true) {
-        deliusGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth, searchWithinAliases)
+        deliusGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth, searchWithinAliases, requestContext)
       } else {
         Response(emptyList(), emptyList())
       }
 
     // Perform prison search
     val attributeSearchRequest = attributeSearchRequest(firstName, lastName, pncNumber, dateOfBirth, searchWithinAliases, consumerFilters)
-    val attributeSearchResponse = prisonerOffenderSearchGateway.attributeSearch(attributeSearchRequest)
+    val attributeSearchResponse = prisonerOffenderSearchGateway.attributeSearch(attributeSearchRequest, requestContext)
     val attributeSearchResponseData = attributeSearchResponse.data?.content?.map { it.toPerson() } ?: emptyList()
 
     // Combine and return results

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/person/PersonControllerTest.kt
@@ -8,7 +8,9 @@ import io.kotest.matchers.string.shouldContain
 import net.javacrumbs.jsonunit.assertj.JsonAssertions
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,6 +23,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.WebMvcTestConfiguration
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext.Companion.buildRequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.BodyMark
@@ -109,7 +113,7 @@ internal class PersonControllerTest(
           Mockito.reset(getPersonsService)
           Mockito.reset(auditService)
 
-          whenever(getPersonsService.personAttributeSearch(firstName, lastName, null, dateOfBirth.toString())).thenReturn(
+          whenever(getPersonsService.personAttributeSearch(eq(firstName), eq(lastName), eq(null), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())).thenReturn(
             Response(
               data =
                 listOf(
@@ -127,92 +131,92 @@ internal class PersonControllerTest(
         it("gets a person with matching search criteria") {
           val result = mockMvc.performAuthorised("$basePath?first_name=$firstName&last_name=$lastName&pnc_number=$pncNumber&date_of_birth=$dateOfBirth")
           result.response.status.shouldNotBe(HttpStatus.FORBIDDEN.value())
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth.toString())
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(lastName), eq(pncNumber), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching first name") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, null, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(null), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching last name") {
           mockMvc.performAuthorised("$basePath?last_name=$lastName")
-          verify(getPersonsService, times(1)).personAttributeSearch(null, lastName, null, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(null), eq(lastName), eq(null), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching alias") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName&search_within_aliases=true")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, null, null, searchWithinAliases = true)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(null), eq(null), eq(true), any<RequestContext>())
         }
 
         it("gets a person with matching pncNumber") {
           mockMvc.performAuthorised("$basePath?pnc_number=$pncNumber")
-          verify(getPersonsService, times(1)).personAttributeSearch(null, null, pncNumber, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(null), eq(null), eq(pncNumber), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching date of birth") {
           mockMvc.performAuthorised("$basePath?date_of_birth=$dateOfBirth")
-          verify(getPersonsService, times(1)).personAttributeSearch(null, null, null, dateOfBirth.toString())
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(null), eq(null), eq(null), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())
         }
 
         it("defaults to not searching within aliases") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, null, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(null), eq(null), eq(false), any<RequestContext>())
         }
 
         it("calls attribute search when prisons filter is present and pnc number in search") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName&pnc_number=$pncNumber")
           verify(getPersonsService, times(1))
-            .personAttributeSearch(firstName, null, pncNumber, null)
+            .personAttributeSearch(eq(firstName), eq(null), eq(pncNumber), eq(null), eq(false), any<RequestContext>())
         }
 
         it("calls attribute search when prisons filter is present and pnc number in search") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName&pnc_number=$pncNumber")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, pncNumber, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(pncNumber), eq(null), eq(false), any<RequestContext>())
         }
 
         it("passes supervision status filters from consumer config to service") {
-          val expectedFilters = ConsumerFilters(supervisionStatuses = listOf("PRISONS"))
-          whenever(getPersonsService.personAttributeSearch(firstName, null, pncNumber, null, false, expectedFilters)).thenReturn(Response(data = emptyList()))
+          val requestContext = buildRequestContext(filters = ConsumerFilters(supervisionStatuses = listOf("PRISONS")))
+          whenever(getPersonsService.personAttributeSearch(eq(firstName), eq(null), eq(pncNumber), eq(null), eq(false), any<RequestContext>())).thenReturn(Response(data = emptyList()))
 
           mockMvc.performAuthorisedWithCN("$basePath?first_name=$firstName&pnc_number=$pncNumber", "supervision-status-prison-only")
 
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, pncNumber, null, false, expectedFilters)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(pncNumber), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching search criteria") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName&last_name=$lastName&pnc_number=$pncNumber&date_of_birth=$dateOfBirth")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth.toString())
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(lastName), eq(pncNumber), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching first name") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, null, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(null), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching last name") {
           mockMvc.performAuthorised("$basePath?last_name=$lastName")
-          verify(getPersonsService, times(1)).personAttributeSearch(null, lastName, null, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(null), eq(lastName), eq(null), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching alias") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName&search_within_aliases=true")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, null, null, searchWithinAliases = true)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(null), eq(null), eq(true), any<RequestContext>())
         }
 
         it("gets a person with matching pncNumber") {
           mockMvc.performAuthorised("$basePath?pnc_number=$pncNumber")
-          verify(getPersonsService, times(1)).personAttributeSearch(null, null, pncNumber, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(null), eq(null), eq(pncNumber), eq(null), eq(false), any<RequestContext>())
         }
 
         it("gets a person with matching date of birth") {
           mockMvc.performAuthorised("$basePath?date_of_birth=$dateOfBirth")
-          verify(getPersonsService, times(1)).personAttributeSearch(null, null, null, dateOfBirth.toString())
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(null), eq(null), eq(null), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())
         }
 
         it("defaults to not searching within aliases") {
           mockMvc.performAuthorised("$basePath?first_name=$firstName")
-          verify(getPersonsService, times(1)).personAttributeSearch(firstName, null, null, null)
+          verify(getPersonsService, times(1)).personAttributeSearch(eq(firstName), eq(null), eq(null), eq(null), eq(false), any<RequestContext>())
         }
 
         it("logs audit") {
@@ -227,7 +231,7 @@ internal class PersonControllerTest(
         }
 
         it("returns paginated results") {
-          whenever(getPersonsService.personAttributeSearch(firstName, lastName, null, dateOfBirth.toString())).thenReturn(
+          whenever(getPersonsService.personAttributeSearch(eq(firstName), eq(lastName), eq(null), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())).thenReturn(
             Response(
               data =
                 List(20) { i ->
@@ -252,7 +256,7 @@ internal class PersonControllerTest(
           val firstNameThatDoesNotExist = "Bob21345"
           val lastNameThatDoesNotExist = "Gun36773"
 
-          whenever(getPersonsService.personAttributeSearch(firstNameThatDoesNotExist, lastNameThatDoesNotExist, null, null)).thenReturn(
+          whenever(getPersonsService.personAttributeSearch(eq(firstNameThatDoesNotExist), eq(lastNameThatDoesNotExist), eq(null), eq(null), eq(false), any<RequestContext>())).thenReturn(
             Response(
               data = emptyList(),
             ),
@@ -287,7 +291,7 @@ internal class PersonControllerTest(
         }
 
         it("fails with the appropriate error when an upstream service is down") {
-          whenever(getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth.toString(), false)).doThrow(
+          whenever(getPersonsService.personAttributeSearch(eq(firstName), eq(lastName), eq(pncNumber), eq(dateOfBirth.toString()), eq(false), any<RequestContext>())).doThrow(
             WebClientResponseException(500, "MockError", null, null, null, null),
           )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/IntegrationTestBase.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.reset
+import org.mockito.kotlin.spy
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
@@ -16,6 +17,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -26,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.CacheDisabledTest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.repository.JdbcTemplateEventNotificationRepository
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.MockMvcExtensions.writeAsJson
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.ActivitiesGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.CorePersonRecordGateway
@@ -85,6 +88,8 @@ abstract class IntegrationTestBase {
   @Autowired
   lateinit var mockMvc: MockMvc
 
+  lateinit var authSpy: WebClientWrapper
+
   @BeforeEach
   fun evictAllCaches() {
     reset(alertsGateway)
@@ -97,6 +102,14 @@ abstract class IntegrationTestBase {
     reset(authorisationService)
     reset(eventNotificationRepository)
     reset(authGateway)
+
+    // Create a spy on the auth client in order to check
+    val authClient =
+      WebClientWrapper(
+        "http://localhost:3000",
+      )
+    authSpy = spy(authClient)
+    ReflectionTestUtils.setField(authGateway, "webClientWrapper", authSpy)
 
     prisonerOffenderSearchMockServer.stubForGet(
       "/prisoner/${Companion.nomsId}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PersonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/PersonIntegrationTest.kt
@@ -6,26 +6,36 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpMethod
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.testRoleWithPrisonFilters
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.GetPersonsService.Companion.attributeSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.onbehalfof.createUnsignedJwt
 import java.io.File
 
 class PersonIntegrationTest : IntegrationTestBase() {
   @Nested
   inner class GetPerson {
-    @Test
-    fun `returns a list of persons using first name and last name as search parameters`() {
-      val firstName = "Robert"
-      val lastName = "Larsen"
+    val firstName = "Robert"
+    val lastName = "Larsen"
+
+    @BeforeEach
+    fun setup() {
       val expectedRequest = attributeSearchRequest(firstName, lastName)
 
       prisonerOffenderSearchMockServer.stubForPost(
@@ -35,7 +45,10 @@ class PersonIntegrationTest : IntegrationTestBase() {
           "src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/prisoneroffendersearch/fixtures/AttributeSearch.json",
         ).readText(),
       )
+    }
 
+    @Test
+    fun `returns a list of persons using first name and last name as search parameters`() {
       val queryParams = "first_name=$firstName&last_name=$lastName"
 
       callApi("$basePath?$queryParams")
@@ -48,9 +61,6 @@ class PersonIntegrationTest : IntegrationTestBase() {
     @Test
     fun `returns a list of persons using pnc number search with consumer filters`() {
       whenever(authorisationConfig.roles).thenReturn(mapOf("full-access" to testRoleWithPrisonFilters))
-
-      val firstName = "Robert"
-      val lastName = "Larsen"
       val pncNumber = "2003/13116M"
 
       val expectedRequest = attributeSearchRequest(firstName, lastName, pncNumber, consumerFilters = testRoleWithPrisonFilters.filters!!)
@@ -70,6 +80,34 @@ class PersonIntegrationTest : IntegrationTestBase() {
         .andExpect(content().json(getExpectedResponse("person-name-pnc-search-response.json")))
 
       prisonerOffenderSearchMockServer.assertValidationPassed()
+    }
+
+    @Test
+    fun `sends the obo username to hmpps auth in a query param when obo username present in request`() {
+      val queryParams = "first_name=$firstName&last_name=$lastName"
+      callApiWithCN("$basePath?$queryParams", "obo-unsigned", oboValue = createUnsignedJwt())
+      val uri = argumentCaptor<String>()
+      verify(authSpy, atLeast(1)).getResponseBodySpec(eq(HttpMethod.POST), uri.capture(), anyMap(), eq(null))
+      val authRequestStrings = uri.allValues
+      // Gets an auth token for deliusGateway.getPersons and prisonerOffenderSearchGateway.attributeSearch passing the username
+      assertThat(authRequestStrings.size).isEqualTo(2)
+      authRequestStrings.forEach {
+        assertThat(it).isEqualTo("/auth/oauth/token?grant_type=client_credentials&username=testName")
+      }
+    }
+
+    @Test
+    fun `does not send the obo username to hmpps auth in a query param when obo username present in request`() {
+      val queryParams = "first_name=$firstName&last_name=$lastName"
+      callApi("$basePath?$queryParams")
+      val uri = argumentCaptor<String>()
+      verify(authSpy, atLeast(1)).getResponseBodySpec(eq(HttpMethod.POST), uri.capture(), anyMap(), eq(null))
+      val authRequestStrings = uri.allValues
+      // Gets an auth token for deliusGateway.getPersons and prisonerOffenderSearchGateway.attributeSearch passing the username
+      assertThat(authRequestStrings.size).isEqualTo(2)
+      authRequestStrings.forEach {
+        assertThat(it).isEqualTo("/auth/oauth/token?grant_type=client_credentials")
+      }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.internal.verification.VerificationModeFactory
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -125,7 +126,7 @@ internal class GetPersonServiceTest :
           .thenReturn(Response(data = null, errors = notFoundErrors(UpstreamApi.PRISONER_OFFENDER_SEARCH)))
 
       fun givenPrisonerNumberMergedAttributeSearchReturnsEmpty() =
-        whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(
+        whenever(prisonerOffenderSearchGateway.attributeSearch(any(), eq(null))).thenReturn(
           Response(
             data =
               POSPaginatedPrisoners(
@@ -165,7 +166,7 @@ internal class GetPersonServiceTest :
       fun givenPrisonerNumberMergedAttributeSearchReturnsMatchingResult(
         removedPrisonerNumber: String?,
         mergedInToPrisonerNumber: String,
-      ) = whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(
+      ) = whenever(prisonerOffenderSearchGateway.attributeSearch(any(), eq(null))).thenReturn(
         Response(
           data =
             POSPaginatedPrisoners(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonsServiceTest.kt
@@ -7,6 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.mockito.Mockito
 import org.mockito.internal.verification.VerificationModeFactory.times
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -14,6 +15,8 @@ import org.springframework.boot.test.context.ConfigDataApplicationContextInitial
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext.Companion.buildRequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.NDeliusGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PrisonerOffenderSearchGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Person
@@ -92,29 +95,29 @@ internal class GetPersonsServiceTest(
       Mockito.reset(featureFlag)
 
       whenever(prisonerOffenderSearchGateway.getPersons(firstName, lastName, dateOfBirth)).thenReturn(Response(data = emptyList()))
-      whenever(deliusGateway.getPersons(firstName, lastName, null, dateOfBirth)).thenReturn(Response(data = emptyList()))
+      whenever(deliusGateway.getPersons(eq(firstName), eq(lastName), eq(null), eq(dateOfBirth), eq(false), any<RequestContext>())).thenReturn(Response(data = emptyList()))
     }
 
     it("search returns prisoner") {
       val responseFromProbationOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "John")))
-      whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(prisonAttributeSearchResponse)
+      whenever(prisonerOffenderSearchGateway.attributeSearch(any(), any<RequestContext>())).thenReturn(prisonAttributeSearchResponse)
       whenever(
         deliusGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth),
       ).thenReturn(responseFromProbationOffenderSearch)
-      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, ConsumerFilters(prisons = listOf("MDI")))
+      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, buildRequestContext(filters = ConsumerFilters(prisons = listOf("MDI"))))
       response.data.size.shouldBe(1)
-      verify(prisonerOffenderSearchGateway, times(1)).attributeSearch(any())
+      verify(prisonerOffenderSearchGateway, times(1)).attributeSearch(any(), any<RequestContext>())
     }
 
     it("search with prisons filter (no probation search) returns an error") {
       val error = UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.TEST)
       val paginatedResponse = Response<POSPaginatedPrisoners?>(errors = listOf(error), data = null)
       val responseFromProbationOffenderSearch = Response(data = listOf(Person(firstName, lastName, middleName = "John")))
-      whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(paginatedResponse)
+      whenever(prisonerOffenderSearchGateway.attributeSearch(any(), any<RequestContext>())).thenReturn(paginatedResponse)
       whenever(
-        deliusGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth),
+        deliusGateway.getPersons(eq(firstName), eq(lastName), eq(pncNumber), eq(dateOfBirth), eq(false), any<RequestContext>()),
       ).thenReturn(responseFromProbationOffenderSearch)
-      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, ConsumerFilters(prisons = listOf("MDI")))
+      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, buildRequestContext(filters = ConsumerFilters(prisons = listOf("MDI"))))
       response.data.shouldBeEmpty()
       response.errors.shouldBe(listOf(error))
     }
@@ -122,11 +125,11 @@ internal class GetPersonsServiceTest(
     it("search without prisons filter continues to call prison search (success) if probation search fails") {
       val error = UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.TEST)
       val responseFromProbationOffenderSearch = Response(errors = listOf(error), data = emptyList<Person>())
-      whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(prisonAttributeSearchResponse)
+      whenever(prisonerOffenderSearchGateway.attributeSearch(any(), any<RequestContext>())).thenReturn(prisonAttributeSearchResponse)
       whenever(
-        deliusGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth),
+        deliusGateway.getPersons(eq(firstName), eq(lastName), eq(pncNumber), eq(dateOfBirth), eq(false), any<RequestContext>()),
       ).thenReturn(responseFromProbationOffenderSearch)
-      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, ConsumerFilters())
+      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, buildRequestContext(filters = ConsumerFilters()))
       response.data.size.shouldBe(1)
       response.errors.shouldBe(listOf(error))
     }
@@ -135,34 +138,34 @@ internal class GetPersonsServiceTest(
       val error = UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.TEST)
       val paginatedResponse = Response<POSPaginatedPrisoners?>(errors = listOf(error), data = null)
       val responseFromProbationOffenderSearch = Response(errors = listOf(error), data = emptyList<Person>())
-      whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(paginatedResponse)
+      whenever(prisonerOffenderSearchGateway.attributeSearch(any(), any<RequestContext>())).thenReturn(paginatedResponse)
       whenever(
-        deliusGateway.getPersons(firstName, lastName, pncNumber, dateOfBirth),
+        deliusGateway.getPersons(eq(firstName), eq(lastName), eq(pncNumber), eq(dateOfBirth), eq(false), any<RequestContext>()),
       ).thenReturn(responseFromProbationOffenderSearch)
-      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, ConsumerFilters())
+      val response = getPersonsService.personAttributeSearch(firstName, lastName, pncNumber, dateOfBirth, false, buildRequestContext(filters = ConsumerFilters()))
       response.data.shouldBeEmpty()
       response.errors.shouldBe(listOf(error, error))
     }
 
     it("does not do probation search for supervisionStatus == PRISON") {
-      whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(prisonAttributeSearchResponse)
+      whenever(prisonerOffenderSearchGateway.attributeSearch(any(), any<RequestContext>())).thenReturn(prisonAttributeSearchResponse)
 
-      val filters = ConsumerFilters(supervisionStatuses = listOf(SupervisionStatus.PRISONS.name))
+      val requestContext = buildRequestContext(filters = ConsumerFilters(supervisionStatuses = listOf(SupervisionStatus.PRISONS.name)))
 
-      getPersonsService.personAttributeSearch(firstName, lastName, null, dateOfBirth, true, filters)
+      getPersonsService.personAttributeSearch(firstName, lastName, null, dateOfBirth, true, requestContext)
 
       verifyNoInteractions(deliusGateway)
-      verify(prisonerOffenderSearchGateway, times(1)).attributeSearch(any())
+      verify(prisonerOffenderSearchGateway, times(1)).attributeSearch(any(), any<RequestContext>())
     }
 
     it("search returns an empty list when no person(s) are found") {
-      whenever(deliusGateway.getPersons(firstName, lastName, null, dateOfBirth)).thenReturn(Response(emptyList()))
-      whenever(prisonerOffenderSearchGateway.attributeSearch(any())).thenReturn(
+      whenever(deliusGateway.getPersons(eq(firstName), eq(lastName), eq(null), eq(dateOfBirth), eq(false), any<RequestContext>())).thenReturn(Response(emptyList()))
+      whenever(prisonerOffenderSearchGateway.attributeSearch(any(), any<RequestContext>())).thenReturn(
         Response<POSPaginatedPrisoners?>(
           data = paginatedPrisoners.copy(content = emptyList()),
         ),
       )
-      val response = getPersonsService.personAttributeSearch(firstName, lastName, null, dateOfBirth)
+      val response = getPersonsService.personAttributeSearch(firstName, lastName, null, dateOfBirth, requestContext = buildRequestContext(filters = ConsumerFilters()))
       response.data.shouldBe(emptyList())
     }
 


### PR DESCRIPTION
ensure that the obo username is passed to the  v1/persons endpoint through to the call to hmpps auth for:

```
prisonerOffenderSearchGateway.attributeSearch
deliusGateway.getPersons
```