### PR TITLE
HIA-1482 + HIA-1466: Ignore expiring certs

### DIFF
--- a/scripts/check_certs_expiry.sh
+++ b/scripts/check_certs_expiry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ignore="dev/sleach5 dev/bmadley"
+ignore="dev/sleach5 dev/bmadley dev/myrall preprod/pmcphee"
 
 configure_aws_credentials() {
     local environment="$1"


### PR DESCRIPTION
This pr removes dev/myrall and preprod/pmcphee from getting expiry alerts. 