### PR TITLE
HIA-1636 unit tests for identifyHmppsId

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -1100,6 +1100,27 @@ internal class GetPersonServiceTest :
         }
       }
 
+      describe("identify hmppsId type") {
+        it("should identify a CRN") {
+          getPersonService.identifyHmppsId("X688624") shouldBe IdentifierType.CRN
+          getPersonService.identifyHmppsId("X963105") shouldBe IdentifierType.CRN
+
+        }
+        it("should identify a NOMS number") {
+          getPersonService.identifyHmppsId("A4433DZ") shouldBe IdentifierType.NOMS
+          getPersonService.identifyHmppsId("G6333VK") shouldBe IdentifierType.NOMS
+        }
+        it("should not identify a random string") {
+          getPersonService.identifyHmppsId("This is not an identifier") shouldBe IdentifierType.UNKNOWN
+        }
+        it("should not identify an empty string") {
+          getPersonService.identifyHmppsId("") shouldBe IdentifierType.UNKNOWN
+        }
+        it("should not identify a CRN with a typo string") {
+          getPersonService.identifyHmppsId("XO12345") shouldBe IdentifierType.UNKNOWN
+        }
+      }
+
       describe("get Supervision Status by hmppsId") {
         it("HmppsId resolves to a supervision status of PROBATION") {
           whenever(deliusGateway.getOffender(any(), eq(null))).thenReturn(Response(data = Offender("Test", "Test", activeProbationManagedSentence = true, otherIds = OtherIds(crn = crnNumber, nomsNumber = nomsNumber))))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsintegrationapi/services/GetPersonServiceTest.kt
@@ -1104,7 +1104,6 @@ internal class GetPersonServiceTest :
         it("should identify a CRN") {
           getPersonService.identifyHmppsId("X688624") shouldBe IdentifierType.CRN
           getPersonService.identifyHmppsId("X963105") shouldBe IdentifierType.CRN
-
         }
         it("should identify a NOMS number") {
           getPersonService.identifyHmppsId("A4433DZ") shouldBe IdentifierType.NOMS


### PR DESCRIPTION
This (simple) method didn't have any unit tests, so this PR fixes that.