### PR TITLE
HIA-1511: Update detekt kotlin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,7 +213,7 @@ detekt {
 configurations.matching { it.name == "detekt" }.all {
   resolutionStrategy.eachDependency {
     if (requested.group == "org.jetbrains.kotlin") {
-      useVersion("2.3.21")
+      useVersion("2.4.0")
     }
   }
 }


### PR DESCRIPTION
The alpha for detekt has been updated by dependabot. This is now using kotlin 2.4