### PR TITLE
HIA-1536: Pass additional config to helm chart

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -48,6 +48,7 @@ jobs:
       environment: 'dev'
       app_version: '${{ needs.build.outputs.app_version }}'
       slack_notification: 'true' # if 'true', it needs a valid NONPROD_RELEASES_SLACK_CHANNEL variable to be set
+      helm_additional_args: '--set "config-override.data=${{ vars.AUTH_CONFIG_DEV }}"'
   dev-smoke-tests:
     uses: ./.github/workflows/smoke-test-dev.yml
     secrets: inherit

--- a/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
+++ b/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
@@ -6,9 +6,5 @@ metadata:
   name: yaml-override-config
 data:
   override.yaml: |
-    authorisation:
-      consumers:
-        pmcphee:
-          roles:
-            - "status-only"
-  {{- end -}}
+  {{ index .Values "config-override" "data" }}
+{{- end -}}


### PR DESCRIPTION
Test auth config is set up in GitHub as follows in the [variables section ](https://github.com/ministryofjustice/hmpps-integration-api/settings/variables/actions/AUTH_CONFIG_DEV)
<img width="1049" height="584" alt="image" src="https://github.com/user-attachments/assets/0fb7d993-1a70-4a06-afe7-1e8fcfe0f16b" />

This PR will pass this down as an additional parameter in the deploy to dev job.
This should then be used as the content for the additional config file
