### PR TITLE
HIA-1293 Start converting SANGateway over to RestApiClient

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -35,6 +35,7 @@ data class FeatureFlagConfig(
     const val CONTACT_LINKED_PRISONERS_ENDPOINT_ENABLED = "contact-linked-prisoners-endpoint-enabled"
     const val PRISON_TIMELINE_ENDPOINT_ENABLED = "prison-timeline-endpoint-enabled"
     const val USE_PROBATION_SEARCH_FOR_PERSON_SEARCH = "use-probation-search-for-person-search"
+    const val SAN_GATEWAY_USES_RESTAPICLIENT = "san-gateway-uses-restapiclient"
 
     // Events feature flags
     const val ENABLE_DELETE_PROCESSED_EVENTS = "enable-delete-processed-events"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -35,7 +35,7 @@ data class FeatureFlagConfig(
     const val CONTACT_LINKED_PRISONERS_ENDPOINT_ENABLED = "contact-linked-prisoners-endpoint-enabled"
     const val PRISON_TIMELINE_ENDPOINT_ENABLED = "prison-timeline-endpoint-enabled"
     const val USE_PROBATION_SEARCH_FOR_PERSON_SEARCH = "use-probation-search-for-person-search"
-    const val SAN_GATEWAY_USES_RESTAPICLIENT = "san-gateway-uses-restapiclient"
+    const val RESTAPICLIENT_FOR_SAN_GATEWAY = "restapiclient-for-san-gateway"
 
     // Events feature flags
     const val ENABLE_DELETE_PROCESSED_EVENTS = "enable-delete-processed-events"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/RestApiClient.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.netty.channel.ChannelOption
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.core.codec.DecodingException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -36,6 +38,10 @@ class RestApiClient(
   val defaultOptions: RestApiOptions = RestApiOptions(),
   val webClient: WebClient? = null,
 ) {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
   val retryCodes = listOf(502, 503, 504, 522, 599, 499, 408)
 
   fun <T : Any> get(
@@ -157,6 +163,7 @@ class RestApiClient(
     headers: Map<String, String>,
     opts: RestApiOptions,
   ): WebClient.RequestBodySpec {
+    log.info("RestApiClient calling $method $path")
     val spec =
       webClient(opts)
         .method(method)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -5,10 +5,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
@@ -17,7 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanCreatio
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanReviewSchedules
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 
 @Component
 class SANGateway(
@@ -80,28 +76,9 @@ class SANGateway(
     return if (result.errors.isEmpty()) {
       Response(data = result.data!!)
     } else {
-      Response(
-        data = PlanCreationSchedules(listOf()),
-        errors = wrapErrors(result.errors),
-      )
+      Response.error(result.errors, PlanCreationSchedules(listOf()))
     }
   }
-
-  internal fun wrapErrors(errors: List<Exception>): List<UpstreamApiError> = errors.map { mapError(it) }
-
-  internal fun mapError(error: Exception): UpstreamApiError =
-    when (error) {
-      is WebClientResponseException -> UpstreamApiError(UpstreamApi.SAN, mapStatus(error.statusCode), error.message)
-      else -> UpstreamApiError(UpstreamApi.SAN, UpstreamApiError.Type.INTERNAL_SERVER_ERROR, error.message)
-    }
-
-  internal fun mapStatus(status: HttpStatusCode): UpstreamApiError.Type =
-    when (status) {
-      HttpStatus.NOT_FOUND -> UpstreamApiError.Type.ENTITY_NOT_FOUND
-      HttpStatus.BAD_REQUEST -> UpstreamApiError.Type.BAD_REQUEST
-      HttpStatus.FORBIDDEN -> UpstreamApiError.Type.FORBIDDEN
-      else -> UpstreamApiError.Type.INTERNAL_SERVER_ERROR
-    }
 
   fun getReviewSchedules(prisonerNumber: String): Response<PlanReviewSchedules> {
     if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
@@ -142,10 +119,7 @@ class SANGateway(
     return if (result.errors.isEmpty()) {
       Response(data = result.data!!)
     } else {
-      Response(
-        data = PlanReviewSchedules(listOf()),
-        errors = wrapErrors(result.errors),
-      )
+      Response.error(result.errors, PlanReviewSchedules(listOf()))
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
@@ -21,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 class SANGateway(
   @Value("\${services.san.base-url}") val baseUrl: String,
   val features: FeatureFlagConfig = FeatureFlagConfig(),
-  val apiClient: RestApiClient? = null,
+  val sanRestClient: RestApiClient? = null,
 ) : UpstreamGateway {
   override fun metaData() =
     GatewayMetadata(
@@ -69,7 +71,7 @@ class SANGateway(
 
   fun getPlanCreationSchedules2(prisonerNumber: String): Response<PlanCreationSchedules> {
     val result =
-      apiClient().get(
+      sanRestClient!!.get(
         "/profile/$prisonerNumber/plan-creation-schedule?includeAllHistory=true",
         PlanCreationSchedules::class,
         authenticationHeader(),
@@ -84,8 +86,6 @@ class SANGateway(
       )
     }
   }
-
-  internal fun apiClient() = apiClient ?: RestApiClient(UpstreamApi.SAN.name, baseUrl)
 
   internal fun wrapErrors(errors: List<Exception>): List<UpstreamApiError> = errors.map { mapError(it) }
 
@@ -133,4 +133,12 @@ class SANGateway(
       "Authorization" to "Bearer $token",
     )
   }
+}
+
+@Configuration
+class RestClientConfig {
+  @Bean("sanRestClient")
+  fun sanRestClient(
+    @Value("\${services.san.base-url}") baseUrl: String,
+  ): RestApiClient = RestApiClient(UpstreamApi.SAN.name, baseUrl)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -38,7 +38,7 @@ class SANGateway(
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPlanCreationSchedules(prisonerNumber: String): Response<PlanCreationSchedules> {
-    if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
+    if (useRestApiClient()) {
       return getPlanCreationSchedules2(prisonerNumber)
     }
 
@@ -81,7 +81,7 @@ class SANGateway(
   }
 
   fun getReviewSchedules(prisonerNumber: String): Response<PlanReviewSchedules> {
-    if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
+    if (useRestApiClient()) {
       return getReviewSchedules2(prisonerNumber)
     }
 
@@ -129,6 +129,8 @@ class SANGateway(
       "Authorization" to "Bearer $token",
     )
   }
+
+  internal fun useRestApiClient() = features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)
 }
 
 @Configuration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -40,7 +40,7 @@ class SANGateway(
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPlanCreationSchedules(prisonerNumber: String): Response<PlanCreationSchedules> {
-    if (features.isEnabled(FeatureFlagConfig.SAN_GATEWAY_USES_RESTAPICLIENT)) {
+    if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
       return getPlanCreationSchedules2(prisonerNumber)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -25,6 +27,10 @@ class SANGateway(
   val features: FeatureFlagConfig = FeatureFlagConfig(),
   val sanRestClient: RestApiClient? = null,
 ) : UpstreamGateway {
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
   override fun metaData() =
     GatewayMetadata(
       summary = "Support for Additional Needs",
@@ -42,7 +48,9 @@ class SANGateway(
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPlanCreationSchedules(prisonerNumber: String): Response<PlanCreationSchedules> {
-    if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
+    val useRestApiClient = features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)
+    log.info("Getting plan creation schedules for $prisonerNumber ($useRestApiClient)")
+    if (useRestApiClient) {
       return getPlanCreationSchedules2(prisonerNumber)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
 
 @Component
 class SANGateway(
-  @Value("\${services.san.base-url}") baseUrl: String,
+  @Value("\${services.san.base-url}") val baseUrl: String,
   val features: FeatureFlagConfig = FeatureFlagConfig(),
   val apiClient: RestApiClient? = null,
 ) : UpstreamGateway {
@@ -85,7 +85,7 @@ class SANGateway(
     }
   }
 
-  internal fun apiClient() = apiClient ?: RestApiClient(UpstreamApi.SAN.name, "Test API")
+  internal fun apiClient() = apiClient ?: RestApiClient(UpstreamApi.SAN.name, baseUrl)
 
   internal fun wrapErrors(errors: List<Exception>): List<UpstreamApiError> = errors.map { mapError(it) }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -104,6 +104,10 @@ class SANGateway(
     }
 
   fun getReviewSchedules(prisonerNumber: String): Response<PlanReviewSchedules> {
+    if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
+      return getReviewSchedules2(prisonerNumber)
+    }
+
     val result =
       webClient.request<PlanReviewSchedules>(
         HttpMethod.GET,
@@ -124,6 +128,24 @@ class SANGateway(
           errors = result.errors,
         )
       }
+    }
+  }
+
+  fun getReviewSchedules2(prisonerNumber: String): Response<PlanReviewSchedules> {
+    val result =
+      sanRestClient!!.get(
+        "/profile/$prisonerNumber/reviews/review-schedules?includeAllHistory=true",
+        PlanReviewSchedules::class,
+        authenticationHeader(),
+      )
+
+    return if (result.errors.isEmpty()) {
+      Response(data = result.data!!)
+    } else {
+      Response(
+        data = PlanReviewSchedules(listOf()),
+        errors = wrapErrors(result.errors),
+      )
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -3,17 +3,25 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.WebClientWrapper.WebClientWrapperResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanCreationSchedules
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanReviewSchedules
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApiError
 
 @Component
 class SANGateway(
   @Value("\${services.san.base-url}") baseUrl: String,
+  val features: FeatureFlagConfig = FeatureFlagConfig(),
+  val apiClient: RestApiClient? = null,
 ) : UpstreamGateway {
   override fun metaData() =
     GatewayMetadata(
@@ -32,6 +40,10 @@ class SANGateway(
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPlanCreationSchedules(prisonerNumber: String): Response<PlanCreationSchedules> {
+    if (features.isEnabled(FeatureFlagConfig.SAN_GATEWAY_USES_RESTAPICLIENT)) {
+      return getPlanCreationSchedules2(prisonerNumber)
+    }
+
     val result =
       webClient.request<PlanCreationSchedules>(
         HttpMethod.GET,
@@ -54,6 +66,42 @@ class SANGateway(
       }
     }
   }
+
+  fun getPlanCreationSchedules2(prisonerNumber: String): Response<PlanCreationSchedules> {
+    val result =
+      apiClient().get(
+        "/profile/$prisonerNumber/plan-creation-schedule?includeAllHistory=true",
+        PlanCreationSchedules::class,
+        authenticationHeader(),
+      )
+
+    return if (result.errors.isEmpty()) {
+      Response(data = result.data!!)
+    } else {
+      Response(
+        data = PlanCreationSchedules(listOf()),
+        errors = wrapErrors(result.errors),
+      )
+    }
+  }
+
+  internal fun apiClient() = apiClient ?: RestApiClient(UpstreamApi.SAN.name, "Test API")
+
+  internal fun wrapErrors(errors: List<Exception>): List<UpstreamApiError> = errors.map { mapError(it) }
+
+  internal fun mapError(error: Exception): UpstreamApiError =
+    when (error) {
+      is WebClientResponseException -> UpstreamApiError(UpstreamApi.SAN, mapStatus(error.statusCode), error.message)
+      else -> UpstreamApiError(UpstreamApi.SAN, UpstreamApiError.Type.INTERNAL_SERVER_ERROR, error.message)
+    }
+
+  internal fun mapStatus(status: HttpStatusCode): UpstreamApiError.Type =
+    when (status) {
+      HttpStatus.NOT_FOUND -> UpstreamApiError.Type.ENTITY_NOT_FOUND
+      HttpStatus.BAD_REQUEST -> UpstreamApiError.Type.BAD_REQUEST
+      HttpStatus.FORBIDDEN -> UpstreamApiError.Type.FORBIDDEN
+      else -> UpstreamApiError.Type.INTERNAL_SERVER_ERROR
+    }
 
   fun getReviewSchedules(prisonerNumber: String): Response<PlanReviewSchedules> {
     val result =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/SANGateway.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
@@ -27,10 +25,6 @@ class SANGateway(
   val features: FeatureFlagConfig = FeatureFlagConfig(),
   val sanRestClient: RestApiClient? = null,
 ) : UpstreamGateway {
-  companion object {
-    val log: Logger = LoggerFactory.getLogger(this::class.java)
-  }
-
   override fun metaData() =
     GatewayMetadata(
       summary = "Support for Additional Needs",
@@ -48,9 +42,7 @@ class SANGateway(
   lateinit var hmppsAuthGateway: HmppsAuthGateway
 
   fun getPlanCreationSchedules(prisonerNumber: String): Response<PlanCreationSchedules> {
-    val useRestApiClient = features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)
-    log.info("Getting plan creation schedules for $prisonerNumber ($useRestApiClient)")
-    if (useRestApiClient) {
+    if (features.isEnabled(FeatureFlagConfig.RESTAPICLIENT_FOR_SAN_GATEWAY)) {
       return getPlanCreationSchedules2(prisonerNumber)
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Response.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/hmpps/Response.kt
@@ -1,11 +1,20 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps
 
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.web.reactive.function.client.WebClientResponseException
+
 data class Response<T>(
   val data: T,
   var errors: List<UpstreamApiError> = emptyList(),
 ) {
   companion object {
     fun <T> merge(responses: List<Response<List<T>>>): Response<List<T>> = Response(data = responses.flatMap { it.data }, errors = responses.flatMap { it.errors })
+
+    fun <T> error(
+      errors: List<Exception>,
+      emptyValue: T,
+    ): Response<T> = Response(emptyValue, wrapErrors(errors))
   }
 
   fun hasError(type: UpstreamApiError.Type): Boolean = this.errors.any { it.type == type }
@@ -23,3 +32,19 @@ data class DataResponse<T>(
 )
 
 inline fun <reified T> Response<T>.withoutNotFound() = Response(data = data, errors = errors.filter { it.type != UpstreamApiError.Type.ENTITY_NOT_FOUND })
+
+fun wrapErrors(errors: List<Exception>): List<UpstreamApiError> = errors.map { mapError(it) }
+
+fun mapError(error: Exception): UpstreamApiError =
+  when (error) {
+    is WebClientResponseException -> UpstreamApiError(UpstreamApi.SAN, mapStatus(error.statusCode), error.message)
+    else -> UpstreamApiError(UpstreamApi.SAN, UpstreamApiError.Type.INTERNAL_SERVER_ERROR, error.message)
+  }
+
+fun mapStatus(status: HttpStatusCode): UpstreamApiError.Type =
+  when (status) {
+    HttpStatus.NOT_FOUND -> UpstreamApiError.Type.ENTITY_NOT_FOUND
+    HttpStatus.BAD_REQUEST -> UpstreamApiError.Type.BAD_REQUEST
+    HttpStatus.FORBIDDEN -> UpstreamApiError.Type.FORBIDDEN
+    else -> UpstreamApiError.Type.INTERNAL_SERVER_ERROR
+  }

--- a/src/main/resources/application-integration-test.yml
+++ b/src/main/resources/application-integration-test.yml
@@ -127,6 +127,7 @@ feature-flag:
   address-search-endpoint-enabled: true
   contact-linked-prisoners-endpoint-enabled: true
   prison-timeline-endpoint-enabled: true
+  restapiclient-for-san-gateway: true
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -110,7 +110,7 @@ feature-flag:
   contact-linked-prisoners-endpoint-enabled: true
   prison-timeline-endpoint-enabled: true
   use-probation-search-for-person-search: false
-  restapiclient-for-san-gateway: true
+  restapiclient-for-san-gateway: false
   # Events Config
   enable-delete-processed-events: false
   enable-publish-pending-events: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -110,6 +110,7 @@ feature-flag:
   contact-linked-prisoners-endpoint-enabled: true
   prison-timeline-endpoint-enabled: true
   use-probation-search-for-person-search: false
+  restapiclient-for-san-gateway: true
   # Events Config
   enable-delete-processed-events: false
   enable-publish-pending-events: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/ResponseTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/ResponseTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.Response
+
+class ResponseTest :
+  DescribeSpec({
+    it("should be handle error responses") {
+      val errors =
+        listOf(
+          WebClientResponseException(400, "Wrong", null, null, null),
+          WebClientResponseException(403, "Nope", null, null, null),
+          WebClientResponseException(404, "Lost it", null, null, null),
+          WebClientResponseException(502, "Bust", null, null, null),
+          RuntimeException("Unknown"),
+        )
+
+      val response = Response.error(errors, "Hello, world!")
+
+      response shouldNotBe null
+      response.data shouldBe "Hello, world!"
+      response.errors.size shouldBe 5
+      response.errors[0].description shouldBe "400 Wrong"
+    }
+  })

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetPlanCreationSchedulesForPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetPlanCreationSchedulesForPrisonerTest.kt
@@ -1,22 +1,36 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.prisonerAlerts
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.san
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.SAN_GATEWAY_USES_RESTAPICLIENT
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.SANGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanCreationSchedule
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanCreationSchedules
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanCreationStatus
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
 
 @ActiveProfiles("test")
 @ContextConfiguration(
@@ -106,6 +120,58 @@ class GetPlanCreationSchedulesForPrisonerTest(
         response.data.shouldNotBeNull()
         response.data.planCreationSchedules.size
           .shouldBe(2)
+      }
+
+      it("can use the RestApiClient") {
+        // Given
+        val ref = UUID.randomUUID()
+        val authToken = "ABC123"
+        val headers = mapOf("Authorization" to "Bearer $authToken")
+
+        val features = FeatureFlagConfig(mapOf(SAN_GATEWAY_USES_RESTAPICLIENT to true))
+
+        val authGateway: HmppsAuthGateway = mock()
+        whenever(authGateway.getClientToken("SAN")).thenReturn(authToken)
+
+        val apiClient: RestApiClient = mock()
+        whenever(apiClient.get(eq(path), eq(PlanCreationSchedules::class), eq(headers), isNull())).thenReturn(
+          RestApiResponse(
+            "Test",
+            HttpStatus.OK,
+            PlanCreationSchedules(
+              planCreationSchedules =
+                listOf(
+                  PlanCreationSchedule(
+                    reference = ref,
+                    status = PlanCreationStatus.COMPLETED,
+                    createdBy = "person",
+                    createdByDisplayName = "Person",
+                    createdAt = OffsetDateTime.now().minusDays(1),
+                    createdAtPrison = "XYZ",
+                    updatedBy = "person",
+                    updatedByDisplayName = "Person",
+                    updatedAt = OffsetDateTime.now(),
+                    updatedAtPrison = "XYZ",
+                    deadlineDate = LocalDate.now(),
+                    needSources = emptyList(),
+                    version = 1,
+                  ),
+                ),
+            ),
+          ),
+        )
+
+        val gateway = SANGateway("http://localhost", features, apiClient)
+        gateway.hmppsAuthGateway = authGateway
+
+        // When
+        val response = gateway.getPlanCreationSchedules(prisonerNumber)
+
+        // Then
+        response.errors.size shouldBe 0
+        response.data.planCreationSchedules.size shouldBe 1
+        response.data.planCreationSchedules[0].status shouldBe PlanCreationStatus.COMPLETED
+        response.data.planCreationSchedules[0].reference shouldBe ref
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetPlanCreationSchedulesForPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetPlanCreationSchedulesForPrisonerTest.kt
@@ -16,7 +16,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
-import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.SAN_GATEWAY_USES_RESTAPICLIENT
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.RESTAPICLIENT_FOR_SAN_GATEWAY
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
@@ -128,7 +128,7 @@ class GetPlanCreationSchedulesForPrisonerTest(
         val authToken = "ABC123"
         val headers = mapOf("Authorization" to "Bearer $authToken")
 
-        val features = FeatureFlagConfig(mapOf(SAN_GATEWAY_USES_RESTAPICLIENT to true))
+        val features = FeatureFlagConfig(mapOf(RESTAPICLIENT_FOR_SAN_GATEWAY to true))
 
         val authGateway: HmppsAuthGateway = mock()
         whenever(authGateway.getClientToken("SAN")).thenReturn(authToken)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetReviewSchedulesForPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetReviewSchedulesForPrisonerTest.kt
@@ -3,21 +3,34 @@ package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.prisonerAlerts
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
+import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.RESTAPICLIENT_FOR_SAN_GATEWAY
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiResponse
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.removeWhitespaceAndNewlines
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.HmppsAuthGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.SANGateway
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.ApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.mockservers.HmppsAuthMockServer
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanReviewSchedule
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanReviewScheduleStatus
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.PlanReviewSchedules
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.hmpps.UpstreamApi
+import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.util.UUID
 
 @ActiveProfiles("test")
@@ -107,6 +120,52 @@ class GetReviewSchedulesForPrisonerTest(
         schedule.reviewCompletedByJobRole.shouldBe(null)
         schedule.exemptionReason.shouldBe(null)
         schedule.version.shouldBe(1)
+      }
+
+      it("can use the RestApiClient") {
+        val ref = UUID.randomUUID()
+        val authToken = "ABC123"
+        val headers = mapOf("Authorization" to "Bearer $authToken")
+
+        val features = FeatureFlagConfig(mapOf(RESTAPICLIENT_FOR_SAN_GATEWAY to true))
+
+        val authGateway: HmppsAuthGateway = mock()
+        whenever(authGateway.getClientToken("SAN")).thenReturn(authToken)
+
+        val apiClient: RestApiClient = mock()
+        whenever(apiClient.get(eq(path), eq(PlanReviewSchedules::class), eq(headers), isNull())).thenReturn(
+          RestApiResponse(
+            "Test",
+            HttpStatus.OK,
+            PlanReviewSchedules(
+              listOf(
+                PlanReviewSchedule(
+                  reference = ref,
+                  status = PlanReviewScheduleStatus.COMPLETED,
+                  deadlineDate = LocalDate.now(),
+                  createdBy = "person",
+                  createdByDisplayName = "Person",
+                  createdAt = OffsetDateTime.now().minusDays(3),
+                  createdAtPrison = "ABC",
+                  updatedBy = "person",
+                  updatedByDisplayName = "Person",
+                  updatedAt = OffsetDateTime.now().minusDays(1),
+                  updatedAtPrison = "ABC",
+                ),
+              ),
+            ),
+          ),
+        )
+        val gateway = SANGateway("http://localhost", features, apiClient)
+        gateway.hmppsAuthGateway = authGateway
+
+        val response = gateway.getReviewSchedules(prisonerNumber)
+
+        response shouldNotBe null
+        response.errors.size shouldBe 0
+        response.data shouldNotBe null
+        response.data.planReviewSchedules.size shouldBe 1
+        response.data.planReviewSchedules[0].reference shouldBe ref
       }
     },
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetReviewSchedulesForPrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/gateways/san/GetReviewSchedulesForPrisonerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.prisonerAlerts
+package uk.gov.justice.digital.hmpps.hmppsintegrationapi.gateways.san
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig.Companion.RESTAPICLIENT_FOR_SAN_GATEWAY
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.extensions.RestApiClient
@@ -166,6 +167,34 @@ class GetReviewSchedulesForPrisonerTest(
         response.data shouldNotBe null
         response.data.planReviewSchedules.size shouldBe 1
         response.data.planReviewSchedules[0].reference shouldBe ref
+      }
+
+      it("can can handle errors with the RestApiClient") {
+        val authToken = "ABC123"
+        val headers = mapOf("Authorization" to "Bearer $authToken")
+
+        val features = FeatureFlagConfig(mapOf(RESTAPICLIENT_FOR_SAN_GATEWAY to true))
+
+        val authGateway: HmppsAuthGateway = mock()
+        whenever(authGateway.getClientToken("SAN")).thenReturn(authToken)
+
+        val apiClient: RestApiClient = mock()
+        whenever(apiClient.get(eq(path), eq(PlanReviewSchedules::class), eq(headers), isNull())).thenReturn(
+          RestApiResponse(
+            "Test",
+            HttpStatus.NOT_FOUND,
+            null,
+            listOf(WebClientResponseException(404, "PlanReviewSchedules not found", null, null, null)),
+          ),
+        )
+        val gateway = SANGateway("http://localhost", features, apiClient)
+        gateway.hmppsAuthGateway = authGateway
+
+        val response = gateway.getReviewSchedules(prisonerNumber)
+
+        response shouldNotBe null
+        response.errors.size shouldBe 1
+        response.errors[0].description shouldBe "404 PlanReviewSchedules not found"
       }
     },
   )


### PR DESCRIPTION
Allow the `SANGateway` to use a `RestApiClient` (see https://github.com/ministryofjustice/hmpps-integration-api/pull/1904) instead of a `WebClientWrapper` for the upstream connectivity.

The new client is used if the `restapiclient-for-san-gateway` feature flag is set; for this PR it is only set for Integration Tests. A follow-up PR will enable it in dev, and another one for production. Once we are confident that we won't need to revert we can remove the old `WebClientWrapper` code and the feature flag.

There is also a helper method on the `Response` class to make it easier to create an error response (with a list of `UpstreamApiError` objects) from the result of the `RestApiClient` (which has a list of exceptions).