### PR TITLE
HIA-1510: Contact Linked Prisoners endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -33,6 +33,7 @@ data class FeatureFlagConfig(
     const val USE_ASSESSMENT_SUMMARY_ENDPOINT = "use-assessment-summary-endpoint"
     const val USE_STUBBED_ASSESSMENT_SUMMARY = "use-stubbed-assessment-summary"
     const val CONTACT_SEARCH_ENDPOINT_ENABLED = "contact-search-endpoint-enabled"
+    const val CONTACT_LINKED_PRISONERS_ENDPOINT_ENABLED = "contact-linked-prisoners-endpoint-enabled"
 
     // Events feature flags
     const val ENABLE_DELETE_PROCESSED_EVENTS = "enable-delete-processed-events"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsController.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.EntityNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.featureflag.FeatureFlag
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactLinkedPrisoner
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactSearchResponseItem
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactSearchType
@@ -74,6 +75,40 @@ class ContactsController(
 
     auditService.createEvent("GET_CONTACT_BY_ID", mapOf("contactId" to contactId))
     return response
+  }
+
+  @GetMapping("/{contactId}/linked-prisoners")
+  @Tag(name = "Visits")
+  @Operation(
+    summary = "Returns the linked prisoners for a contact id.",
+    description = "",
+    responses = [
+      ApiResponse(responseCode = "200", useReturnTypeSchema = true, description = "Successfully retrieved linked prisoners by contact ID."),
+      ApiResponse(responseCode = "404", content = [Content(schema = Schema(ref = "#/components/schemas/PersonNotFound"))]),
+      ApiResponse(responseCode = "500", content = [Content(schema = Schema(ref = "#/components/schemas/InternalServerError"))]),
+    ],
+  )
+  @FeatureFlag(name = FeatureFlagConfig.CONTACT_LINKED_PRISONERS_ENDPOINT_ENABLED)
+  fun getContactLinkedPrisoners(
+    @Parameter(description = "The page number (starting at 1)", schema = Schema(minimum = "1")) @RequestParam(required = false, defaultValue = "1") pageNo: Int,
+    @Parameter(description = "The maximum number of results for a page (starting at 1)", schema = Schema(minimum = "1")) @RequestParam(required = false, defaultValue = "10", name = "perPage") perPage: Int,
+    @PathVariable contactId: Long,
+    @RequestAttribute requestContext: RequestContext?,
+  ): PaginatedResponse<ContactLinkedPrisoner> {
+    val response =
+      getContactService.getContactLinkedPrisoners(
+        contactId,
+        pageNo = pageNo,
+        perPage = perPage,
+        requestContext = requestContext,
+      )
+
+    if (response.hasError(UpstreamApiError.Type.ENTITY_NOT_FOUND)) {
+      throw EntityNotFoundException("Linked prisoners not found for $contactId")
+    }
+
+    auditService.createEvent("GET_CONTACT_LINKED_PRISONERS", mapOf("contactId" to contactId.toString()))
+    return response.data.toPaginatedResponse()
   }
 
   @RequestMapping(method = [RequestMethod.GET, RequestMethod.POST])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PersonalRelationshipsGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/PersonalRelationshipsGateway.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpMethod
 import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
@@ -38,12 +39,21 @@ class PersonalRelationshipsGateway(
   @Autowired
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
-  fun getLinkedPrisoner(contactId: Long): Response<PRLinkedPrisoners?> {
+  fun getLinkedPrisoner(
+    contactId: Long,
+    pageNo: Int? = null,
+    perPage: Int? = null,
+    requestContext: RequestContext? = null,
+  ): Response<PRLinkedPrisoners?> {
+    val uri = UriComponentsBuilder.fromUriString("/contact/$contactId/linked-prisoners")
+    pageNo?.let { uri.queryParam("page", (pageNo - 1).toString()) }
+    perPage?.let { uri.queryParam("size", perPage.toString()) }
+
     val result =
       webClient.request<PRLinkedPrisoners>(
         HttpMethod.GET,
-        "/contact/$contactId/linked-prisoners",
-        authenticationHeader(),
+        uri.toUriString(),
+        authenticationHeader(requestContext),
         UpstreamApi.PERSONAL_RELATIONSHIPS,
       )
     return when (result) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/ContactLinkedPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/ContactLinkedPrisoner.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.interfaces.IPaginatedObject
+
+data class ContactLinkedPrisoner(
+  @Schema(description = "The prisoner number", example = "A1234BC")
+  val prisonerNumber: String,
+  @Schema(description = "The prisoners last name", example = "Smith")
+  val lastName: String,
+  @Schema(description = "The prisoners first name", example = "John")
+  val firstName: String,
+  @Schema(description = "The prisoners middle names", example = "Simon James")
+  val middleNames: String?,
+  @Schema(description = "Relationship type code ", example = "S")
+  val relationshipTypeCode: String,
+  @Schema(description = "Relationship type description", example = "Official")
+  val relationshipTypeDescription: String,
+  @Schema(description = "Relationship to prisoner code", example = "FRI")
+  val relationshipToPrisonerCode: String,
+  @Schema(description = "Relationship to prisoner code description", example = "Friend")
+  val relationshipToPrisonerDescription: String?,
+  @Schema(description = "Is relationship active?", example = "True")
+  val isRelationshipActive: Boolean,
+  @Schema(description = "The prisoner contact Id", example = "123456")
+  val prisonerContactId: Long,
+)
+
+data class PaginatedContactLinkedPrisonerResponse(
+  override val content: List<ContactLinkedPrisoner>,
+  override val isLastPage: Boolean,
+  override val count: Int,
+  override val page: Int,
+  override val perPage: Int,
+  override val totalCount: Long,
+  override val totalPages: Int,
+) : IPaginatedObject<ContactLinkedPrisoner>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRLinkedPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRLinkedPrisoner.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactLinkedPrisoner
 
 data class PRLinkedPrisoner(
   @JsonProperty("prisonerNumber")
@@ -23,4 +24,18 @@ data class PRLinkedPrisoner(
   val isRelationshipActive: Boolean,
   @JsonProperty("prisonerContactId")
   val prisonerContactId: Long,
-)
+) {
+  fun toLinkedPrisoner() =
+    ContactLinkedPrisoner(
+      prisonerNumber = this.prisonerNumber,
+      firstName = this.firstName,
+      middleNames = middleNames,
+      lastName = this.lastName,
+      relationshipTypeCode = this.relationshipTypeCode,
+      relationshipTypeDescription = this.relationshipTypeDescription,
+      relationshipToPrisonerCode = this.relationshipToPrisonerCode,
+      relationshipToPrisonerDescription = this.relationshipToPrisonerDescription,
+      isRelationshipActive = this.isRelationshipActive,
+      prisonerContactId = this.prisonerContactId,
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRLinkedPrisoners.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/personalRelationships/PRLinkedPrisoners.kt
@@ -2,10 +2,22 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelation
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import org.springframework.data.web.PagedModel
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedContactLinkedPrisonerResponse
 
 data class PRLinkedPrisoners(
   @JsonProperty("content")
   val prisoners: List<PRLinkedPrisoner>,
   @JsonProperty("page")
   val pageMetadata: PagedModel.PageMetadata,
-)
+) {
+  fun toPaginatedLinkedPrisonerResponse(): PaginatedContactLinkedPrisonerResponse =
+    PaginatedContactLinkedPrisonerResponse(
+      content = this.prisoners.map { it.toLinkedPrisoner() },
+      count = this.prisoners.size,
+      page = this.pageMetadata.number.toInt() + 1,
+      totalCount = this.pageMetadata.totalElements,
+      totalPages = this.pageMetadata.totalPages.toInt(),
+      isLastPage = (this.pageMetadata.totalPages.toInt() == 0 || this.pageMetadata.number + 1 == this.pageMetadata.totalPages),
+      perPage = this.pageMetadata.size.toInt(),
+    )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/roleconfig/Role.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/roleconfig/Role.kt
@@ -53,6 +53,7 @@ val roleConstants =
       -"/v1/activities/{activityId}/schedules"
       -"/v1/contacts"
       -"/v1/contacts/{contactId}"
+      -"/v1/contacts/{contactId}/linked-prisoners"
       -"/v1/education/course-completion"
       -"/v1/epf/person-details/{hmppsId}/{eventNumber}"
       -"/v1/hmpps/id/by-nomis-number/{nomisNumber}"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetContactService.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.services
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PersonalRelationshipsGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.DetailedContact
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedContactLinkedPrisonerResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
@@ -40,5 +42,16 @@ class GetContactService(
     return Response(
       data = response.data.toDetailedContact(),
     )
+  }
+
+  fun getContactLinkedPrisoners(
+    contactId: Long,
+    pageNo: Int,
+    perPage: Int,
+    requestContext: RequestContext? = null,
+  ): Response<PaginatedContactLinkedPrisonerResponse?> {
+    val linkedPrisoners = personalRelationshipsGateway.getLinkedPrisoner(contactId, pageNo, perPage, requestContext)
+    val data = linkedPrisoners.data ?: return Response(null, linkedPrisoners.errors)
+    return Response(data.toPaginatedLinkedPrisonerResponse())
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -62,6 +62,7 @@ feature-flag:
   use-assessment-summary-endpoint: true
   use-stubbed-assessment-summary: true
   contact-search-endpoint-enabled: true
+  contact-linked-prisoners-endpoint-enabled: true
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -118,6 +118,7 @@ feature-flag:
   use-assessment-summary-endpoint: true
   use-stubbed-assessment-summary: false
   contact-search-endpoint-enabled: true
+  contact-linked-prisoners-endpoint-enabled: true
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true

--- a/src/main/resources/application-local-docker.yml
+++ b/src/main/resources/application-local-docker.yml
@@ -100,6 +100,7 @@ feature-flag:
   use-assessment-summary-endpoint: true
   use-stubbed-assessment-summary: false
   contact-search-endpoint-enabled: true
+  contact-linked-prisoners-endpoint-enabled: true
   # Events Config
   enable-delete-processed-events: false
   enable-publish-pending-events: false

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -78,6 +78,7 @@ feature-flag:
   use-assessment-summary-endpoint: true
   use-stubbed-assessment-summary: false
   contact-search-endpoint-enabled: true
+  contact-linked-prisoners-endpoint-enabled: true
   # Events Config
   enable-delete-processed-events: false
   enable-publish-pending-events: false

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -60,6 +60,7 @@ feature-flag:
   use-assessment-summary-endpoint: false
   use-stubbed-assessment-summary: false
   contact-search-endpoint-enabled: false
+  contact-linked-prisoners-endpoint-enabled: false
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -60,6 +60,7 @@ feature-flag:
   use-assessment-summary-endpoint: false
   use-stubbed-assessment-summary: false
   contact-search-endpoint-enabled: false
+  contact-linked-prisoners-endpoint-enabled: false
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -103,6 +103,7 @@ feature-flag:
   use-assessment-summary-endpoint: false
   use-stubbed-assessment-summary: false
   contact-search-endpoint-enabled: true
+  contact-linked-prisoners-endpoint-enabled: true
   # Events Config
   enable-delete-processed-events: false
   enable-publish-pending-events: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsControllerTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
@@ -15,9 +16,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.WebMvcTestConfiguration
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.MockMvcExtensions.contentAsJson
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.helpers.IntegrationAPIMockMvc
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactLinkedPrisoner
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.ContactSearchResponseItem
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedContactLinkedPrisonerResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PaginatedContactSearchResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -307,6 +311,61 @@ internal class ContactsControllerTest(
       it("returns a 200 status code when a valid date of birth provided") {
         val result = mockMvc.performAuthorisedPost(path, ContactSearchRequest("John", "Simon", "Smith", dateOfBirth = "12/08/1990"))
         result.response.status.shouldBe(HttpStatus.OK.value())
+      }
+    }
+
+    describe("GET contact linked prisoners") {
+
+      val linkedPrisoner =
+        ContactLinkedPrisoner(
+          prisonerNumber = "AA1234BC",
+          lastName = "Smith",
+          firstName = "John",
+          middleNames = "Simon",
+          relationshipTypeCode = "S",
+          relationshipTypeDescription = "Official",
+          relationshipToPrisonerCode = "FRI",
+          relationshipToPrisonerDescription = "Friend",
+          isRelationshipActive = true,
+          prisonerContactId = 123456,
+        )
+
+      val response =
+        PaginatedContactLinkedPrisonerResponse(
+          content = listOf(linkedPrisoner),
+          isLastPage = true,
+          page = 1,
+          perPage = 10,
+          totalCount = 1,
+          totalPages = 1,
+          count = 1,
+        )
+
+      beforeTest {
+        Mockito.reset(auditService)
+        Mockito.reset(getContactService)
+
+        whenever(getContactService.getContactLinkedPrisoners(eq(defaultContactId.toLong()), eq(1), eq(10), any<RequestContext>())).thenReturn(
+          Response(response),
+        )
+      }
+
+      it("returns a 200 OK status code") {
+        val result = mockMvc.performAuthorised("$path/$defaultContactId/linked-prisoners")
+        result.response.status.shouldBe(HttpStatus.OK.value())
+        val response = result.response.contentAsJson<PaginatedResponse<ContactLinkedPrisoner>>()
+        response.data
+          .first()
+          .prisonerNumber
+          .shouldBe("AA1234BC")
+      }
+
+      it("returns a 404 Not found status code") {
+        whenever(getContactService.getContactLinkedPrisoners(eq(defaultContactId.toLong()), eq(1), eq(10), any<RequestContext>())).thenReturn(
+          Response(null, listOf(UpstreamApiError(UpstreamApi.PERSONAL_RELATIONSHIPS, UpstreamApiError.Type.ENTITY_NOT_FOUND))),
+        )
+        val result = mockMvc.performAuthorised("$path/$defaultContactId/linked-prisoners")
+        result.response.status.shouldBe(HttpStatus.NOT_FOUND.value())
       }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/personalRelationships/PersonalRelationshipsGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/personalRelationships/PersonalRelationshipsGatewayTest.kt
@@ -438,4 +438,44 @@ class PersonalRelationshipsGatewayTest(
         contactResponse.errors[0].shouldBe(UpstreamApiError(type = UpstreamApiError.Type.BAD_REQUEST, causedBy = UpstreamApi.PERSONAL_RELATIONSHIPS))
       }
     }
+
+    it("gets a list of prisoner contact ids with page data") {
+      val path = "/contact/$contactId/linked-prisoners?page=0&size=10"
+      personalRelationshipsApiMockServer.stubForGet(
+        path,
+        body =
+          """
+          {
+            "content": [
+              {
+                "prisonerNumber": "A1234BC",
+                "lastName": "Doe",
+                "firstName": "John",
+                "middleNames": "William",
+                "prisonerContactId": 123456,
+                "relationshipTypeCode": "S",
+                "relationshipTypeDescription": "Official",
+                "relationshipToPrisonerCode": "FRI",
+                "relationshipToPrisonerDescription": "Friend",
+                "isRelationshipActive": true
+              }
+            ],
+            "page": {
+              "size": 10,
+              "totalElements": 1,
+              "totalPages": 1,
+              "number": 0
+            }
+          }
+          """.trimIndent(),
+      )
+
+      val response = personalRelationshipsGateway.getLinkedPrisoner(contactId, 1, 10)
+      response.errors.shouldBeEmpty()
+      response.data.shouldNotBeNull()
+      response.data.prisoners
+        .first()
+        .prisonerNumber
+        .shouldBe("A1234BC")
+    }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/ContactsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/ContactsIntegrationTest.kt
@@ -139,4 +139,19 @@ class ContactsIntegrationTest : IntegrationTestBase() {
       "",
     ).andExpect(status().isServiceUnavailable)
   }
+
+  @Test
+  fun `GET linked prisoners returns a 200`() {
+    callApi(
+      "/v1/contacts/$contactId/linked-prisoners",
+    ).andExpect(status().isOk)
+  }
+
+  @Test
+  fun `GET linked prisoners returns a 503 when feature flag is disabled `() {
+    whenever(featureFlagConfig.getConfigFlagValue(FeatureFlagConfig.CONTACT_LINKED_PRISONERS_ENDPOINT_ENABLED)).thenReturn(false)
+    callApi(
+      "/v1/contacts/$contactId/linked-prisoners",
+    ).andExpect(status().isServiceUnavailable)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetContactServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetContactServiceTest.kt
@@ -6,9 +6,12 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.data.web.PagedModel
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RequestContext.Companion.buildRequestContext
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.PersonalRelationshipsGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
@@ -16,6 +19,8 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships.Address
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships.EmailAddress
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships.PRDetailedContact
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships.PRLinkedPrisoner
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships.PRLinkedPrisoners
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelationships.PhoneNumber
 
 @ContextConfiguration(
@@ -25,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.personalRelations
 internal class GetContactServiceTest(
   private val getVisitorService: GetContactService,
   @MockitoBean val personalRelationshipsGateway: PersonalRelationshipsGateway,
+  @Autowired private val getContactService: GetContactService,
 ) : DescribeSpec({
 
     val contactId = "123456"
@@ -181,5 +187,54 @@ internal class GetContactServiceTest(
     it("will return 400 when invalid contactId") {
       val response = getVisitorService.execute(contactId = "THIS_ISNT_A_LONG!")
       response.errors.shouldContain(UpstreamApiError(UpstreamApi.PERSONAL_RELATIONSHIPS, UpstreamApiError.Type.BAD_REQUEST))
+    }
+
+    it("will return 200 for linked offenders for contactId") {
+      val linkedPrisoner =
+        PRLinkedPrisoner(
+          prisonerNumber = "AA1234BC",
+          lastName = "Smith",
+          firstName = "John",
+          middleNames = "Simon",
+          relationshipTypeCode = "S",
+          relationshipTypeDescription = "Official",
+          relationshipToPrisonerCode = "FRI",
+          relationshipToPrisonerDescription = "Friend",
+          isRelationshipActive = true,
+          prisonerContactId = 123456,
+        )
+      val gwResponse =
+        PRLinkedPrisoners(
+          prisoners = listOf(linkedPrisoner),
+          pageMetadata = PagedModel.PageMetadata(10, 0, 1, 1),
+        )
+      val requestContext = buildRequestContext()
+      whenever(personalRelationshipsGateway.getLinkedPrisoner(contactId.toLong(), 1, 10, requestContext)).thenReturn(Response(gwResponse))
+      val response = getContactService.getContactLinkedPrisoners(contactId = contactId.toLong(), 1, 10, requestContext)
+
+      response.data
+        ?.content
+        ?.size
+        .shouldBe(1)
+      response.data
+        ?.content
+        ?.first()
+        ?.prisonerNumber
+        .shouldBe("AA1234BC")
+      response.data?.perPage?.shouldBe(10)
+      response.data?.page?.shouldBe(1)
+    }
+
+    it("will return the upstream 404 for linked offenders for contactId") {
+      val requestContext = buildRequestContext()
+      val error =
+        UpstreamApiError(
+          UpstreamApi.PERSONAL_RELATIONSHIPS,
+          UpstreamApiError.Type.ENTITY_NOT_FOUND,
+        )
+      whenever(personalRelationshipsGateway.getLinkedPrisoner(contactId.toLong(), 1, 10, requestContext)).thenReturn(Response(null, listOf(error)))
+      val response = getContactService.getContactLinkedPrisoners(contactId = contactId.toLong(), 1, 10, requestContext)
+      response.data?.shouldBe(null)
+      response.errors[0].shouldBe(error)
     }
   })


### PR DESCRIPTION
New endpoint  `/v1/contacts/{contactId}/linked-prisoners `for JAI to retrieve linked prisoner details (using the contact id returned by the contact search.

The getLinkedPrisoner method already exists (but it doesnt support pagination) which is why ive modified it