### PR TITLE
HIA-1610: Add zkhan to cert expiry ignore list

### DIFF
--- a/.hmpps-external-api-suppressions.xml
+++ b/.hmpps-external-api-suppressions.xml
@@ -13,4 +13,15 @@
     <packageUrl regex="true">^pkg:maven/org\.jetbrains\.intellij\.deps\.kotlinx/kotlinx-coroutines-core-jvm@.*$</packageUrl>
     <vulnerabilityName>CVE-2026-53914</vulnerabilityName>
   </suppress>
+  <suppress until="2026-10-01Z">
+    <notes><![CDATA[
+    Suppressed until 2.4.20 is released (due September 2026).
+    <notes><![CDATA[
+    This only affects the kotlin build cache, and we use the gradle build cache that has built in encryption anyway.
+    Bundled with detekt which is only used for static code analysis
+    file name: kotlinx-coroutines-core-jvm-1.10.2-intellij-1.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.jetbrains\.intellij\.deps\.kotlinx/kotlinx-coroutines-core-jvm@.*$</packageUrl>
+    <vulnerabilityName>CVE-2020-29582</vulnerabilityName>
+  </suppress>
 </suppressions>

--- a/scripts/check_certs_expiry.sh
+++ b/scripts/check_certs_expiry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ignore="dev/sleach5 dev/bmadley dev/mryall preprod/pmcphee"
+ignore="dev/sleach5 dev/bmadley dev/mryall preprod/pmcphee dev/zkhan"
 
 configure_aws_credentials() {
     local environment="$1"


### PR DESCRIPTION
Simple PR to add zkhan to the cert expiry ignore list. Also i have suppressed CVE-2020-29582  in the same way we are currently suppressing CVE-2026-53914 . Its the same jar file (bundled by detekt) and is only used by detekt. 