### PR TITLE
HIA-1594: Externalise preprod auth config

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,6 +16,18 @@ generic-service:
     SPRING_PROFILES_ACTIVE: preprod
     SENTRY_ENVIRONMENT: preprod
 
+  volumeMounts:
+    - name: config-volume
+      mountPath: /app/authorisation.yaml
+      subPath: authorisation.yaml
+  volumes:
+    - name: config-volume
+      configMap:
+        name: authorisation-yaml
+        items:
+          - key: authorisation.yaml
+            path: authorisation.yaml
+
   namespace_secrets:
     hmpps-auth:
       CLIENT_ID: "client-id"

--- a/src/main/resources/application-preprod.yml
+++ b/src/main/resources/application-preprod.yml
@@ -1,3 +1,7 @@
+spring:
+  config:
+    import: "optional:file:/app/authorisation.yaml"
+
 services:
   int-api:
     base-url: https://preprod.integration-api.hmpps.service.justice.gov.uk
@@ -81,59 +85,7 @@ feature-flag:
   limited-access-notifications-enabled: true
   deduplicate-events: true
 
-authorisation:
-  consumers:
-    ctrlo:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
-      queueName: "ctrlosubscriberqueue"
-    moj-pes:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
-    kubernetes-health-check-client:
-      notes: "Kubernetes cluster automated healthchecks"
-      roles:
-        - "hmpps-system"
-    event-service:
-      notes: "HMPPS External Events service"
-      roles:
-        - "hmpps-system"
-    meganexus:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
-      queueName: "plpsubscriberqueue"
-    pnd:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
-      queueName: "pndsubscriberqueue"
-    pmcphee:
-      notes: "ExtApi developer"
-      roles:
-        - "status-only"
-    smoke-test:
-      notes: "Post-deployment smoke tests"
-      roles:
-        - "hmpps-system"
-    smartinbox:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
-    prisonerfacing:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
-    enhanced-reception-checks:
-      notes: "See client list in Confluence"
-      roles:
-        - "enhanced-reception-checks"
-    community-campus:
-      notes: "See client list in Confluence"
-      roles:
-        - "status-only"
+#authorisation.consumers - now defined in the configuration repository
 
 hmpps.sqs:
   queues:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/AuthorisationServiceTest.kt
@@ -88,14 +88,12 @@ class AuthorisationServiceTest : ConfigTest() {
 
   @Test
   fun `show permission matches`() {
-    val endpoint = "/health/readiness"
-    val environment = "preprod"
+    val endpoint = "/v1/persons"
+    val environment = "test"
 
     // You can temporarily change endpoint & environment to see who has access to what, where
     val matches = listConsumersWithAccess(environment, endpoint)
-
-    assertEquals(3, matches.size)
-    assertContains(matches, "kubernetes-health-check-client")
+    assertContains(matches, "automated-test-client")
   }
 
   @Test


### PR DESCRIPTION
Externalising preprod config now the config map is in place