### PR TITLE
HIA-1534: Add completed assessment filter to ROSH event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/enums/IntegrationEventType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/enums/IntegrationEventType.kt
@@ -391,7 +391,7 @@ enum class IntegrationEventType(
   ),
   RISK_OF_SERIOUS_HARM_CHANGED(
     "v1/persons/{hmppsId}/risks/serious-harm",
-    { ROSH_TYPES.contains(it.eventType) },
+    { ROSH_TYPES.contains(it.eventType) && it.isCompletedAssessmentEvent() },
     description = "Risk of Serious Harm Changed",
   ),
   ASSESSMENT_SUMMARY_CHANGE(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventsListenerAssessmentSummaryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventsListenerAssessmentSummaryTest.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.listeners
 
-import io.mockk.verify
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.entities.EventNotification
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED
@@ -23,18 +20,16 @@ class DomainEventsListenerAssessmentSummaryTest : DomainEventsListenerTestCase()
       DomainEvents
         .generateDomainEvent(eventType, message)
 
-    domainEventsListener.onDomainEvent(payload)
-    // Assert
-    val events = mutableListOf<EventNotification>()
-    verify { eventNotificationRepository.insert(capture(events)) }
-
-    assertThat(events.size).isEqualTo(2)
-    assertThat(events.map { it.eventType }).contains(IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED.name)
-    assertThat(events.map { it.eventType }).contains(IntegrationEventType.ASSESSMENT_SUMMARY_CHANGE.name)
+    // Act, Assert
+    onDomainEventShouldCreateEventNotification(
+      hmppsEventRawMessage = payload,
+      hmppsId = crn,
+      expectedNotificationType = IntegrationEventType.ASSESSMENT_SUMMARY_CHANGE.toString(),
+    )
   }
 
   @Test
-  fun `will NOT create a assessment summary notification when incorrect status - will only create a RISK_OF_SERIOUS_HARM_CHANGED`() {
+  fun `will NOT create a assessment summary notification when incorrect status`() {
     // Arrange
     val eventType = "assessment.summary.produced"
     val message = ASSESSMENT_SUMMARY_PRODUCED_LOCKED_INCOMPLETE
@@ -44,12 +39,6 @@ class DomainEventsListenerAssessmentSummaryTest : DomainEventsListenerTestCase()
       DomainEvents
         .generateDomainEvent(eventType, message)
 
-    domainEventsListener.onDomainEvent(payload)
-    // Assert
-    val events = mutableListOf<EventNotification>()
-    verify { eventNotificationRepository.insert(capture(events)) }
-
-    assertThat(events.size).isEqualTo(1)
-    assertThat(events.map { it.eventType }).contains(IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED.name)
+    onDomainEventShouldNotCreateEventNotification(payload)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventsListenerROSHTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/events/listeners/DomainEventsListenerROSHTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.enums.IntegrationEventType
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.events.helpers.DomainEvents.ASSESSMENT_SUMMARY_PRODUCED_LOCKED_INCOMPLETE
 
 class DomainEventsListenerROSHTest : DomainEventsListenerTestCase() {
   private val crn = "X777776"
@@ -24,5 +25,19 @@ class DomainEventsListenerROSHTest : DomainEventsListenerTestCase() {
       hmppsId = crn,
       expectedNotificationType = IntegrationEventType.RISK_OF_SERIOUS_HARM_CHANGED.toString(),
     )
+  }
+
+  @Test
+  fun `will NOT create a rosh notification when incorrect status`() {
+    // Arrange
+    val eventType = "assessment.summary.produced"
+    val message = ASSESSMENT_SUMMARY_PRODUCED_LOCKED_INCOMPLETE
+    assumeIdentities(hmppsId = crn)
+
+    val payload =
+      DomainEvents
+        .generateDomainEvent(eventType, message)
+
+    onDomainEventShouldNotCreateEventNotification(payload)
   }
 }


### PR DESCRIPTION
Added the `isCompletedAssessmentEvent` filter to the `RISK_OF_SERIOUS_HARM` event to prevent notifications being sent for incomplete assessments