### PR TITLE
HIA-1299: Remove `/queue-admin` endpoints from published API spec

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,8 @@ spring:
 
 springdoc:
   default-produces-media-type: application/json
+  paths-to-exclude:
+    - /queue-admin/**
 
 server:
   port: 8080


### PR DESCRIPTION
Before change
<img width="2916" height="1362" alt="image" src="https://github.com/user-attachments/assets/d26ad663-f9ba-4a0d-b1e9-844dc45efecb" />

After change
<img width="2916" height="1198" alt="image" src="https://github.com/user-attachments/assets/3e8836c9-fffe-496f-a148-bdca44f9fdcc" />
