### PR TITLE
HIA-1488: Add dynamic risk text redactions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/redaction/RisksTextRedactions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/redaction/RisksTextRedactions.kt
@@ -3,14 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.redactionconfig.RedactionType.MASK
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.dsl.redactionPolicy
 
-val seriousHarmRedactions =
+val risksTextRedactions =
   redactionPolicy(
-    "serious-harm-redactions",
+    "risks-text-redactions",
   ) {
     responseRedactions {
       jsonPath {
         endpoints {
           -"/v1/persons/{hmppsId}/risks/serious-harm"
+          -"/v1/persons/{hmppsId}/risks/dynamic"
         }
         redactions {
           -("$..previousConcernsText" to MASK)
@@ -20,6 +21,7 @@ val seriousHarmRedactions =
           -("$..riskImminence" to MASK)
           -("$..riskIncreaseFactors" to MASK)
           -("$..riskMitigationFactors" to MASK)
+          -("$..notes" to MASK)
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/roles/Police.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/roles/Police.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.laoRedactionPolicy
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.personResponsibleOfficerRedactions
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.riskScores.generalRiskScoreRedactions
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.seriousHarmRedactions
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.risksTextRedactions
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.redaction.unusedKeyDatesRedactions
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.role
 
@@ -29,7 +29,7 @@ val police =
       -laoRedactionPolicy
       -generalRiskScoreRedactions
       -personResponsibleOfficerRedactions
-      -seriousHarmRedactions
+      -risksTextRedactions
       -unusedKeyDatesRedactions
     }
     filters {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/RisksIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/RisksIntegrationTest.kt
@@ -43,5 +43,4 @@ class RisksIntegrationTest : IntegrationTestBase() {
       .andExpect(status().isOk)
       .andExpect(content().json(getExpectedResponse("person-risk-dynamic-text-redacted.json")))
   }
-
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/RisksIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/person/RisksIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration.IntegrationTestBase
+import kotlin.test.Test
 
 class RisksIntegrationTest : IntegrationTestBase() {
   @ParameterizedTest
@@ -35,4 +36,12 @@ class RisksIntegrationTest : IntegrationTestBase() {
     callApi("$basePath/invalid-invalid/risks/$path")
       .andExpect(status().isBadRequest)
   }
+
+  @Test
+  fun `notes are redacted for dynamic risks for police role`() {
+    callApiWithCN("$basePath/$crn/risks/dynamic", "police")
+      .andExpect(status().isOk)
+      .andExpect(content().json(getExpectedResponse("person-risk-dynamic-text-redacted.json")))
+  }
+
 }

--- a/src/test/resources/expected-responses/person-risk-dynamic-text-redacted.json
+++ b/src/test/resources/expected-responses/person-risk-dynamic-text-redacted.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "code": "RCCO",
+      "description": "Child Concerns",
+      "startDate": "2019-08-24",
+      "reviewDate": "2019-08-24",
+      "notes": "**REDACTED**"
+    }
+  ],
+  "pagination": {
+    "isLastPage": true,
+    "count": 1,
+    "page": 1,
+    "perPage": 10,
+    "totalCount": 1,
+    "totalPages": 1
+  }
+}


### PR DESCRIPTION
Renamed `RiskHarmRedactions` to `RisksTextRedactions` and added /`risks/dynamic` and redacted the `notes` field