### PR TITLE
HIA-969 feature flag override poc

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -73,3 +73,29 @@ data class FeatureFlagConfig(
     }
   }
 }
+
+/**
+ * Merge a set of feature settings into a feature flag configuration.
+ *
+ * The new values are specified as a comma separated list of key/value pairs
+ * with the key and value separated by an equals sign.
+ *
+ * e.g. `first.feature=true,feature.two=false`
+ *
+ * Returns a new FeatureFlagConfig object, leaving the original unchanged.
+ */
+fun mergeFeatures(
+  features: FeatureFlagConfig,
+  featureValues: String?,
+): FeatureFlagConfig {
+  val flags = mutableMapOf<String, Boolean>()
+  flags.putAll(features.flags)
+  if (featureValues != null) {
+    val overrideValues = featureValues.split(",")
+    for (override in overrideValues) {
+      val parts = override.split("=")
+      flags[parts[0]] = parts[1].toBoolean()
+    }
+  }
+  return FeatureFlagConfig(flags)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfig.kt
@@ -90,7 +90,7 @@ fun mergeFeatures(
 ): FeatureFlagConfig {
   val flags = mutableMapOf<String, Boolean>()
   flags.putAll(features.flags)
-  if (featureValues != null) {
+  if (!featureValues.isNullOrEmpty()) {
     val overrideValues = featureValues.split(",")
     for (override in overrideValues) {
       val parts = override.split("=")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilter.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.AuthorisationConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.FeatureFlagConfig
+import uk.gov.justice.digital.hmpps.hmppsintegrationapi.config.mergeFeatures
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.exception.LimitedAccessException
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.models.roleconfig.ConsumerConfig
 import uk.gov.justice.digital.hmpps.hmppsintegrationapi.services.AuthorisationService
@@ -92,6 +93,8 @@ class AuthorisationFilter(
       return
     }
 
+    val requestFeatures = featuresWithOverrides(features, consumerConfig, request.getHeader("X-Feature-Override"))
+
     // Authorise request
 
     val filters = authorisationService.allFilters(clientName)
@@ -99,7 +102,7 @@ class AuthorisationFilter(
 
     val requestedPath = req.requestURI
 
-    val context = RequestContext(clientName, consumerConfig, filters, features, oboUsername)
+    val context = RequestContext(clientName, consumerConfig, filters, requestFeatures, oboUsername)
     request.setAttribute("requestContext", context)
 
     if (authorisationService.hasAccess(clientName, requestedPath)) {
@@ -118,6 +121,24 @@ class AuthorisationFilter(
       res.sendError(HttpServletResponse.SC_FORBIDDEN, "Unable to authorise $requestedPath for $clientName")
     }
   }
+
+  /**
+   * Override feature flags based on request headers if the consumer is permitted to do this.
+   *
+   * If not permitted, returns the original feature config.
+   *
+   * The original feature config is not modified in either case.
+   */
+  internal fun featuresWithOverrides(
+    environmentFeatures: FeatureFlagConfig,
+    consumerConfig: ConsumerConfig,
+    overrides: String?,
+  ): FeatureFlagConfig =
+    if (consumerConfig.allowFeatureOverride) {
+      mergeFeatures(environmentFeatures, overrides)
+    } else {
+      environmentFeatures
+    }
 
   fun extractConsumerName(subjectDistinguishedName: String?): String? {
     if (subjectDistinguishedName.isNullOrEmpty()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/roleconfig/ConsumerConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/models/roleconfig/ConsumerConfig.kt
@@ -9,6 +9,7 @@ data class ConsumerConfig(
   val notes: String? = null,
   val queueName: String? = null,
   val oboConfig: OboConfig? = null,
+  val allowFeatureOverride: Boolean = false,
 ) {
   fun permissions(): List<String>? = include
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -159,6 +159,7 @@ authorisation:
       oboConfig:
         strategy: "unsigned"
         required: false
+      allowFeatureOverride: true
     smoke-test-limited-access:
       notes: "Automated post-deployment smoke tests (some access denied)"
       roles:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfigTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/config/FeatureFlagConfigTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsintegrationapi.config
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -93,5 +94,28 @@ class FeatureFlagConfigTest : ConfigTest() {
         .filterNot { it in flagsInCode }
         .toSet()
     assertTrue(notInCode.isEmpty(), "The following flags have been left in config: ${notInCode.joinToString(",")}")
+  }
+
+  @Test
+  fun `overrides can be merged into configuration`() {
+    val config1 = FeatureFlagConfig(mapOf("flag-a" to true, "flag-b" to false))
+    val overrides = "flag-b=true,flag-c=false"
+
+    val config2 = mergeFeatures(config1, overrides)
+
+    assertEquals(config2.flags, mapOf("flag-a" to true, "flag-b" to true, "flag-c" to false))
+  }
+
+  @Test
+  fun `null and empty overrides are ignored`() {
+    val config1 = FeatureFlagConfig(mapOf("flag-a" to true, "flag-b" to false))
+
+    val config2 = mergeFeatures(config1, null)
+
+    assertEquals(config2.flags, config1.flags)
+
+    val config3 = mergeFeatures(config1, "")
+
+    assertEquals(config3.flags, config1.flags)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/extensions/AuthorisationFilterTest.kt
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -475,5 +476,23 @@ class AuthorisationFilterTest {
     val finalFilter = mock(Filter::class.java)
     mockFilterChain(authorisationFilter, finalFilter).doFilter(mockRequest, mockResponse)
     verify(mockTelemetryService, times(0)).setSpanAttribute(eq("certExpiryDate"), any())
+  }
+
+  @Test
+  fun `feature overrides allowed`() {
+    val features = FeatureFlagConfig(mapOf("flag-a" to false, "flag-b" to false))
+    val consumerConfig = ConsumerConfig(allowFeatureOverride = true)
+    val requestConfig = authorisationFilter.featuresWithOverrides(features, consumerConfig, "flag-a=true")
+
+    assertEquals(requestConfig.flags, mapOf("flag-a" to true, "flag-b" to false))
+  }
+
+  @Test
+  fun `feature overrides denied`() {
+    val features = FeatureFlagConfig(mapOf("flag-a" to false, "flag-b" to false))
+    val consumerConfig = ConsumerConfig(allowFeatureOverride = false)
+    val requestConfig = authorisationFilter.featuresWithOverrides(features, consumerConfig, "flag-a=true")
+
+    assertEquals(requestConfig.flags, mapOf("flag-a" to false, "flag-b" to false))
   }
 }


### PR DESCRIPTION
A basic proof-of-concept for overriding feature flag values using request headers. This would allow us to test both toggled-on and toggled-off versions of a feature in the dev environment; for feature flags that should be transparent to the end user this could include the smoke tests calling the same endpoint with the flag on and off and comparing the results.

This implementation allows us to specify for each consumer whether overrides are allowed, so we can enable this for our own test consumers in dev, but not for external consumers, and not for any consumers in prod.

**Note**
The overrides will only work if the feature flags are checked using the value from the `RequestContext`, and will be ignored if the checks are done using a `FeatureFlagConfig` injected into a class by Spring.