### PR TITLE
HIA-1493: Change smoke test obo username

### DIFF
--- a/scripts/K6/smoke-tests.js
+++ b/scripts/K6/smoke-tests.js
@@ -61,10 +61,10 @@ const httpOboHeaderParams = {
     //          "aud":"testAud"
     //          "iss":"testIss"
     //          "appid":"testId"
-    //          "unique_name":"testName"
+    //          "unique_name":"hmpps-external-api@justice.gov.uk"
     //        }
     //      }
-    'X-On-Behalf-Of': "eyJhbGciOiJub25lIiwia2lkIjoidGVzdEtpZCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjoidGVzdEF1ZCIsImlzcyI6InRlc3RJc3MiLCJhcHBpZCI6InRlc3RJZCIsInVuaXF1ZV9uYW1lIjoidGVzdE5hbWUifQ."
+    'X-On-Behalf-Of': "eyJhbGciOiJub25lIiwia2lkIjoidGVzdEtpZCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMiwiYXVkIjoidGVzdEF1ZCIsImlzcyI6InRlc3RJc3MiLCJhcHBpZCI6InRlc3RJZCIsInVuaXF1ZV9uYW1lIjoiaG1wcHMtZXh0ZXJuYWwtYXBpQGp1c3RpY2UuZ292LnVrIn0."
   },
 };
 


### PR DESCRIPTION
To be able to track the requests to auth better in app insights, changing `testUser` to `hmpps-external-api@justice.gov.uk`