### PR TITLE
Hia 1391 deprecate severity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
@@ -10,5 +10,6 @@ data class Need(
   @Schema(description = "Risk of reoffending")
   val riskOfReoffending: Boolean? = null,
   @Schema(description = "Severity of need", example = "NO_NEED", deprecated = true)
+  @Deprecated("No longer populated by upstream. This will always be null")
   val severity: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
@@ -9,7 +9,7 @@ data class Need(
   val riskOfHarm: Boolean? = null,
   @Schema(description = "Risk of reoffending")
   val riskOfReoffending: Boolean? = null,
-  @Schema(description = "Severity of need", example = "NO_NEED", deprecated = true)
+  @Schema(description = "Severity of need", example = "null", deprecated = true)
   @Deprecated("No longer populated by upstream. This will always be null")
   val severity: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
@@ -9,6 +9,6 @@ data class Need(
   val riskOfHarm: Boolean? = null,
   @Schema(description = "Risk of reoffending")
   val riskOfReoffending: Boolean? = null,
-  @Schema(description = "Severity of need", example = "NO_NEED")
+  @Schema(description = "Severity of need", example = "NO_NEED", deprecated = true)
   val severity: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Need.kt
@@ -9,7 +9,7 @@ data class Need(
   val riskOfHarm: Boolean? = null,
   @Schema(description = "Risk of reoffending")
   val riskOfReoffending: Boolean? = null,
-  @Schema(description = "Severity of need", example = "null", deprecated = true)
+  @Schema(description = "Severity of need", deprecated = true)
   @Deprecated("No longer populated by upstream. This will always be null")
   val severity: String? = null,
 )


### PR DESCRIPTION
Deprecating the `severity` field in the `Need` model

<img width="706" height="669" alt="image" src="https://github.com/user-attachments/assets/29b252ef-cbc1-4014-bb74-d22f7c678af2" />
