### PR TITLE
HIA-1560: use preferred_username rather than email for Entra obo service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationService.kt
@@ -182,7 +182,7 @@ class AuthorisationService(
   fun allNull(vararg values: List<Any>?) = values.all { it == null }
 
   private val entraJwksUrl = URI.create("https://login.microsoftonline.com/common/discovery/v2.0/keys").toURL()
-  private val entraOboService = JwksOboService(entraJwksUrl, "email")
+  private val entraOboService = JwksOboService(entraJwksUrl, "preferred_username")
 
   fun oboService(consumerName: String): OboService? {
     val oboServiceName = authorisationConfig.consumers[consumerName]?.oboConfig?.strategy


### PR DESCRIPTION
JAI have now hooked up their app, but the tokens being sent dont have an `email` claim, they have a `preferred_username` claim. Changing to `preferred_username`