### PR TITLE
HIA-1529: Filter assessment summary event using detail url

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/enums/IntegrationEventType.kt
@@ -121,6 +121,8 @@ enum class PrisonerChangedCategory {
   PHYSICAL_DETAILS,
 }
 
+const val ASSESSMENT_STATUS_COMPLETE = "COMPLETE"
+
 val PERSON_ADDRESS_EVENTS =
   listOf(
     DomainEventName.ProbabtionCase.Address.CREATED,
@@ -394,7 +396,7 @@ enum class IntegrationEventType(
   ),
   ASSESSMENT_SUMMARY_CHANGE(
     "v1/persons/{hmppsId}/assessment-summary",
-    { ASSESSMENT_SUMMARY_TYPES.contains(it.eventType) },
+    { ASSESSMENT_SUMMARY_TYPES.contains(it.eventType) && it.isCompletedAssessmentEvent() },
     featureFlag = FeatureFlagConfig.USE_ASSESSMENT_SUMMARY_ENDPOINT,
     description = "Assessment Summary Changed",
   ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/models/HmppsDomainEventModels.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/models/HmppsDomainEventModels.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.models
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.enums.ASSESSMENT_STATUS_COMPLETE
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.roles.dsl.MappaCategory
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -13,8 +14,11 @@ data class HmppsDomainEvent(
   @JsonProperty("reason") val reason: String? = null,
   @JsonProperty("prisonerId") val prisonerId: String? = null,
   @JsonProperty("prisonId") val prisonId: String? = null,
+  @JsonProperty("detailUrl") val detailUrl: String? = null,
 ) {
   fun isValidContactEvent(): Boolean = additionalInformation?.mappa?.category != null && MappaCategory.from(additionalInformation.mappa.category) != MappaCategory.UNKNOWN
+
+  fun isCompletedAssessmentEvent(): Boolean = detailUrl?.split("/")?.lastOrNull() == ASSESSMENT_STATUS_COMPLETE
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/helpers/DomainEvents.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/helpers/DomainEvents.kt
@@ -70,6 +70,11 @@ object DomainEvents {
     {\"eventType\":\"assessment.summary.produced\",\"version\": 1,\"description\":\"Assessment Summary has been produced\",\"detailUrl\":\"https://oasys.service.justice.gov.uk/eor/oasys/ass/asssumm/R007565/ALLOW/2513077240/COMPLETE\",\"occurredAt\": \"2024-08-14T12:33:34+01:00\",\"personReference\":{\"identifiers\":[{\"type\": \"CRN\", \"value\": \"$crn\"}]}}
     """.trimIndent()
 
+  val ASSESSMENT_SUMMARY_PRODUCED_LOCKED_INCOMPLETE =
+    """
+    {\"eventType\":\"assessment.summary.produced\",\"version\": 1,\"description\":\"Assessment Summary has been produced\",\"detailUrl\":\"https://oasys.service.justice.gov.uk/eor/oasys/ass/asssumm/R007565/ALLOW/2513077240/LOCKED_INCOMPLETE\",\"occurredAt\": \"2024-08-14T12:33:34+01:00\",\"personReference\":{\"identifiers\":[{\"type\": \"CRN\", \"value\": \"$crn\"}]}}
+    """.trimIndent()
+
   private val sqsNotificationGeneratingHelper =
     SqsNotificationGeneratingHelper()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventsListenerAssessmentSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventsListenerAssessmentSummaryTest.kt
@@ -1,28 +1,55 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.listeners
 
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.entities.EventNotification
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED_LOCKED_INCOMPLETE
 
 class DomainEventsListenerAssessmentSummaryTest : DomainEventsListenerTestCase() {
   private val crn = "X777776"
 
   @Test
-  fun `will process and save a assessment summary notification`() {
+  fun `will process and save a assessment summary notification with the correct status`() {
     // Arrange
     val eventType = "assessment.summary.produced"
     val message = ASSESSMENT_SUMMARY_PRODUCED
+    assumeIdentities(hmppsId = crn)
 
     val payload =
       DomainEvents
         .generateDomainEvent(eventType, message)
 
-    // Act, Assert
-    onDomainEventShouldCreateEventNotification(
-      hmppsEventRawMessage = payload,
-      hmppsId = crn,
-      expectedNotificationType = IntegrationEventType.ASSESSMENT_SUMMARY_CHANGE.toString(),
-    )
+    domainEventsListener.onDomainEvent(payload)
+    // Assert
+    val events = mutableListOf<EventNotification>()
+    verify { eventNotificationRepository.insert(capture(events)) }
+
+    assertThat(events.size).isEqualTo(2)
+    assertThat(events.map { it.eventType }).contains(IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED.name)
+    assertThat(events.map { it.eventType }).contains(IntegrationEventType.ASSESSMENT_SUMMARY_CHANGE.name)
+  }
+
+  @Test
+  fun `will NOT create a assessment summary notification when incorrect status - will only create a RISK_OF_SERIOUS_HARM_CHANGED`() {
+    // Arrange
+    val eventType = "assessment.summary.produced"
+    val message = ASSESSMENT_SUMMARY_PRODUCED_LOCKED_INCOMPLETE
+    assumeIdentities(hmppsId = crn)
+
+    val payload =
+      DomainEvents
+        .generateDomainEvent(eventType, message)
+
+    domainEventsListener.onDomainEvent(payload)
+    // Assert
+    val events = mutableListOf<EventNotification>()
+    verify { eventNotificationRepository.insert(capture(events)) }
+
+    assertThat(events.size).isEqualTo(1)
+    assertThat(events.map { it.eventType }).contains(IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED.name)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/models/DomainEventPredicatesTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/models/DomainEventPredicatesTests.kt
@@ -29,4 +29,22 @@ class DomainEventPredicatesTests {
     val event = SqsNotificationGeneratingHelper().createHmppsDomainEvent().copy(additionalInformation = AdditionalInformation(mappa = Mappa(1)))
     assertTrue(event.isValidContactEvent())
   }
+
+  @Test
+  fun `is not a completed assessment event when no detail url`() {
+    val event = SqsNotificationGeneratingHelper().createHmppsDomainEvent()
+    assertFalse(event.isCompletedAssessmentEvent())
+  }
+
+  @Test
+  fun `is not a completed assessment event when the detail url ends with LOCKED_INCOMPLETE `() {
+    val event = SqsNotificationGeneratingHelper().createHmppsDomainEvent().copy(detailUrl = "http://localhost/eor/oasys/ass/asssumm/R007565/ALLOW/2513077240/LOCKED_INCOMPLETE")
+    assertFalse(event.isCompletedAssessmentEvent())
+  }
+
+  @Test
+  fun `is  a completed assessment event when the detail url ends with complete`() {
+    val event = SqsNotificationGeneratingHelper().createHmppsDomainEvent().copy(detailUrl = "http://localhost/eor/oasys/ass/asssumm/R007565/ALLOW/2513077240/COMPLETE")
+    assertTrue(event.isCompletedAssessmentEvent())
+  }
 }


### PR DESCRIPTION
Only assessment.summary.produced domain events that have a `detailUrl` ending with COMPLETE should trigger an `ASSESSMENT_SUMMARY_CHANGE` external api event