### PR TITLE
HIA-1293 POC for mockable REST API client

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.http.codec.json.JacksonJsonDecoder
+import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
@@ -42,11 +43,41 @@ class RestApiClient(
     responseType: KClass<T>,
     headers: Map<String, String> = mapOf(),
     options: RestApiOptions? = null,
-  ): RestApiResponse<T> {
-    val opts = options ?: defaultOptions
+  ): RestApiResponse<T> = request(HttpMethod.GET, path, null, headers, options ?: defaultOptions, responseType)
 
+  fun <T : Any> post(
+    path: String,
+    requestBody: Any? = null,
+    responseType: KClass<T>,
+    headers: Map<String, String> = mapOf(),
+    options: RestApiOptions? = null,
+  ): RestApiResponse<T> = request(HttpMethod.POST, path, requestBody, headers, options ?: defaultOptions, responseType)
+
+  fun <T : Any> getList(
+    path: String,
+    responseType: KClass<T>,
+    headers: Map<String, String> = mapOf(),
+    options: RestApiOptions? = null,
+  ): RestApiResponse<List<T>> = requestForList(HttpMethod.GET, path, null, headers, options ?: defaultOptions, responseType)
+
+  fun <T : Any> postForList(
+    path: String,
+    requestBody: Any? = null,
+    responseType: KClass<T>,
+    headers: Map<String, String> = mapOf(),
+    options: RestApiOptions? = null,
+  ): RestApiResponse<List<T>> = requestForList(HttpMethod.POST, path, requestBody, headers, options ?: defaultOptions, responseType)
+
+  private fun <T : Any> request(
+    method: HttpMethod,
+    path: String,
+    requestBody: Any? = null,
+    headers: Map<String, String>,
+    opts: RestApiOptions,
+    responseType: KClass<T>,
+  ): RestApiResponse<T> {
     try {
-      val request = buildRequest(HttpMethod.GET, path, headers, opts)
+      val request = buildRequest(method, path, requestBody, headers, opts)
 
       val responseSpec = retrieveWithOptionalRetry(request, path, opts)
 
@@ -62,16 +93,16 @@ class RestApiClient(
     }
   }
 
-  fun <T : Any> getList(
+  internal fun <T : Any> requestForList(
+    method: HttpMethod,
     path: String,
+    requestBody: Any? = null,
+    headers: Map<String, String>,
+    opts: RestApiOptions,
     responseType: KClass<T>,
-    headers: Map<String, String> = mapOf(),
-    options: RestApiOptions? = null,
   ): RestApiResponse<List<T>> {
-    val opts = options ?: defaultOptions
-
     try {
-      val request = buildRequest(HttpMethod.GET, path, headers, opts)
+      val request = buildRequest(method, path, requestBody, headers, opts)
 
       val responseSpec = retrieveWithOptionalRetry(request, path, opts)
 
@@ -106,13 +137,22 @@ class RestApiClient(
   internal fun buildRequest(
     method: HttpMethod,
     path: String,
+    requestBody: Any? = null,
     headers: Map<String, String>,
     opts: RestApiOptions,
-  ): WebClient.RequestBodySpec =
-    webClient(opts)
-      .method(method)
-      .uri(path)
-      .headers(mapHeaders(headers))
+  ): WebClient.RequestBodySpec {
+    var spec =
+      webClient(opts)
+        .method(method)
+        .uri(path)
+        .headers(mapHeaders(headers))
+
+    if (requestBody != null) {
+      spec.body(BodyInserters.fromValue(requestBody))
+    }
+
+    return spec
+  }
 
   internal fun <T : Any> wrapError(e: Exception): RestApiResponse<T> =
     when (e) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -44,13 +44,9 @@ class RestApiClient(
   ): RestApiResponse<T> {
     val opts = options ?: defaultOptions
 
-    val request =
-      webClient(opts)
-        .method(HttpMethod.GET)
-        .uri(path)
-        .headers(mapHeaders(headers))
-
     try {
+      val request = buildRequest(path, headers, opts)
+
       var responseSpec = request.retrieve()
 
       responseSpec = addOptionalRetry(opts, responseSpec, path)
@@ -62,14 +58,27 @@ class RestApiClient(
       val data = mono.block()
 
       return RestApiResponse(apiName, HttpStatus.OK, data)
-    } catch (e: WebClientResponseException) {
-      return RestApiResponse(apiName, HttpStatus.valueOf(e.statusCode.value()), null, listOf(e))
-    } catch (e: DecodingException) {
-      return RestApiResponse(apiName, HttpStatus.OK, null, listOf(e))
     } catch (e: Exception) {
-      return RestApiResponse(apiName, null, null, listOf(e))
+      return wrapError(e)
     }
   }
+
+  internal fun buildRequest(
+    path: String,
+    headers: Map<String, String>,
+    opts: RestApiOptions,
+  ): WebClient.RequestBodySpec =
+    webClient(opts)
+      .method(HttpMethod.GET)
+      .uri(path)
+      .headers(mapHeaders(headers))
+
+  internal fun <T : Any> wrapError(e: Exception): RestApiResponse<T> =
+    when (e) {
+      is WebClientResponseException -> RestApiResponse(apiName, HttpStatus.valueOf(e.statusCode.value()), null, listOf(e))
+      is DecodingException -> RestApiResponse(apiName, HttpStatus.OK, null, listOf(e))
+      else -> RestApiResponse(apiName, null, null, listOf(e))
+    }
 
   internal fun <T : Any> addOptionalRetry(
     opts: RestApiOptions,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -53,18 +53,11 @@ class RestApiClient(
     try {
       var responseSpec = request.retrieve()
 
-      if (opts.retryAttempts > 0) {
-        responseSpec =
-          responseSpec.onStatus({ status -> status.value() in retryCodes }) { response ->
-            retryError(response, apiName, HttpMethod.GET, path)
-          }
-      }
+      responseSpec = addOptionalRetry(opts, responseSpec, path)
 
       var mono = responseSpec.bodyToMono(responseType.java)
 
-      if (opts.retryAttempts > 0) {
-        mono = mono.retryWhen(retrySpec(opts))
-      }
+      mono = addOptionalRetry(opts, mono)
 
       val data = mono.block()
 
@@ -78,11 +71,34 @@ class RestApiClient(
     }
   }
 
+  internal fun <T : Any> addOptionalRetry(
+    opts: RestApiOptions,
+    mono: Mono<T>,
+  ): Mono<T> =
+    if (opts.retryAttempts > 0) {
+      mono.retryWhen(retrySpec(opts))
+    } else {
+      mono
+    }
+
+  internal fun addOptionalRetry(
+    opts: RestApiOptions,
+    responseSpec: WebClient.ResponseSpec,
+    path: String,
+  ): WebClient.ResponseSpec =
+    if (opts.retryAttempts > 0) {
+      responseSpec.onStatus({ status -> status.value() in retryCodes }) { response ->
+        retryError(response, apiName, HttpMethod.GET, path)
+      }
+    } else {
+      responseSpec
+    }
+
   private fun mapHeaders(headers: Map<String, String>): Consumer<HttpHeaders> = { header -> headers.forEach { requestHeader -> header.set(requestHeader.key, requestHeader.value) } }
 
-  private fun isSafeToRetry(throwable: Throwable) = throwable is ResponseException || throwable is WebClientRequestException
+  internal fun isSafeToRetry(throwable: Throwable) = throwable is ResponseException || throwable is WebClientRequestException
 
-  private fun retrySpec(opts: RestApiOptions) =
+  internal fun retrySpec(opts: RestApiOptions) =
     Retry
       .backoff(opts.retryAttempts, opts.initialBackOffDuration)
       .filter { throwable -> isSafeToRetry(throwable) }
@@ -115,7 +131,7 @@ class RestApiClient(
         configurer.defaultCodecs().maxInMemorySize(-1)
       }.build()
 
-  private fun webClient(options: RestApiOptions) =
+  internal fun webClient(options: RestApiOptions) =
     webClient ?: WebClient
       .builder()
       .baseUrl(baseUrl)
@@ -123,7 +139,7 @@ class RestApiClient(
       .exchangeStrategies(strategies)
       .build()
 
-  fun retryError(
+  internal fun retryError(
     response: ClientResponse,
     upstreamApi: String,
     method: HttpMethod,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -46,11 +46,9 @@ class RestApiClient(
     val opts = options ?: defaultOptions
 
     try {
-      val request = buildRequest(path, headers, opts)
+      val request = buildRequest(HttpMethod.GET, path, headers, opts)
 
-      var responseSpec = request.retrieve()
-
-      responseSpec = addOptionalRetry(opts, responseSpec, path)
+      val responseSpec = retrieveWithOptionalRetry(request, path, opts)
 
       var mono = responseSpec.bodyToMono(responseType.java)
 
@@ -73,11 +71,9 @@ class RestApiClient(
     val opts = options ?: defaultOptions
 
     try {
-      val request = buildRequest(path, headers, opts)
+      val request = buildRequest(HttpMethod.GET, path, headers, opts)
 
-      var responseSpec = request.retrieve()
-
-      responseSpec = addOptionalRetry(opts, responseSpec, path)
+      val responseSpec = retrieveWithOptionalRetry(request, path, opts)
 
       var flux = responseSpec.bodyToFlux(responseType.java)
 
@@ -91,13 +87,30 @@ class RestApiClient(
     }
   }
 
+  internal fun retrieveWithOptionalRetry(
+    request: WebClient.RequestBodySpec,
+    path: String,
+    opts: RestApiOptions,
+  ): WebClient.ResponseSpec {
+    val responseSpec = request.retrieve()
+
+    return if (opts.retryAttempts > 0) {
+      responseSpec.onStatus({ status -> status.value() in retryCodes }) { response ->
+        retryError(response, apiName, HttpMethod.GET, path)
+      }
+    } else {
+      responseSpec
+    }
+  }
+
   internal fun buildRequest(
+    method: HttpMethod,
     path: String,
     headers: Map<String, String>,
     opts: RestApiOptions,
   ): WebClient.RequestBodySpec =
     webClient(opts)
-      .method(HttpMethod.GET)
+      .method(method)
       .uri(path)
       .headers(mapHeaders(headers))
 
@@ -126,19 +139,6 @@ class RestApiClient(
       flux.retryWhen(retrySpec(opts))
     } else {
       flux
-    }
-
-  internal fun addOptionalRetry(
-    opts: RestApiOptions,
-    responseSpec: WebClient.ResponseSpec,
-    path: String,
-  ): WebClient.ResponseSpec =
-    if (opts.retryAttempts > 0) {
-      responseSpec.onStatus({ status -> status.value() in retryCodes }) { response ->
-        retryError(response, apiName, HttpMethod.GET, path)
-      }
-    } else {
-      responseSpec
     }
 
   private fun mapHeaders(headers: Map<String, String>): Consumer<HttpHeaders> = { header -> headers.forEach { requestHeader -> header.set(requestHeader.key, requestHeader.value) } }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -68,6 +68,11 @@ class RestApiClient(
     options: RestApiOptions? = null,
   ): RestApiResponse<List<T>> = requestForList(HttpMethod.POST, path, requestBody, headers, options, responseType)
 
+  fun authHeaders(authToken: String): Map<String, String> =
+    mapOf(
+      "Authorization" to "Bearer $authToken",
+    )
+
   internal fun <T : Any> request(
     method: HttpMethod,
     path: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -34,7 +34,7 @@ class RestApiClient(
   val defaultOptions: RestApiOptions = RestApiOptions(),
   val webClient: WebClient? = null,
 ) {
-  val CREATE_TRANSACTION_RETRY_HTTP_CODES = listOf(502, 503, 504, 522, 599, 499, 408)
+  val retryCodes = listOf(502, 503, 504, 522, 599, 499, 408)
 
   fun <T : Any> get(
     path: String,
@@ -55,7 +55,7 @@ class RestApiClient(
 
       if (opts.retryAttempts > 0) {
         responseSpec =
-          responseSpec.onStatus({ status -> status.value() in CREATE_TRANSACTION_RETRY_HTTP_CODES }) { response ->
+          responseSpec.onStatus({ status -> status.value() in retryCodes }) { response ->
             retryError(response, apiName, HttpMethod.GET, path)
           }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -1,0 +1,152 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.netty.channel.ChannelOption
+import org.springframework.core.codec.DecodingException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.http.codec.json.JacksonJsonDecoder
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientRequestException
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Mono
+import reactor.netty.http.client.HttpClient
+import reactor.util.retry.Retry
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.ResponseException
+import java.time.Duration
+import java.util.function.Consumer
+import kotlin.collections.emptyList
+import kotlin.reflect.KClass
+
+/**
+ * Mockable client wrapper for making upstream API calls.
+ */
+class RestApiClient(
+  val apiName: String,
+  val baseUrl: String,
+  val defaultOptions: RestApiOptions = RestApiOptions(),
+  val webClient: WebClient? = null,
+) {
+  val CREATE_TRANSACTION_RETRY_HTTP_CODES = listOf(502, 503, 504, 522, 599, 499, 408)
+
+  fun <T : Any> get(
+    path: String,
+    responseType: KClass<T>,
+    headers: Map<String, String> = mapOf(),
+    options: RestApiOptions? = null,
+  ): RestApiResponse<T> {
+    val opts = options ?: defaultOptions
+
+    val request =
+      webClient(opts)
+        .method(HttpMethod.GET)
+        .uri(path)
+        .headers(mapHeaders(headers))
+
+    try {
+      var responseSpec = request.retrieve()
+
+      if (opts.retryAttempts > 0) {
+        responseSpec =
+          responseSpec.onStatus({ status -> status.value() in CREATE_TRANSACTION_RETRY_HTTP_CODES }) { response ->
+            retryError(response, apiName, HttpMethod.GET, path)
+          }
+      }
+
+      var mono = responseSpec.bodyToMono(responseType.java)
+
+      if (opts.retryAttempts > 0) {
+        mono = mono.retryWhen(retrySpec(opts))
+      }
+
+      val data = mono.block()
+
+      return RestApiResponse(apiName, HttpStatus.OK, data)
+    } catch (e: WebClientResponseException) {
+      return RestApiResponse(apiName, HttpStatus.valueOf(e.statusCode.value()), null, listOf(e))
+    } catch (e: DecodingException) {
+      return RestApiResponse(apiName, HttpStatus.OK, null, listOf(e))
+    } catch (e: Exception) {
+      return RestApiResponse(apiName, null, null, listOf(e))
+    }
+  }
+
+  private fun mapHeaders(headers: Map<String, String>): Consumer<HttpHeaders> = { header -> headers.forEach { requestHeader -> header.set(requestHeader.key, requestHeader.value) } }
+
+  private fun isSafeToRetry(throwable: Throwable) = throwable is ResponseException || throwable is WebClientRequestException
+
+  private fun retrySpec(opts: RestApiOptions) =
+    Retry
+      .backoff(opts.retryAttempts, opts.initialBackOffDuration)
+      .filter { throwable -> isSafeToRetry(throwable) }
+      .onRetryExhaustedThrow { _, retrySignal -> throw ResponseException("External Service failed to process after ${retrySignal.totalRetries()} retries with ${retrySignal.failure().message}", HttpStatus.SERVICE_UNAVAILABLE.value(), retrySignal.failure().cause) }
+
+  private fun httpClient(options: RestApiOptions) =
+    HttpClient
+      .create()
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, options.connectTimeoutMillis)
+      .responseTimeout(Duration.ofSeconds(options.responseTimeoutSeconds))
+
+  private val mapper: JsonMapper =
+    JsonMapper
+      .builder()
+      .configureForJackson2()
+      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+      .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+      .changeDefaultPropertyInclusion { it.withContentInclusion(JsonInclude.Include.NON_NULL) }
+      .addModule(KotlinModule.Builder().build())
+      .build()
+
+  private val strategies =
+    ExchangeStrategies
+      .builder()
+      .codecs { configurer ->
+        configurer
+          .defaultCodecs()
+          .jacksonJsonDecoder(JacksonJsonDecoder(mapper))
+        configurer.defaultCodecs().maxInMemorySize(-1)
+      }.build()
+
+  private fun webClient(options: RestApiOptions) =
+    webClient ?: WebClient
+      .builder()
+      .baseUrl(baseUrl)
+      .clientConnector(ReactorClientHttpConnector(httpClient(options)))
+      .exchangeStrategies(strategies)
+      .build()
+
+  fun retryError(
+    response: ClientResponse,
+    upstreamApi: String,
+    method: HttpMethod,
+    uri: String,
+  ): Mono<ResponseException> =
+    Mono.error(
+      ResponseException(
+        message = "Call to upstream api $upstreamApi failed. ${method.name()} for $uri returned ${response.statusCode().value()}",
+        statusCode = response.statusCode().value(),
+      ),
+    )
+}
+
+data class RestApiResponse<T>(
+  val apiName: String?,
+  val status: HttpStatus?,
+  val data: T?,
+  var errors: List<Exception> = emptyList(),
+)
+
+data class RestApiOptions(
+  val connectTimeoutMillis: Int = 10_000,
+  val responseTimeoutSeconds: Long = 15,
+  val retryAttempts: Long = 3L,
+  val initialBackOffDuration: Duration = Duration.ofSeconds(3),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -68,7 +68,7 @@ class RestApiClient(
     options: RestApiOptions? = null,
   ): RestApiResponse<List<T>> = requestForList(HttpMethod.POST, path, requestBody, headers, options ?: defaultOptions, responseType)
 
-  private fun <T : Any> request(
+  internal fun <T : Any> request(
     method: HttpMethod,
     path: String,
     requestBody: Any? = null,
@@ -141,7 +141,7 @@ class RestApiClient(
     headers: Map<String, String>,
     opts: RestApiOptions,
   ): WebClient.RequestBodySpec {
-    var spec =
+    val spec =
       webClient(opts)
         .method(method)
         .uri(path)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientRequestException
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
 import reactor.util.retry.Retry
@@ -63,6 +64,33 @@ class RestApiClient(
     }
   }
 
+  fun <T : Any> getList(
+    path: String,
+    responseType: KClass<T>,
+    headers: Map<String, String> = mapOf(),
+    options: RestApiOptions? = null,
+  ): RestApiResponse<List<T>> {
+    val opts = options ?: defaultOptions
+
+    try {
+      val request = buildRequest(path, headers, opts)
+
+      var responseSpec = request.retrieve()
+
+      responseSpec = addOptionalRetry(opts, responseSpec, path)
+
+      var flux = responseSpec.bodyToFlux(responseType.java)
+
+      flux = addOptionalRetry(opts, flux)
+
+      val data = flux.collectList().block() as List<T>
+
+      return RestApiResponse(apiName, HttpStatus.OK, data = data)
+    } catch (e: Exception) {
+      return wrapError(e)
+    }
+  }
+
   internal fun buildRequest(
     path: String,
     headers: Map<String, String>,
@@ -88,6 +116,16 @@ class RestApiClient(
       mono.retryWhen(retrySpec(opts))
     } else {
       mono
+    }
+
+  internal fun <T : Any> addOptionalRetry(
+    opts: RestApiOptions,
+    flux: Flux<T>,
+  ): Flux<T> =
+    if (opts.retryAttempts > 0) {
+      flux.retryWhen(retrySpec(opts))
+    } else {
+      flux
     }
 
   internal fun addOptionalRetry(
@@ -165,7 +203,7 @@ class RestApiClient(
 data class RestApiResponse<T>(
   val apiName: String?,
   val status: HttpStatus?,
-  val data: T?,
+  val data: T? = null,
   var errors: List<Exception> = emptyList(),
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -43,7 +43,7 @@ class RestApiClient(
     responseType: KClass<T>,
     headers: Map<String, String> = mapOf(),
     options: RestApiOptions? = null,
-  ): RestApiResponse<T> = request(HttpMethod.GET, path, null, headers, options ?: defaultOptions, responseType)
+  ): RestApiResponse<T> = request(HttpMethod.GET, path, null, headers, options, responseType)
 
   fun <T : Any> post(
     path: String,
@@ -51,14 +51,14 @@ class RestApiClient(
     responseType: KClass<T>,
     headers: Map<String, String> = mapOf(),
     options: RestApiOptions? = null,
-  ): RestApiResponse<T> = request(HttpMethod.POST, path, requestBody, headers, options ?: defaultOptions, responseType)
+  ): RestApiResponse<T> = request(HttpMethod.POST, path, requestBody, headers, options, responseType)
 
   fun <T : Any> getList(
     path: String,
     responseType: KClass<T>,
     headers: Map<String, String> = mapOf(),
     options: RestApiOptions? = null,
-  ): RestApiResponse<List<T>> = requestForList(HttpMethod.GET, path, null, headers, options ?: defaultOptions, responseType)
+  ): RestApiResponse<List<T>> = requestForList(HttpMethod.GET, path, null, headers, options, responseType)
 
   fun <T : Any> postForList(
     path: String,
@@ -66,20 +66,19 @@ class RestApiClient(
     responseType: KClass<T>,
     headers: Map<String, String> = mapOf(),
     options: RestApiOptions? = null,
-  ): RestApiResponse<List<T>> = requestForList(HttpMethod.POST, path, requestBody, headers, options ?: defaultOptions, responseType)
+  ): RestApiResponse<List<T>> = requestForList(HttpMethod.POST, path, requestBody, headers, options, responseType)
 
   internal fun <T : Any> request(
     method: HttpMethod,
     path: String,
     requestBody: Any? = null,
     headers: Map<String, String>,
-    opts: RestApiOptions,
+    options: RestApiOptions? = null,
     responseType: KClass<T>,
   ): RestApiResponse<T> {
+    val opts = options ?: defaultOptions
     try {
-      val request = buildRequest(method, path, requestBody, headers, opts)
-
-      val responseSpec = retrieveWithOptionalRetry(request, path, opts)
+      val responseSpec = buildRequestWithOptionalRetry(method, path, requestBody, headers, opts)
 
       var mono = responseSpec.bodyToMono(responseType.java)
 
@@ -98,13 +97,12 @@ class RestApiClient(
     path: String,
     requestBody: Any? = null,
     headers: Map<String, String>,
-    opts: RestApiOptions,
+    options: RestApiOptions?,
     responseType: KClass<T>,
   ): RestApiResponse<List<T>> {
+    val opts = options ?: defaultOptions
     try {
-      val request = buildRequest(method, path, requestBody, headers, opts)
-
-      val responseSpec = retrieveWithOptionalRetry(request, path, opts)
+      val responseSpec = buildRequestWithOptionalRetry(method, path, requestBody, headers, opts)
 
       var flux = responseSpec.bodyToFlux(responseType.java)
 
@@ -116,6 +114,19 @@ class RestApiClient(
     } catch (e: Exception) {
       return wrapError(e)
     }
+  }
+
+  private fun buildRequestWithOptionalRetry(
+    method: HttpMethod,
+    path: String,
+    requestBody: Any?,
+    headers: Map<String, String>,
+    opts: RestApiOptions,
+  ): WebClient.ResponseSpec {
+    val request = buildRequest(method, path, requestBody, headers, opts)
+
+    val responseSpec = retrieveWithOptionalRetry(request, path, opts)
+    return responseSpec
   }
 
   internal fun retrieveWithOptionalRetry(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.RETURNS_DEEP_STUBS
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+class RestApiClientTest :
+  DescribeSpec({
+    describe("basic RestApiClient functionality") {
+      fun buildMockClient(responseBody: String?) : WebClient {
+        val webClient = mock(WebClient::class.java, RETURNS_DEEP_STUBS)
+        val requestSpec = mock(WebClient.RequestBodySpec::class.java)
+        val responseSpec = mock(WebClient.ResponseSpec::class.java)
+        val mono: Mono<String> = mock(Mono::class.java) as Mono<String>
+        whenever(webClient.method(any()).uri(anyString()).headers(any())).thenReturn(requestSpec)
+        whenever(requestSpec.retrieve()).thenReturn(responseSpec)
+        whenever(responseSpec.bodyToMono(String::class.java)).thenReturn(mono)
+        whenever(mono.block()).thenReturn(responseBody)
+        return webClient
+      }
+
+      it("should handle a successful GET request") {
+        val webClient = buildMockClient("It works!")
+
+        val options = RestApiOptions(retryAttempts = 0)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+
+        val response = client.get("/test", String::class)
+
+        response.status shouldBe HttpStatus.OK
+        response.errors.size shouldBe 0
+        response.data shouldBe "It works!"
+      }
+    }
+  })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -158,22 +158,16 @@ class RestApiClientTest :
         defaultClient.isSafeToRetry(error500) shouldBe false
       }
 
-      it("can create a non-retryable request") {
-        val spec = mock(WebClient.ResponseSpec::class.java)
-
-        val spec2 = defaultClient.addOptionalRetry(RestApiOptions(retryAttempts = 0), spec, "")
-
-        spec2 shouldNotBe null
-        spec2 shouldBe spec
-      }
-
       it("can create a retryable request") {
-        val spec = mock(WebClient.ResponseSpec::class.java)
-        whenever(spec.onStatus(any(), any())).thenReturn(spec)
+        val requestSpec: WebClient.RequestBodySpec = mock()
+        val mockResponse: WebClient.ResponseSpec = mock()
+        whenever(requestSpec.retrieve()).thenReturn(mockResponse)
+        whenever(mockResponse.onStatus(any(), any())).thenReturn(mockResponse)
+        val options = RestApiOptions(retryAttempts = 1)
 
-        val spec2 = defaultClient.addOptionalRetry(RestApiOptions(retryAttempts = 1), spec, "")
+        val responseSpec = defaultClient.retrieveWithOptionalRetry(requestSpec, "/", options)
 
-        spec2 shouldNotBe null
+        responseSpec shouldNotBe null
       }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -15,7 +15,11 @@ import reactor.core.publisher.Mono
 class RestApiClientTest :
   DescribeSpec({
     describe("basic RestApiClient functionality") {
-      fun buildMockClient(responseBody: String?, httpError: Exception? = null, retrySuccess: Boolean = false): WebClient {
+      fun buildMockClient(
+        responseBody: String?,
+        httpError: Exception? = null,
+        retrySuccess: Boolean = false,
+      ): WebClient {
         val webClient = mock(WebClient::class.java, RETURNS_DEEP_STUBS)
         val requestSpec = mock(WebClient.RequestBodySpec::class.java)
         val responseSpec = mock(WebClient.ResponseSpec::class.java)
@@ -49,7 +53,7 @@ class RestApiClientTest :
       }
 
       it("should handle HTTP errors") {
-        val webClient = buildMockClient("It fails", WebClientResponseException(500,"Server error 543", null, null, null))
+        val webClient = buildMockClient("It fails", WebClientResponseException(500, "Server error 543", null, null, null))
 
         val options = RestApiOptions(retryAttempts = 0)
         val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -14,7 +14,7 @@ import reactor.core.publisher.Mono
 class RestApiClientTest :
   DescribeSpec({
     describe("basic RestApiClient functionality") {
-      fun buildMockClient(responseBody: String?) : WebClient {
+      fun buildMockClient(responseBody: String?): WebClient {
         val webClient = mock(WebClient::class.java, RETURNS_DEEP_STUBS)
         val requestSpec = mock(WebClient.RequestBodySpec::class.java)
         val responseSpec = mock(WebClient.ResponseSpec::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -38,10 +38,12 @@ class RestApiClientTest :
         retrySuccess: Boolean = false,
       ): WebClient {
         val webClient = mock(WebClient::class.java, RETURNS_DEEP_STUBS)
-        val requestSpec = mock(WebClient.RequestBodySpec::class.java)
-        val responseSpec = mock(WebClient.ResponseSpec::class.java)
-        val mono: Mono<String> = mock(Mono::class.java) as Mono<String>
+        val requestSpec: WebClient.RequestBodySpec = mock()
+        val responseSpec: WebClient.ResponseSpec = mock()
+        val mono: Mono<String> = mock()
+
         whenever(webClient.method(any()).uri(anyString()).headers(any())).thenReturn(requestSpec)
+
         if (httpError == null) {
           whenever(requestSpec.retrieve()).thenReturn(responseSpec)
         } else {
@@ -51,8 +53,10 @@ class RestApiClientTest :
             whenever(requestSpec.retrieve()).thenThrow(httpError)
           }
         }
+
         whenever(responseSpec.bodyToMono(String::class.java)).thenReturn(mono)
         whenever(mono.block()).thenReturn(responseBody)
+
         return webClient
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -9,18 +9,27 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 
 class RestApiClientTest :
   DescribeSpec({
     describe("basic RestApiClient functionality") {
-      fun buildMockClient(responseBody: String?): WebClient {
+      fun buildMockClient(responseBody: String?, httpError: Exception? = null, retrySuccess: Boolean = false): WebClient {
         val webClient = mock(WebClient::class.java, RETURNS_DEEP_STUBS)
         val requestSpec = mock(WebClient.RequestBodySpec::class.java)
         val responseSpec = mock(WebClient.ResponseSpec::class.java)
         val mono: Mono<String> = mock(Mono::class.java) as Mono<String>
         whenever(webClient.method(any()).uri(anyString()).headers(any())).thenReturn(requestSpec)
-        whenever(requestSpec.retrieve()).thenReturn(responseSpec)
+        if (httpError == null) {
+          whenever(requestSpec.retrieve()).thenReturn(responseSpec)
+        } else {
+          if (retrySuccess) {
+            whenever(requestSpec.retrieve()).thenThrow(httpError).thenReturn(responseSpec)
+          } else {
+            whenever(requestSpec.retrieve()).thenThrow(httpError)
+          }
+        }
         whenever(responseSpec.bodyToMono(String::class.java)).thenReturn(mono)
         whenever(mono.block()).thenReturn(responseBody)
         return webClient
@@ -37,6 +46,20 @@ class RestApiClientTest :
         response.status shouldBe HttpStatus.OK
         response.errors.size shouldBe 0
         response.data shouldBe "It works!"
+      }
+
+      it("should handle HTTP errors") {
+        val webClient = buildMockClient("It fails", WebClientResponseException(500,"Server error 543", null, null, null))
+
+        val options = RestApiOptions(retryAttempts = 0)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+
+        val response = client.get("/test", String::class)
+
+        response.status shouldBe HttpStatus.INTERNAL_SERVER_ERROR
+        response.errors.size shouldBe 1
+        response.errors[0].message shouldBe "500 Server error 543"
+        response.data shouldBe null
       }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -183,5 +183,12 @@ class RestApiClientTest :
 
         responseSpec shouldNotBe null
       }
+
+      it("can set up auth headers") {
+        val headers = defaultClient.authHeaders("JKDSHF8GASKJDSFH")
+        headers shouldNotBe null
+        headers.size shouldBe 1
+        headers["Authorization"] shouldBe "Bearer JKDSHF8GASKJDSFH"
+      }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -2,19 +2,36 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import org.springframework.core.codec.DecodingException
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
 
+/**
+ * Pure Kotlin unit tests for the RestApiClient.
+ *
+ * Because the underlying WebClient and HttpClient classes are so hard to mock
+ * these tests mainly focus on verifying the internal helper methods. Testing of
+ * the primary functionality, other than some very basic paths, is left for
+ * integration tests.
+ */
 class RestApiClientTest :
   DescribeSpec({
     describe("basic RestApiClient functionality") {
+      val defaultClient = RestApiClient("TestAPI", "http://localhost")
+      val error500 = WebClientResponseException(500, "Server error 543", null, null, null)
+      val decodingError = DecodingException("Decoding error 987")
+      val genericError = RuntimeException("Generic error 555")
+
       fun buildMockClient(
         responseBody: String?,
         httpError: Exception? = null,
@@ -53,7 +70,7 @@ class RestApiClientTest :
       }
 
       it("should handle HTTP errors") {
-        val webClient = buildMockClient("It fails", WebClientResponseException(500, "Server error 543", null, null, null))
+        val webClient = buildMockClient("It fails", error500)
 
         val options = RestApiOptions(retryAttempts = 0)
         val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
@@ -64,6 +81,75 @@ class RestApiClientTest :
         response.errors.size shouldBe 1
         response.errors[0].message shouldBe "500 Server error 543"
         response.data shouldBe null
+      }
+
+      it("should handle decoding errors") {
+        val webClient = buildMockClient("It fails", decodingError)
+
+        val options = RestApiOptions(retryAttempts = 0)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+
+        val response = client.get("/test", String::class)
+
+        response.errors.size shouldBe 1
+        response.errors[0].message shouldBe "Decoding error 987"
+        response.data shouldBe null
+      }
+
+      it("should handle generic errors") {
+        val webClient = buildMockClient("It fails", genericError)
+
+        val options = RestApiOptions(retryAttempts = 0)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+
+        val response = client.get("/test", String::class)
+
+        response.errors.size shouldBe 1
+        response.errors[0].message shouldBe "Generic error 555"
+      }
+
+      it("can build a WebClient") {
+        val options = RestApiOptions(retryAttempts = 0)
+
+        val webClient = defaultClient.webClient(options)
+
+        webClient shouldNotBe null
+      }
+
+      it("can build a RetrySpec") {
+        val options = RestApiOptions(retryAttempts = 77)
+        defaultClient.retrySpec(options) shouldNotBe null
+      }
+
+      it("can build a RetryError") {
+        val response = mock(ClientResponse::class.java)
+        whenever(response.statusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR)
+
+        val error = defaultClient.retryError(response, "SomeAPI", HttpMethod.GET, "http://localhost:8765")
+
+        error shouldNotBe null
+      }
+
+      it("should not retry a 500 error") {
+        defaultClient.isSafeToRetry(error500) shouldBe false
+      }
+
+      it("can create a non-retryable request") {
+        val spec = mock(WebClient.ResponseSpec::class.java)
+
+        val spec2 = defaultClient.addOptionalRetry(RestApiOptions(retryAttempts = 0), spec, "")
+
+        spec2 shouldNotBe null
+        spec2 shouldBe spec
+      }
+
+      it("can create a retryable request") {
+        val spec = mock(WebClient.ResponseSpec::class.java)
+        whenever(spec.onStatus(any(), any())).thenReturn(spec)
+
+        val spec2 = defaultClient.addOptionalRetry(RestApiOptions(retryAttempts = 1), spec, "")
+
+        spec2 shouldNotBe null
       }
     }
   })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
@@ -41,6 +42,7 @@ class RestApiClientTest :
         val requestSpec: WebClient.RequestBodySpec = mock()
         val responseSpec: WebClient.ResponseSpec = mock()
         val mono: Mono<String> = mock()
+        val flux: Flux<String> = mock()
 
         whenever(webClient.method(any()).uri(anyString()).headers(any())).thenReturn(requestSpec)
 
@@ -57,6 +59,11 @@ class RestApiClientTest :
         whenever(responseSpec.bodyToMono(String::class.java)).thenReturn(mono)
         whenever(mono.block()).thenReturn(responseBody)
 
+        whenever(responseSpec.bodyToFlux(String::class.java)).thenReturn(flux)
+        val listMono: Mono<List<String>> = mock()
+        whenever(flux.collectList()).thenReturn(listMono)
+        whenever(listMono.block()).thenReturn(listOf(responseBody!!))
+
         return webClient
       }
 
@@ -71,6 +78,19 @@ class RestApiClientTest :
         response.status shouldBe HttpStatus.OK
         response.errors.size shouldBe 0
         response.data shouldBe "It works!"
+      }
+
+      it("should handle a successful GET request with list responses") {
+        val webClient = buildMockClient("Lists work!")
+
+        val options = RestApiOptions(retryAttempts = 0)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+
+        val response = client.getList("/test", String::class)
+
+        response.status shouldBe HttpStatus.OK
+        response.errors.size shouldBe 0
+        response.data shouldBe listOf("Lists work!")
       }
 
       it("should handle HTTP errors") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClientTest.kt
@@ -29,6 +29,7 @@ class RestApiClientTest :
   DescribeSpec({
     describe("basic RestApiClient functionality") {
       val defaultClient = RestApiClient("TestAPI", "http://localhost")
+      val nonRetryOptions = RestApiOptions(retryAttempts = 0)
       val error500 = WebClientResponseException(500, "Server error 543", null, null, null)
       val decodingError = DecodingException("Decoding error 987")
       val genericError = RuntimeException("Generic error 555")
@@ -70,8 +71,7 @@ class RestApiClientTest :
       it("should handle a successful GET request") {
         val webClient = buildMockClient("It works!")
 
-        val options = RestApiOptions(retryAttempts = 0)
-        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
 
         val response = client.get("/test", String::class)
 
@@ -82,9 +82,7 @@ class RestApiClientTest :
 
       it("should handle a successful GET request with list responses") {
         val webClient = buildMockClient("Lists work!")
-
-        val options = RestApiOptions(retryAttempts = 0)
-        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
 
         val response = client.getList("/test", String::class)
 
@@ -93,11 +91,31 @@ class RestApiClientTest :
         response.data shouldBe listOf("Lists work!")
       }
 
+      it("should handle a POST request") {
+        val webClient = buildMockClient("POST works")
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
+
+        val response = client.post("/test", "Query details", String::class)
+
+        response.status shouldBe HttpStatus.OK
+        response.errors.size shouldBe 0
+        response.data shouldBe "POST works"
+      }
+
+      it("should handle a POST with a list response") {
+        val webClient = buildMockClient("Lists work!")
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
+
+        val response = client.postForList("/test", "Query details", String::class)
+
+        response.status shouldBe HttpStatus.OK
+        response.errors.size shouldBe 0
+        response.data shouldBe listOf("Lists work!")
+      }
+
       it("should handle HTTP errors") {
         val webClient = buildMockClient("It fails", error500)
-
-        val options = RestApiOptions(retryAttempts = 0)
-        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
 
         val response = client.get("/test", String::class)
 
@@ -109,9 +127,7 @@ class RestApiClientTest :
 
       it("should handle decoding errors") {
         val webClient = buildMockClient("It fails", decodingError)
-
-        val options = RestApiOptions(retryAttempts = 0)
-        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
 
         val response = client.get("/test", String::class)
 
@@ -122,9 +138,7 @@ class RestApiClientTest :
 
       it("should handle generic errors") {
         val webClient = buildMockClient("It fails", genericError)
-
-        val options = RestApiOptions(retryAttempts = 0)
-        val client = RestApiClient("TestAPI", "http://localhost:8765", webClient = webClient, defaultOptions = options)
+        val client = RestApiClient("TestAPI", "http://localhost:8765", nonRetryOptions, webClient)
 
         val response = client.get("/test", String::class)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RestApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RestApiClientIntegrationTest.kt
@@ -1,0 +1,107 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.integration
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiResponse
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.TestApiMockServer
+
+class RestApiClientIntegrationTest :
+  DescribeSpec({
+    // Use WireMock for testing the RestApiClient
+    // then we can mock the RestApiClient for testing gateways.
+    val mockServer = TestApiMockServer()
+
+    beforeEach {
+      mockServer.start()
+      mockServer.resetAll()
+    }
+
+    afterTest {
+      mockServer.stop()
+    }
+
+    describe("basic rest client functionality") {
+      it("Should handle a basic GET request") {
+        mockServer.stubGetTest(
+          "/api/1234",
+          """
+              {
+                "name": "Tester 123"
+              }
+            """.removeWhitespaceAndNewlines(),
+          HttpStatus.OK,
+        )
+        val client = RestApiClient("Test API", mockServer.baseUrl())
+
+        val response = client.get("/api/1234", TestItem::class)
+
+        response.apiName shouldBe "Test API"
+        response.status shouldBe HttpStatus.OK
+        response.errors.size shouldBe 0
+        response.data!!.name shouldBe "Tester 123"
+      }
+
+      it("Should handle not-found errors") {
+        mockServer.stubGetTest(
+          "/api/4567",
+          "",
+          HttpStatus.NOT_FOUND,
+        )
+        val client = RestApiClient("Test API", mockServer.baseUrl())
+
+        val response = client.get("/api/4567", TestItem::class)
+
+        response.apiName shouldBe "Test API"
+        response.status shouldBe HttpStatus.NOT_FOUND
+      }
+
+      it("Can be used in a Gateway") {
+        mockServer.stubGetTest(
+          "/api/1234",
+          """
+              {
+                "name": "Tester 1234"
+              }
+            """.removeWhitespaceAndNewlines(),
+          HttpStatus.OK,
+        )
+        val gateway = TestGateway(mockServer.baseUrl())
+
+        val response = gateway.restApiCall("1234")
+
+        response.status shouldBe HttpStatus.OK
+        response.data!!.name shouldBe "Tester 1234"
+      }
+
+      it("Should be easy to mock") {
+        val mockClient: RestApiClient = mock()
+        val gateway = TestGateway("http://localhost/", mockClient)
+        val upstreamData = TestItem(name = "Tester 3456")
+        whenever(mockClient.get("/api/3456", upstreamData::class)).thenReturn(RestApiResponse("", HttpStatus.OK, upstreamData))
+
+        val response = gateway.restApiCall("3456")
+
+        response.status shouldBe HttpStatus.OK
+        response.data!!.name shouldBe "Tester 3456"
+      }
+    }
+  })
+
+data class TestItem(
+  val name: String?,
+)
+
+class TestGateway(
+  val baseUrl: String,
+  val restApiClient: RestApiClient? = null,
+) {
+  fun restApiCall(id: String): RestApiResponse<TestItem> = restClient().get("/api/$id", TestItem::class)
+
+  // Is there a way we can get Spring to inject a configured RestApiClient into the gateway?
+  private fun restClient() = restApiClient ?: RestApiClient("TestApi", baseUrl)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RestApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/integration/RestApiClientIntegrationTest.kt
@@ -46,6 +46,27 @@ class RestApiClientIntegrationTest :
         response.data!!.name shouldBe "Tester 123"
       }
 
+      it("Should handle a list responses") {
+        mockServer.stubGetTest(
+          "/api/1234",
+          """
+              [
+                {"name": "Tester 123"}
+              ]
+            """.removeWhitespaceAndNewlines(),
+          HttpStatus.OK,
+        )
+        val client = RestApiClient("Test API", mockServer.baseUrl())
+
+        val response = client.getList("/api/1234", TestItem::class)
+
+        response.apiName shouldBe "Test API"
+        response.status shouldBe HttpStatus.OK
+        response.errors.size shouldBe 0
+        response.data!!.size shouldBe 1
+        response.data[0].name shouldBe "Tester 123"
+      }
+
       it("Should handle not-found errors") {
         mockServer.stubGetTest(
           "/api/4567",


### PR DESCRIPTION
After many attempts to mock `WebClientWrapper` or to extract a mockable interface from it, I've come to the conclusion that it is going to take some more fundamental changes. This POC introduces a new `RestApiClient` to be used in place of `WebClientWrapper` in gateways, but that is easy to mock for unit tests.

It doesn't try to maintain a backwards-compatible interface because the existing methods rely on `reified` parameters which themselves rely on `inline` functions which make mocking really difficult, especially with fluent interfaces.

Without inline functions we can't use reified types, so need to specify the response data type as a parameter...

`val response = restApiClient.get("/something", SomeType::class)` 

rather than

`val response = webClientWrapper.request<SomeType>(GET, "/something")`

RestApiClient can be mocked like any other class...
```
val mockClient: RestApiClient = mock()
whenever(mockClient.get("/api/3456", upstreamData::class)).thenReturn(RestApiResponse("", HttpStatus.OK, upstreamData))
```

The PR only currently includes an implementation for the non-list GET method, but adding the corresponding methods for POSTs and List response types should be straightforward. It does include unified handling of the retry and non-retry scenarios though.


The new interface is also entirely independent of the `WebClient` concept which means we can swap the implementation in future if we need to (maybe to something that doesn't have all the complexity of a non-blocking interface but blocks anyway).