### PR TITLE
HIA-1493: Corrected search mismatch and corrected upstream endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsController.kt
@@ -110,7 +110,7 @@ class ContactsController(
     @RequestAttribute requestContext: RequestContext?,
     @Valid @RequestBody request: ContactSearchRequest? = null,
   ): ResponseEntity<PaginatedResponse<ContactSearchResponseItem>> {
-    val req = request ?: ContactSearchRequest(firstName, lastName, middleNames, dateOfBirth, searchType)
+    val req = request ?: ContactSearchRequest(firstName, middleNames, lastName, dateOfBirth, searchType)
     req.validate()
 
     val response = contactSearchService.contactSearch(req, pageNo, perPage, requestContext)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/ContactSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/ContactSearchRequest.kt
@@ -18,7 +18,7 @@ data class ContactSearchRequest(
   ): String {
     val uri =
       UriComponentsBuilder
-        .fromUriString("/contacts/search")
+        .fromUriString("/contact/search")
     // Downstream pagination is zero based
     uri.queryParam("page", (pageNo - 1).toString())
     uri.queryParam("size", perPage.toString())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/controllers/v1/ContactsControllerTest.kt
@@ -248,6 +248,14 @@ internal class ContactsControllerTest(
           .first()
           .firstName
           .shouldBe("John")
+        response.data
+          .first()
+          .middleNames
+          .shouldBe("Simon")
+        response.data
+          .first()
+          .lastName
+          .shouldBe("Smith")
       }
 
       it("returns a 400 status code when no search criteria found") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/personalRelationships/PersonalRelationshipsGatewayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/personalRelationships/PersonalRelationshipsGatewayTest.kt
@@ -381,7 +381,7 @@ class PersonalRelationshipsGatewayTest(
       it("returns a search response") {
 
         personalRelationshipsApiMockServer.stubForGet(
-          "/contacts/search?page=0&size=10&firstName=John&searchType=EXACT",
+          "/contact/search?page=0&size=10&firstName=John&searchType=EXACT",
           body =
             File(
               fixturesPath,
@@ -418,7 +418,7 @@ class PersonalRelationshipsGatewayTest(
 
       it("returns a 404 response") {
         personalRelationshipsApiMockServer.stubForGet(
-          "/contacts/search?page=0&size=10&firstName=John&searchType=EXACT",
+          "/contact/search?page=0&size=10&firstName=John&searchType=EXACT",
           body = "",
           status = HttpStatus.NOT_FOUND,
         )
@@ -429,7 +429,7 @@ class PersonalRelationshipsGatewayTest(
 
       it("returns a 400 response") {
         personalRelationshipsApiMockServer.stubForGet(
-          "/contacts/search?page=0&size=10&searchType=EXACT",
+          "/contact/search?page=0&size=10&searchType=EXACT",
           body = "",
           status = HttpStatus.BAD_REQUEST,
         )


### PR DESCRIPTION
The search criteria was in the incorrect order (middleName was in lastName place)
The upstream endpoint should be `contact/search` not `contacts/search`