### PR TITLE
HIA-1293 Turn on the SAN RestApiClient in preprod and prod

### DIFF
--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -67,6 +67,7 @@ feature-flag:
   contact-linked-prisoners-endpoint-enabled: false
   prison-timeline-endpoint-enabled: false
   use-probation-search-for-person-search: false
+  restapiclient-for-san-gateway: true
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -67,6 +67,7 @@ feature-flag:
   contact-linked-prisoners-endpoint-enabled: false
   prison-timeline-endpoint-enabled: false
   use-probation-search-for-person-search: false
+  restapiclient-for-san-gateway: true
   # Events Config
   enable-delete-processed-events: true
   enable-publish-pending-events: true


### PR DESCRIPTION

Previously enabled in dev (https://github.com/ministryofjustice/hmpps-integration-api/pull/1925) and tested with smoke tests and with a call from Meganexus

<img width="2048" height="1198" alt="image" src="https://github.com/user-attachments/assets/f751edbc-f22c-46b5-bb08-35c8fb00b7f5" />
