### PR TITLE
HIA-1536: Base64 encode/decode helm value

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,6 +33,16 @@ jobs:
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || true }}
       docker_multiplatform: false
+  authConfig:
+    runs-on: ubuntu-latest
+    name: Encode Auth config
+    outputs:
+      devConfig: ${{ steps.auth_output.outputs.encoded }}
+    steps:
+      - name: Get Dev Auth Config
+        run: |
+          echo "encoded=$(echo '${{ vars.AUTH_CONFIG_DEV }}' | base64 -w 0)" >> ${GITHUB_OUTPUT}
+        id: auth_output
   deploy_dev:
     concurrency:
       # Only 1 job can deploy to dev at a time
@@ -40,6 +50,7 @@ jobs:
       cancel-in-progress: false
     name: Deploy to the development environment
     needs:
+      - authConfig
       - build
       - test
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
@@ -48,6 +59,7 @@ jobs:
       environment: 'dev'
       app_version: '${{ needs.build.outputs.app_version }}'
       slack_notification: 'true' # if 'true', it needs a valid NONPROD_RELEASES_SLACK_CHANNEL variable to be set
+      helm_additional_args: '--set "config-override.data=${{ needs.authConfig.outputs.devConfig }}"'
   dev-smoke-tests:
     uses: ./.github/workflows/smoke-test-dev.yml
     secrets: inherit

--- a/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
+++ b/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
@@ -6,9 +6,5 @@ metadata:
   name: yaml-override-config
 data:
   override.yaml: |
-    authorisation:
-      consumers:
-        pmcphee:
-          roles:
-            - "status-only"
-  {{- end -}}
+  {{ index .Values "config-override" "data" | b64dec }}
+{{- end -}}

--- a/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
+++ b/helm_deploy/hmpps-integration-api/templates/config-override-test.yaml
@@ -1,10 +1,12 @@
 {{- $config := index .Values "config-override" | default dict -}}
 {{- if $config.enabled | default false -}}
+{{- if $config.data }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: yaml-override-config
 data:
   override.yaml: |
-  {{ index .Values "config-override" "data" | b64dec }}
+  {{ $config.data | b64dec }}
+{{- end }}
 {{- end -}}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,7 +1,3 @@
-spring:
-  config:
-    import: "optional:file:/app/test-override.yaml"
-
 services:
   int-api:
     base-url: https://dev.integration-api.hmpps.service.justice.gov.uk


### PR DESCRIPTION
PR to pass the auth config down in the helm command from the value of a GitHub variable
The config map will take the value passed down from helm.
Base64 encoding / decoding allow this to be passed as a helm --set argument.

Removing the config import in the dev profile until we can see the override config looks correct