### PR TITLE
HIA-1536: Test Additional Config

### DIFF
--- a/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
+++ b/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
@@ -6,12 +6,9 @@ metadata:
   name: yaml-override-config
 data:
   override.yaml: |
-    authorisation-test:
+    authorisation:
       consumers:
-        test1:
-          roles:
-            - "status-only"
-        test2:
+        pmcphee:
           roles:
             - "full-access"
   {{- end -}}

--- a/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
+++ b/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
@@ -10,5 +10,5 @@ data:
       consumers:
         pmcphee:
           roles:
-            - "full-access"
+            - "status-only"
   {{- end -}}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,7 @@
+spring:
+  config:
+    import: "optional:file:/app/test-override.yaml"
+
 services:
   int-api:
     base-url: https://dev.integration-api.hmpps.service.justice.gov.uk

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import: "resource:classpath:test-auth-override.yaml"
+
   datasource:
     url: "jdbc:postgresql://localhost:5432/event_store?sslmode=prefer"
     username: postgres
@@ -137,12 +140,6 @@ feature-flag:
 
 authorisation:
   consumers:
-    automated-test-client:
-      roles:
-        - "full-access"
-        - "mappa-cat4"
-      filters:
-      queueName: "testqueue"
     automated-test-client-mappa:
       roles:
         - "full-access"

--- a/src/main/resources/test-auth-override.yaml
+++ b/src/main/resources/test-auth-override.yaml
@@ -1,0 +1,8 @@
+authorisation:
+  consumers:
+    automated-test-client:
+      roles:
+        - "full-access"
+        - "mappa-cat4"
+      filters:
+      queueName: "testqueue"


### PR DESCRIPTION
This PR proves the use of an override config file in the integration tests by moving the `automated-test-client` consumer out of the main config into a separate file to import.

Testing that the `pmcphee` in dev is also updated using the config map to be given the status only role